### PR TITLE
UI rebuild layer 1: foundation tokens, first primitive, and the fix that unblocked accessibility testing

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -302,6 +302,45 @@ Ranked, with the reason each was deferred rather than attempted here:
    primary brand blue `#007AFF` on white is 4.02:1 and fails WCAG AA; the
    `dark:` variant is wired to a selector nothing sets.
 
+## 0b. Why the a11y suite asserted HTML strings (root cause found 2026-08-07)
+
+Item 7 above notes that "the a11y suite asserts against hand-written HTML
+strings rather than rendered components". The reason was not preference. It was
+not possible to do otherwise.
+
+`tests/setup.ts` replaced `window.getComputedStyle` with a stub that reported
+`display: 'none'` for **every** element:
+
+```js
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => ({ getPropertyValue: () => '', display: 'none', ... }),
+});
+```
+
+Testing Library consults `getComputedStyle` to decide whether a node belongs to
+the accessibility tree. With that stub in place, every element in the entire
+suite was invisible to accessible queries: `getByRole`, `getByLabelText` and
+every sibling query could never match anything, in any test. Only
+`{ hidden: true }` worked — a bare `<button>Hello</button>` was unreachable by
+role.
+
+The string assertions were therefore a workaround for a broken environment, and
+they are what let `BaseModal` ship to 28 dialogs with no `role="dialog"`, no
+`aria-modal` and `initialFocus: false` while `A11Y_EVIDENCE.md` claimed all of
+it was present. A test that reads source as text cannot notice that the
+rendered component has no accessible role.
+
+**Fixed:** jsdom's real implementation is used, with `width`/`height` filled in
+for AntD's measurement code (jsdom performs no layout, so those come back as
+empty strings). The full suite was run before and after — **1772 → 1773
+passing, zero regressions.** The stub was never load-bearing.
+
+**Consequence for the rebuild:** new components can now use real accessible
+queries — see `src/components/ds/__tests__/Button.test.tsx`, which drives the
+component the way a user does rather than asserting markup. Migrating the
+existing a11y suite off string assertions is unblocked, and is worth doing:
+those tests currently cannot fail for the defects they exist to catch.
+
 ## 0. Gate-Status Correction & P0 Remediation (2026-06-05)
 
 This file is the takeover ledger for any AI LLM CLI.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,101 @@
+# Design system — specification
+
+These 14 documents are the design specification for the UI rebuild. They are
+**specification, not application code**: each one renders a layer of the system
+so it can be reviewed, and nothing in `src/` imports them.
+
+Open any of them directly in a browser.
+
+## Why they are in the repository
+
+They were produced outside this codebase and existed only as downloads. A
+specification that lives beside the code it governs can be diffed, reviewed and
+blamed; one that lives in someone's Downloads folder cannot. When an
+implementation and its spec disagree, this directory is the record of what was
+intended.
+
+## Layers
+
+| Layer | Documents | Implemented in `src/` |
+|---|---|---|
+| 1 — Foundations | `foundations.html` | ✅ `src/styles/foundations.css` |
+| 2 — Primitives | `primitives.html` | ⬜ not started |
+| 3 — Composites | `composites.html`, `composites2.html` | ⬜ not started |
+| 4 — Domain surfaces | `gantt.html`, `gantt2.html`, `gantt3.html`, `allocation-matrix.html`, `org-chart.html`, `cost.html`, `sync.html` | ⬜ not started |
+| 5 — Screens | `screens-auth.html`, `screens-core.html`, `screens-admin.html` | ⬜ not started |
+
+The app currently ships **19 pages, 3 layouts and 58 components** on the legacy
+UI. None of them have been migrated. Layer 1 is additive and changes nothing
+visible — it is the substrate the later layers are built from.
+
+## Deliberate divergences from the spec
+
+Two, both recorded in full at the head and foot of `src/styles/foundations.css`.
+
+**1. Every token is prefixed `--ds-`.** The spec ships a "paste-ready" block
+using bare names. Pasting it would have been silently destructive, because this
+codebase already owns those names with different meanings:
+
+| Name | Existing meaning | Spec meaning |
+|---|---|---|
+| `--space-4` | `0.25rem` (4px) — keyed by pixel value | `16px` — keyed by step index |
+| `--space-16` | `1rem` (16px) | `64px` |
+| `--radius-md` | `8px` | `6px` |
+| `--z-modal` | `1050` | `400` |
+
+`--space-4` alone would have jumped 4× across every existing component, and
+modals would have fallen behind current overlays. The legacy UI is the live
+product until migration finishes, so the two systems must not touch. The prefix
+is what makes that true.
+
+**2. `content/tertiary` is `#5F6B7F`, not the spec's `#667085`.** Every ratio
+in the spec was computed against `surface/base` alone. These tokens also land on
+`surface/sunken` and, in dark, on `surface/raised`, where every ratio is lower.
+Recomputing each pair against the worst surface it can legitimately appear on
+found one genuine failure:
+
+```
+content/tertiary #667085 on surface/sunken #F1F3F7 = 4.48:1   (floor 4.5)
+```
+
+The spec assigns `content/tertiary` to "metadata, timestamps, placeholder" and
+`surface/sunken` to "table headers, inset wells, disabled fields" — a
+placeholder in an inset well is exactly that pairing, so it is reachable rather
+than theoretical. `#5F6B7F` keeps the hue (220.6°) and measures 4.85:1 on the
+worst light surface.
+
+Nothing else failed. The status-pill pairs reproduce the spec's stated ratios
+exactly.
+
+## The floors are enforced
+
+`src/styles/__tests__/foundations-contrast.test.ts` parses the real stylesheet
+and recomputes every ratio against every surface the token can appear on. It
+does not restate the palette — a test that did would pass while the shipped CSS
+drifted.
+
+It was verified to **fail** when `#667085` is reintroduced:
+
+```
+--ds-content-tertiary (#667085) on --ds-surface-sunken (#f1f3f7) = 4.48:1
+```
+
+This matters because the previous design system shipped `#007AFF` at 4.02:1 on
+the background of every primary button while `A11Y_EVIDENCE.md` claimed it
+passed, and two visual tests asserted the failing value as correct. That is what
+undetected drift looks like.
+
+## Using the tokens
+
+Wrap a new-system subtree in `.ds`, which sets the base font, colour and
+background, and scopes the focus-ring and reduced-motion rules so they cannot
+reach the legacy UI:
+
+```tsx
+<div className="ds">
+  <NewThing />
+</div>
+```
+
+Once every route has migrated, `.ds` moves to `<body>` and the legacy token
+files are deleted.

--- a/docs/design/allocation-matrix.html
+++ b/docs/design/allocation-matrix.html
@@ -1,0 +1,680 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 26px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4b of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Resource allocation matrix</h1>
+  <p style="margin:16px 0 0;max-width:78ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">{{ resCount }} named resources × {{ weekCount }} weeks of the programme calendar. Every cell prints its own percentage — colour and hatch are the second and third channels, never the first. Click a cell or use the arrow keys; <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">Enter</kbd> edits, <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">↑↓</kbd> adjusts by 10 points while editing.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #CBD2DC;flex-wrap:wrap">
+      <div role="radiogroup" aria-label="Group rows by" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+        <sc-for list="{{ groupCells }}" as="g" hint-placeholder-count="3">
+          <button onClick="{{ g.on }}" style="height:26px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ g.bg }};color:{{ g.fg }};border:1px solid {{ g.bd }};box-shadow:{{ g.sh }}">{{ g.label }}</button>
+        </sc-for>
+      </div>
+      <button onClick="{{ toggleOver }}" style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;border-radius:6px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ overBg }};color:{{ overFg }};border:1px solid {{ overBd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:11px">{{ overMark }}</span>Over-allocated only</button>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <span style="font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ conflictCount }} over-allocated cells across {{ conflictPeople }} people</span>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:8px;font-size:12px;color:#4B5563">
+        <span>Weeks {{ visFromLabel }} – {{ visToLabel }}</span>
+        <button onClick="{{ jumpToConflict }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Jump to first conflict</button>
+      </div>
+    </div>
+
+    <div style="display:flex;border-bottom:1px solid #CBD2DC;background:#F1F3F7">
+      <div style="width:300px;flex:none;border-right:1px solid #CBD2DC;height:52px;display:flex;align-items:flex-end;padding:0 12px 8px">
+        <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Resource</span>
+      </div>
+      <div style="flex:1;overflow:hidden;position:relative;height:52px">
+        <div style="position:absolute;top:0;left:0;height:52px;width:{{ gridWidth }};transform:translateX({{ axisShift }})">
+          <sc-for list="{{ monthTicks }}" as="m" hint-placeholder-count="8">
+            <div style="position:absolute;top:0;left:{{ m.left }};width:{{ m.width }};height:26px;border-left:1px solid #CBD2DC;display:flex;align-items:center;padding-left:6px;font-size:11.5px;font-weight:600;color:#101720;white-space:nowrap;overflow:hidden">{{ m.label }}</div>
+          </sc-for>
+          <sc-for list="{{ weekTicks }}" as="w" hint-placeholder-count="24">
+            <div style="position:absolute;top:26px;left:{{ w.left }};width:52px;height:26px;border-left:1px solid #E4E7EC;background:{{ w.bg }};display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:10px;color:{{ w.fg }};font-variant-numeric:tabular-nums">{{ w.label }}<span style="font-size:9px;color:#667085">{{ w.sub }}</span></div>
+          </sc-for>
+        </div>
+      </div>
+      <div style="width:104px;flex:none;border-left:1px solid #CBD2DC;height:52px;display:flex;align-items:flex-end;justify-content:flex-end;padding:0 10px 8px">
+        <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Avg · Peak</span>
+      </div>
+    </div>
+
+    <div role="grid" aria-label="Resource allocation by week" aria-rowcount="{{ resCount }}" aria-colcount="{{ weekCount }}" tabindex="0" onKeyDown="{{ onKey }}" style="display:flex;height:492px;outline:none">
+      <div style="width:300px;flex:none;border-right:1px solid #CBD2DC;overflow:hidden;position:relative;background:#FFFFFF">
+        <div style="position:absolute;top:0;left:0;right:0;transform:translateY({{ rowShift }})">
+          <sc-for list="{{ rowHeads }}" as="r" hint-placeholder-count="14">
+            <div style="position:absolute;top:{{ r.top }};left:0;right:0;height:36px;display:flex;align-items:center;gap:8px;padding:0 12px;background:{{ r.bg }};box-shadow:{{ r.bar }};border-bottom:1px solid #F1F3F7">
+              <sc-if value="{{ r.isGroup }}" hint-placeholder-val="{{ false }}">
+                <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">{{ r.name }}</span>
+              </sc-if>
+              <sc-if value="{{ r.isPerson }}" hint-placeholder-val="{{ true }}">
+                <span style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:none;border-radius:999px;background:{{ r.avBg }};color:{{ r.avFg }};font-size:10px;font-weight:600">{{ r.initials }}</span>
+              </sc-if>
+              <sc-if value="{{ r.isPerson }}" hint-placeholder-val="{{ true }}">
+                <span style="min-width:0;flex:1">
+                  <span style="display:block;font-size:12.5px;line-height:16px;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+                  <span style="display:block;font-size:11px;line-height:15px;color:#667085;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.role }} · {{ r.region }} · {{ r.rate }}</span>
+                </span>
+              </sc-if>
+              <sc-if value="{{ r.flag }}" hint-placeholder-val="{{ false }}">
+                <span title="Has over-allocated weeks" style="flex:none;display:inline-flex;align-items:center;gap:4px;height:18px;padding:0 5px;border-radius:3px;background:#FBF0DC;border:1px solid #E0C089;color:#8A5200;font-size:10px;font-weight:600"><span aria-hidden="true">⚠</span>{{ r.flagN }}</span>
+              </sc-if>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div ref="{{ gridRef }}" onScroll="{{ onScroll }}" style="flex:1;overflow:auto;position:relative;background:#FFFFFF">
+        <div style="position:relative;width:{{ gridWidth }};height:{{ gridHeight }}">
+          <sc-for list="{{ bands }}" as="b" hint-placeholder-count="6">
+            <div style="position:absolute;top:0;bottom:0;left:{{ b.left }};width:52px;background:{{ b.bg }}"></div>
+          </sc-for>
+          <div style="position:absolute;top:0;bottom:0;left:{{ todayLeft }};width:2px;background:#0B57D0"></div>
+          <sc-for list="{{ cells }}" as="c" hint-placeholder-count="200">
+            <div role="gridcell" aria-selected="{{ c.sel }}" aria-label="{{ c.aria }}" tabindex="{{ c.tab }}" onClick="{{ c.on }}" style="position:absolute;top:{{ c.top }};left:{{ c.left }};width:51px;height:35px;box-sizing:border-box;display:flex;align-items:center;justify-content:center;background:{{ c.bg }};border:{{ c.border }};box-shadow:{{ c.ring }};cursor:pointer">
+              <sc-if value="{{ c.hatch }}" hint-placeholder-val="{{ false }}">
+                <span aria-hidden="true" style="position:absolute;inset:0;background:{{ c.hatchBg }}"></span>
+              </sc-if>
+              <span style="position:relative;display:flex;align-items:center;gap:3px;padding:0 3px;border-radius:2px;background:{{ c.bg }};font-size:11.5px;font-weight:{{ c.fw }};color:{{ c.fg }};font-variant-numeric:tabular-nums">
+                <sc-if value="{{ c.glyph }}" hint-placeholder-val="{{ false }}"><span aria-hidden="true" style="font-size:10px">{{ c.glyph }}</span></sc-if>
+                {{ c.text }}
+              </span>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="width:104px;flex:none;border-left:1px solid #CBD2DC;overflow:hidden;position:relative;background:#FFFFFF">
+        <div style="position:absolute;top:0;left:0;right:0;transform:translateY({{ rowShift }})">
+          <sc-for list="{{ rowTotals }}" as="t" hint-placeholder-count="14">
+            <div style="position:absolute;top:{{ t.top }};left:0;right:0;height:36px;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:0 10px;border-bottom:1px solid #F1F3F7;background:{{ t.bg }}">
+              <span style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ t.avg }}</span>
+              <span style="font-size:12px;font-weight:600;color:{{ t.peakFg }};font-variant-numeric:tabular-nums">{{ t.peak }}</span>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div id="matrix-status" role="status" aria-live="polite" aria-atomic="true" style="display:flex;align-items:flex-start;gap:10px;padding:8px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }}">
+      <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">Announced</span>
+      <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:16px;padding:9px 14px;border-top:1px solid #CBD2DC;background:#F6F7F9;flex-wrap:wrap">
+      <sc-for list="{{ legend }}" as="l" hint-placeholder-count="6">
+        <span style="display:inline-flex;align-items:center;gap:7px;font-size:11.5px;color:#4B5563">
+          <span style="position:relative;display:inline-flex;align-items:center;justify-content:center;width:38px;height:20px;border-radius:3px;background:{{ l.bg }};border:{{ l.border }};font-size:10px;font-weight:600;color:{{ l.fg }};font-variant-numeric:tabular-nums"><span aria-hidden="true" style="position:absolute;inset:0;background:{{ l.hatch }};border-radius:3px"></span><span style="position:relative;padding:0 3px;border-radius:2px;background:{{ l.bg }}">{{ l.sample }}</span></span>
+          {{ l.label }}
+        </span>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:28px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Cell states &amp; contrast</h3>
+      <p style="margin:0 0 12px;font-size:12.5px;line-height:19px;color:#4B5563">Every ratio is text against that cell’s own fill, measured — not the page background.</p>
+      <sc-for list="{{ contrast }}" as="c" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:66px 1fr 62px;gap:10px;padding:8px 0;border-top:1px solid #E4E7EC;align-items:center">
+          <span style="position:relative;display:inline-flex;align-items:center;justify-content:center;height:24px;border-radius:3px;background:{{ c.bg }};border:{{ c.border }};font-size:11px;font-weight:600;color:{{ c.fg }};font-variant-numeric:tabular-nums"><span aria-hidden="true" style="position:absolute;inset:0;background:{{ c.hatch }};border-radius:3px"></span><span style="position:relative;padding:0 3px;border-radius:2px;background:{{ c.bg }}">{{ c.sample }}</span></span>
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ c.desc }}</div>
+          <div style="text-align:right;font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#0A7A47;font-variant-numeric:tabular-nums">{{ c.ratio }}</div>
+        </div>
+      </sc-for>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Rules</h3>
+      <sc-for list="{{ rules }}" as="r" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Keyboard &amp; announcements</h3>
+      <sc-for list="{{ keys }}" as="k" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:96px 1fr;gap:12px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+      </sc-for>
+      <div style="margin-top:14px;display:flex;flex-direction:column;gap:6px">
+        <sc-for list="{{ sayExamples }}" as="s" hint-placeholder-count="4">
+          <div style="font-size:12px;line-height:18px;color:#101720;background:#F1F3F7;border:1px solid #E4E7EC;border-radius:4px;padding:6px 8px"><span style="font-family:'IBM Plex Mono',monospace;color:#0B57D0">{{ s.k }}</span> — “{{ s.v }}”</div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:120px repeat(6,1fr);background:#0A0D12;border-bottom:1px solid #232A35">
+          <div style="padding:6px 8px;font-size:10px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#AFBACA">Resource</div>
+          <sc-for list="{{ darkWeeks }}" as="w" hint-placeholder-count="6">
+            <div style="padding:6px 0;text-align:center;font-size:10px;color:#AFBACA;font-variant-numeric:tabular-nums">{{ w }}</div>
+          </sc-for>
+        </div>
+        <sc-for list="{{ darkRows }}" as="r" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:120px repeat(6,1fr);border-bottom:1px solid #232A35">
+            <div style="padding:8px;font-size:11.5px;color:#E9EEF6;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</div>
+            <sc-for list="{{ r.cells }}" as="c" hint-placeholder-count="6">
+              <div style="position:relative;height:30px;display:flex;align-items:center;justify-content:center;background:{{ c.bg }};border-left:1px solid #232A35"><span aria-hidden="true" style="position:absolute;inset:0;background:{{ c.hatch }}"></span><span style="position:relative;padding:0 3px;border-radius:2px;background:{{ c.bg }};font-size:11px;font-weight:{{ c.fw }};color:{{ c.fg }};font-variant-numeric:tabular-nums">{{ c.t }}</span></div>
+            </sc-for>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Dark heat inverts the ramp rather than the hues: empty is surface/base, full is accent/subtle #16294A with #E9EEF6 at 12.43:1, over is warning/subtle #33240B with #E9B45A at 7.97:1, severe is danger/subtle #3A1512 with #FF8A80 at 7.10:1. The hatch lightens instead of darkening — <span style="font-family:'IBM Plex Mono',monospace">rgba(233,238,246,.30)</span> — because a dark hatch on a dark cell disappears.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Greyscale &amp; print proof</h3>
+      <div style="border:1px solid #CBD2DC;border-radius:6px;overflow:hidden">
+        <sc-for list="{{ greyRows }}" as="r" hint-placeholder-count="3">
+          <div style="display:grid;grid-template-columns:110px repeat(6,1fr);border-bottom:1px solid #E4E7EC">
+            <div style="padding:7px 8px;font-size:11.5px;color:#101720">{{ r.name }}</div>
+            <sc-for list="{{ r.cells }}" as="c" hint-placeholder-count="6">
+              <div style="position:relative;height:30px;display:flex;align-items:center;justify-content:center;background:{{ c.bg }};border-left:1px solid #E4E7EC"><span aria-hidden="true" style="position:absolute;inset:0;background:{{ c.hatch }}"></span><span style="position:relative;display:flex;align-items:center;gap:2px;padding:0 3px;border-radius:2px;background:{{ c.bg }};font-size:11px;font-weight:{{ c.fw }};color:{{ c.fg }};font-variant-numeric:tabular-nums"><span aria-hidden="true" style="font-size:9px">{{ c.g }}</span>{{ c.t }}</span></div>
+            </sc-for>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:12px;text-wrap:pretty">The same three weeks with every hue removed. Over-allocation still reads: the number is above 100, the hatch is present, and the glyph is ⚠ or ✕. This is the test the matrix must pass before any colour decision is discussed — and it is also what the Excel export and the A3 wall chart look like.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+const ROSTER = [
+  ['Rajesh Menon', 'Solution Architect', 'MY', 3200, 'Technical'],
+  ['Goh Mei Yee', 'Integration Architect', 'SG', 3800, 'Integration'],
+  ['Chan Wei Ling', 'Delivery Manager', 'MY', 2900, 'PMO'],
+  ['Nurul Iman', 'Programme Director', 'MY', 4000, 'PMO'],
+  ['Aisyah Rahman', 'FI/CO Consultant', 'MY', 2400, 'Finance'],
+  ['Tan Boon Hock', 'FI/CO Consultant', 'MY', 2400, 'Finance'],
+  ['Lim Siew Fong', 'MM/SD Consultant', 'MY', 2400, 'Logistics'],
+  ['Hafiz Kamarudin', 'MM/SD Consultant', 'MY', 2400, 'Logistics'],
+  ['Yeo Chin Wei', 'PP/QM Consultant', 'MY', 2500, 'Logistics'],
+  ['Sharifah Aziz', 'HCM Consultant', 'MY', 2300, 'Human Capital'],
+  ['Devi Krishnan', 'HCM Consultant', 'MY', 2300, 'Human Capital'],
+  ['Zulkifli Hassan', 'Basis Consultant', 'MY', 2600, 'Technical'],
+  ['Arun Prakash', 'ABAP Developer', 'IN', 1100, 'Technical'],
+  ['Priya Raghavan', 'ABAP Developer', 'IN', 1100, 'Technical'],
+  ['Vikram Shetty', 'ABAP Developer', 'IN', 1100, 'Technical'],
+  ['Daniel Okafor', 'Data Migration Lead', 'MY', 2700, 'Data Migration'],
+  ['Ng Kah Seng', 'Data Migration Analyst', 'MY', 2700, 'Data Migration'],
+  ['Siti Nurhaliza', 'Test Lead', 'MY', 2200, 'Testing'],
+  ['Ravi Subramaniam', 'Test Analyst', 'MY', 2200, 'Testing'],
+  ['Farah Nasution', 'Change Manager', 'MY', 2100, 'Change Management'],
+  ['Iskandar Zulkarnain', 'Business Analyst', 'MY', 1800, 'Finance'],
+  ['Chong Li Mei', 'Business Analyst', 'MY', 1800, 'Logistics'],
+  ['Nguyen Thi Lan', 'Security Consultant', 'VN', 1300, 'Technical'],
+  ['Tran Van Minh', 'Security Consultant', 'VN', 1300, 'Technical'],
+  ['Wong Jia Hui', 'PMO Analyst', 'MY', 1400, 'PMO'],
+  ['Amirul Shah', 'PMO Analyst', 'MY', 1400, 'PMO'],
+  ['Kavitha Nair', 'Integration Consultant', 'SG', 3800, 'Integration'],
+  ['Lee Kok Wai', 'Cutover Lead', 'MY', 2900, 'Cutover'],
+  ['Suriani Bakar', 'Training Lead', 'MY', 2100, 'Change Management'],
+  ['Ganesh Iyer', 'Analytics Consultant', 'IN', 1100, 'Analytics'],
+  ['Ong Hui Ying', 'Analytics Consultant', 'MY', 2400, 'Analytics'],
+  ['Mohd Faizal', 'Basis Consultant', 'MY', 2600, 'Technical'],
+  ['Cheryl Tan', 'FI/CO Consultant', 'SG', 3200, 'Finance'],
+  ['Anand Pillai', 'MM/SD Consultant', 'IN', 1100, 'Logistics'],
+  ['Norhayati Yusof', 'Test Analyst', 'MY', 2200, 'Testing'],
+  ['Koh Beng Huat', 'Data Migration Analyst', 'MY', 2700, 'Data Migration'],
+  ['Rina Solehah', 'Business Analyst', 'MY', 1800, 'Human Capital'],
+  ['Jason Lau', 'Integration Consultant', 'SG', 3800, 'Integration'],
+  ['Meena Balakrishnan', 'Change Analyst', 'MY', 2100, 'Change Management'],
+  ['Firdaus Omar', 'Cutover Analyst', 'MY', 2900, 'Cutover'],
+  ['Low Sze Ting', 'PMO Analyst', 'MY', 1400, 'PMO'],
+  ['Hoang Duc Anh', 'Security Analyst', 'VN', 1300, 'Technical']
+];
+const WEEKS = 104;
+const CW = 52;
+const RH = 36;
+const TODAY_W = 38;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const HATCH_DARK = 'repeating-linear-gradient(135deg,rgba(16,23,32,0) 0 3px,rgba(16,23,32,.42) 3px 6px)';
+const HATCH_HEAVY = 'repeating-linear-gradient(135deg,rgba(16,23,32,0) 0 2px,rgba(16,23,32,.55) 2px 5px)';
+const HATCH_LIGHT = 'repeating-linear-gradient(135deg,rgba(233,238,246,0) 0 3px,rgba(233,238,246,.30) 3px 6px)';
+
+function seed(n) { const x = Math.sin(n * 12.9898) * 43758.5453; return x - Math.floor(x); }
+
+// Over-allocation is exceptional by design: five named people under two
+// pressure windows — integration test (W40–46) and cutover (W72–78).
+const PRESSURED = { 12: 1, 13: 1, 14: 1, 1: 1, 15: 1 };
+function inPressure(w) { return (w >= 40 && w <= 46) || (w >= 72 && w <= 78); }
+function alloc(r, w) {
+  const ramp = w < 6 ? 0.3 : w < 14 ? 0.7 : w < 70 ? 1 : w < 86 ? 0.8 : 0.45;
+  const base = (35 + Math.round(seed(r * 17 + w * 3) * 60)) * ramp;
+  let v = Math.round(base / 5) * 5;
+  if (v > 100) v = 100;
+  if (PRESSURED[r] && inPressure(w) && seed(r * 5 + w) > 0.35) {
+    v = 105 + Math.round(seed(r * 11 + w * 2) * 8) * 5;
+  }
+  if ((r + w) % 53 === 0) v = 0;
+  if (w > 96 && r % 4 !== 0) v = 0;
+  return Math.max(0, Math.min(160, v));
+}
+
+function weekLabel(w) {
+  const d = new Date(2026, 0, 5 + w * 7);
+  return { wk: 'W' + (w % 52 + 1), sub: d.getDate() + ' ' + MONTHS[d.getMonth()], month: MONTHS[d.getMonth()] + ' ' + d.getFullYear(), key: d.getMonth() + '-' + d.getFullYear() };
+}
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.state = {
+      group: 'None', overOnly: false, scrollTop: 0, scrollLeft: 0, vw: 900,
+      cursor: { r: 12, c: 36 }, editing: false, edits: {},
+      announce: 'Allocation matrix ready. 42 resources by 104 weeks. Arrow keys move the cell cursor; Enter edits.'
+    };
+  }
+
+  rowsModel() {
+    const S = this.state;
+    let people = ROSTER.map((p, i) => ({ i, name: p[0], role: p[1], region: p[2], rate: p[3], stream: p[4] }));
+    if (S.overOnly) people = people.filter(p => this.peak(p.i) > 100);
+    if (S.group === 'Workstream') {
+      const out = [];
+      const streams = [];
+      people.forEach(p => { if (streams.indexOf(p.stream) < 0) streams.push(p.stream); });
+      streams.sort().forEach(s => {
+        out.push({ group: s });
+        people.filter(p => p.stream === s).forEach(p => out.push(p));
+      });
+      return out;
+    }
+    if (S.group === 'Region') {
+      const out = [];
+      ['MY', 'SG', 'IN', 'VN'].forEach(rg => {
+        const set = people.filter(p => p.region === rg);
+        if (!set.length) return;
+        out.push({ group: rg === 'MY' ? 'Malaysia' : rg === 'SG' ? 'Singapore' : rg === 'IN' ? 'India (offshore)' : 'Vietnam (subcontract)' });
+        set.forEach(p => out.push(p));
+      });
+      return out;
+    }
+    return people;
+  }
+
+  val(ri, w) {
+    const k = ri + ':' + w;
+    return this.state.edits[k] !== undefined ? this.state.edits[k] : alloc(ri, w);
+  }
+  peak(ri) { let m = 0; for (let w = 0; w < WEEKS; w++) { const v = this.val(ri, w); if (v > m) m = v; } return m; }
+  avg(ri) { let t = 0, n = 0; for (let w = 0; w < WEEKS; w++) { const v = this.val(ri, w); if (v > 0) { t += v; n++; } } return n ? Math.round(t / n) : 0; }
+
+  style(v) {
+    if (v === 0) return { bg: '#FFFFFF', fg: '#667085', fw: 400, text: '—', glyph: '', hatch: false, hatchBg: 'none', border: '1px solid #F1F3F7', state: 'unstaffed' };
+    if (v < 50) return { bg: '#F6F7F9', fg: '#101720', fw: 400, text: v + '%', glyph: '', hatch: false, hatchBg: 'none', border: '1px solid #E4E7EC', state: 'part time' };
+    if (v < 80) return { bg: '#F1F3F7', fg: '#101720', fw: 400, text: v + '%', glyph: '', hatch: false, hatchBg: 'none', border: '1px solid #E4E7EC', state: 'partly allocated' };
+    if (v <= 100) return { bg: '#E8F0FE', fg: '#101720', fw: 600, text: v + '%', glyph: '', hatch: false, hatchBg: 'none', border: '1px solid #BBD0F6', state: 'fully allocated' };
+    if (v <= 120) return { bg: '#FBF0DC', fg: '#8A5200', fw: 600, text: v + '%', glyph: '⚠', hatch: true, hatchBg: HATCH_DARK, border: '1px solid #E0C089', state: 'over-allocated' };
+    return { bg: '#FDE9E7', fg: '#B3261E', fw: 600, text: v + '%', glyph: '✕', hatch: true, hatchBg: HATCH_HEAVY, border: '1.5px solid #B3261E', state: 'severely over-allocated' };
+  }
+
+  say(m) { this.setState({ announce: m }); }
+
+  cellName(rowObj, w, v) {
+    const lb = weekLabel(w);
+    const st = this.style(v);
+    return rowObj.name + ', ' + lb.wk + ' beginning ' + lb.sub + ', ' + (v === 0 ? 'not staffed' : v + ' percent, ' + st.state) +
+      (v > 100 ? ', over by ' + (v - 100) + ' points' : '') + '.';
+  }
+
+  moveCursor(dr, dc) {
+    const rows = this.rowsModel();
+    let { r, c } = this.state.cursor;
+    let nr = r, nc = Math.max(0, Math.min(WEEKS - 1, c + dc));
+    if (dr !== 0) {
+      nr = r;
+      do { nr += dr; } while (nr >= 0 && nr < rows.length && rows[nr].group);
+      if (nr < 0 || nr >= rows.length) nr = r;
+    }
+    this.setState({ cursor: { r: nr, c: nc } }, () => this.ensureVisible(nr, nc));
+    const row = rows[nr];
+    if (row && !row.group) this.say(this.cellName(row, nc, this.val(row.i, nc)));
+  }
+
+  ensureVisible(r, c) {
+    const el = this._el;
+    if (!el) return;
+    const top = r * RH, left = c * CW;
+    if (top < el.scrollTop) el.scrollTop = top;
+    else if (top + RH > el.scrollTop + el.clientHeight) el.scrollTop = top + RH - el.clientHeight;
+    if (left < el.scrollLeft) el.scrollLeft = left;
+    else if (left + CW > el.scrollLeft + el.clientWidth) el.scrollLeft = left + CW - el.clientWidth;
+    this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, vw: el.clientWidth });
+  }
+
+  onKey(e) {
+    const k = e.key;
+    const S = this.state;
+    const rows = this.rowsModel();
+    const row = rows[S.cursor.r];
+    if (S.editing) {
+      if (k === 'ArrowUp' || k === 'ArrowDown') {
+        e.preventDefault();
+        const cur = this.val(row.i, S.cursor.c);
+        const nv = Math.max(0, Math.min(160, cur + (k === 'ArrowUp' ? 10 : -10)));
+        const ed = Object.assign({}, S.edits); ed[row.i + ':' + S.cursor.c] = nv;
+        this.setState({ edits: ed });
+        this.say(nv + ' percent' + (nv > 100 ? ', over by ' + (nv - 100) + ' points' : '') + '.');
+        return;
+      }
+      if (k === 'Enter' || k === 'Tab') {
+        e.preventDefault();
+        const v = this.val(row.i, S.cursor.c);
+        this.setState({ editing: false });
+        this.say('Set ' + row.name + ', ' + weekLabel(S.cursor.c).wk + ' to ' + v + ' percent. Saved locally, 1 change pending sync.' + (v > 100 ? ' Over-allocated by ' + (v - 100) + ' points.' : ''));
+        return;
+      }
+      if (k === 'Escape') {
+        e.preventDefault();
+        const ed = Object.assign({}, S.edits); delete ed[row.i + ':' + S.cursor.c];
+        this.setState({ editing: false, edits: ed });
+        this.say('Edit cancelled. ' + this.cellName(row, S.cursor.c, this.val(row.i, S.cursor.c)));
+        return;
+      }
+      return;
+    }
+    if (k === 'ArrowRight') { e.preventDefault(); this.moveCursor(0, 1); return; }
+    if (k === 'ArrowLeft') { e.preventDefault(); this.moveCursor(0, -1); return; }
+    if (k === 'ArrowDown') { e.preventDefault(); this.moveCursor(1, 0); return; }
+    if (k === 'ArrowUp') { e.preventDefault(); this.moveCursor(-1, 0); return; }
+    if (k === 'PageDown') { e.preventDefault(); this.moveCursor(0, 13); return; }
+    if (k === 'PageUp') { e.preventDefault(); this.moveCursor(0, -13); return; }
+    if (k === 'Home') { e.preventDefault(); this.setState({ cursor: { r: S.cursor.r, c: 0 } }, () => this.ensureVisible(S.cursor.r, 0)); this.say('First week, ' + weekLabel(0).sub + '.'); return; }
+    if (k === 'End') { e.preventDefault(); this.setState({ cursor: { r: S.cursor.r, c: WEEKS - 1 } }, () => this.ensureVisible(S.cursor.r, WEEKS - 1)); this.say('Last week, ' + weekLabel(WEEKS - 1).sub + '.'); return; }
+    if (k === 'Enter') {
+      e.preventDefault();
+      if (!row || row.group) return;
+      this.setState({ editing: true });
+      this.say('Editing ' + row.name + ', ' + weekLabel(S.cursor.c).wk + '. Up and down arrows change by 10 points. Enter commits, Escape cancels.');
+      return;
+    }
+    if (k === 'n' || k === 'N') { e.preventDefault(); this.nextConflict(); }
+  }
+
+  nextConflict() {
+    const rows = this.rowsModel();
+    const S = this.state;
+    for (let r = S.cursor.r; r < rows.length; r++) {
+      const row = rows[r];
+      if (row.group) continue;
+      for (let w = (r === S.cursor.r ? S.cursor.c + 1 : 0); w < WEEKS; w++) {
+        if (this.val(row.i, w) > 100) {
+          this.setState({ cursor: { r, c: w } }, () => this.ensureVisible(r, w));
+          this.say('Next conflict: ' + this.cellName(row, w, this.val(row.i, w)));
+          return;
+        }
+      }
+    }
+    this.say('No further over-allocated cells after the cursor.');
+  }
+
+  renderVals() {
+    const S = this.state;
+    const rows = this.rowsModel();
+    const firstRow = Math.max(0, Math.floor(S.scrollTop / RH) - 2);
+    const rowWin = Math.ceil(492 / RH) + 4;
+    const firstCol = Math.max(0, Math.floor(S.scrollLeft / CW) - 1);
+    const colWin = Math.ceil(S.vw / CW) + 2;
+
+    const rowHeads = [];
+    const rowTotals = [];
+    for (let i = firstRow; i < Math.min(rows.length, firstRow + rowWin); i++) {
+      const r = rows[i];
+      const isCursor = S.cursor.r === i;
+      if (r.group) {
+        rowHeads.push({ top: (i * RH) + 'px', isGroup: true, isPerson: false, name: r.group, bg: '#F1F3F7', bar: 'none', flag: false, initials: '', role: '', region: '', rate: '', flagN: '' });
+        rowTotals.push({ top: (i * RH) + 'px', avg: '', peak: '', peakFg: '#4B5563', bg: '#F1F3F7' });
+        continue;
+      }
+      const peak = this.peak(r.i);
+      let overWeeks = 0;
+      for (let w = 0; w < WEEKS; w++) if (this.val(r.i, w) > 100) overWeeks++;
+      rowHeads.push({
+        top: (i * RH) + 'px', isGroup: false, isPerson: true, name: r.name, role: r.role, region: r.region,
+        rate: 'MYR ' + r.rate.toLocaleString(),
+        initials: r.name.split(' ').map(x => x[0]).slice(0, 2).join(''),
+        avBg: peak > 120 ? '#FDE9E7' : peak > 100 ? '#FBF0DC' : '#E8F0FE',
+        avFg: peak > 120 ? '#B3261E' : peak > 100 ? '#8A5200' : '#0B57D0',
+        bg: isCursor ? '#E8F0FE' : '#FFFFFF', bar: isCursor ? 'inset 2px 0 0 #0B57D0' : 'none',
+        flag: overWeeks > 0, flagN: overWeeks + 'w'
+      });
+      rowTotals.push({
+        top: (i * RH) + 'px', avg: this.avg(r.i) + '%', peak: peak + '%',
+        peakFg: peak > 120 ? '#B3261E' : peak > 100 ? '#8A5200' : '#101720',
+        bg: isCursor ? '#E8F0FE' : '#FFFFFF'
+      });
+    }
+
+    const cells = [];
+    for (let i = firstRow; i < Math.min(rows.length, firstRow + rowWin); i++) {
+      const r = rows[i];
+      if (r.group) continue;
+      for (let w = firstCol; w < Math.min(WEEKS, firstCol + colWin); w++) {
+        const v = this.val(r.i, w);
+        const st = this.style(v);
+        const sel = S.cursor.r === i && S.cursor.c === w;
+        cells.push({
+          top: (i * RH) + 'px', left: (w * CW) + 'px',
+          bg: st.bg, fg: st.fg, fw: st.fw, text: st.text, glyph: st.glyph,
+          hatch: st.hatch, hatchBg: st.hatchBg,
+          border: sel && S.editing ? '2px solid #0B57D0' : st.border,
+          ring: sel ? '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' : 'none',
+          sel: sel ? 'true' : 'false', tab: sel ? 0 : -1,
+          aria: this.cellName(r, w, v),
+          on: () => { this.setState({ cursor: { r: i, c: w }, editing: false }); this.say(this.cellName(r, w, v)); }
+        });
+      }
+    }
+
+    const weekTicks = [];
+    const monthTicks = [];
+    let lastKey = '';
+    for (let w = firstCol; w < Math.min(WEEKS, firstCol + colWin); w++) {
+      const lb = weekLabel(w);
+      weekTicks.push({ left: (w * CW) + 'px', label: lb.wk, sub: lb.sub, bg: w === TODAY_W ? '#E8F0FE' : 'transparent', fg: w === TODAY_W ? '#0B57D0' : '#4B5563' });
+      if (lb.key !== lastKey) { monthTicks.push({ left: (w * CW) + 'px', width: (CW * 4.34) + 'px', label: lb.month }); lastKey = lb.key; }
+    }
+
+    const bands = [];
+    for (let w = firstCol; w < Math.min(WEEKS, firstCol + colWin); w++) {
+      const m = new Date(2026, 0, 5 + w * 7).getMonth();
+      if (m % 2 === 1) bands.push({ left: (w * CW) + 'px', bg: '#FBFCFD' });
+    }
+
+    let conflictCount = 0;
+    const conflictPeople = {};
+    ROSTER.forEach((p, ri) => { for (let w = 0; w < WEEKS; w++) if (this.val(ri, w) > 100) { conflictCount++; conflictPeople[ri] = 1; } });
+
+    const HG = (o) => o;
+    return {
+      resCount: '42', weekCount: '104',
+      gridWidth: (WEEKS * CW) + 'px', gridHeight: (rows.length * RH) + 'px',
+      rowShift: (-S.scrollTop) + 'px', axisShift: (-S.scrollLeft) + 'px',
+      todayLeft: (TODAY_W * CW) + 'px',
+      rowHeads, rowTotals, cells, weekTicks, monthTicks, bands,
+      announce: S.announce,
+      statusBg: S.editing ? '#E8F0FE' : '#FFFFFF',
+      conflictCount, conflictPeople: Object.keys(conflictPeople).length,
+      visFromLabel: weekLabel(firstCol).wk, visToLabel: weekLabel(Math.min(WEEKS - 1, firstCol + colWin - 2)).wk,
+      onScroll: (e) => { this._el = e.target; this.setState({ scrollTop: e.target.scrollTop, scrollLeft: e.target.scrollLeft, vw: e.target.clientWidth }); },
+      gridRef: (el) => { if (el) this._el = el; },
+      onKey: (e) => this.onKey(e),
+      jumpToConflict: () => { this.setState({ cursor: { r: 0, c: 0 } }, () => this.nextConflict()); },
+      toggleOver: () => this.setState(s => ({ overOnly: !s.overOnly })),
+      overMark: S.overOnly ? '✓' : '○',
+      overBg: S.overOnly ? '#E8F0FE' : '#FFFFFF',
+      overFg: S.overOnly ? '#0B57D0' : '#4B5563',
+      overBd: S.overOnly ? '#BBD0F6' : '#CBD2DC',
+      groupCells: ['None', 'Workstream', 'Region'].map(g => ({
+        label: g === 'None' ? 'Flat list' : 'By ' + g.toLowerCase(),
+        bg: S.group === g ? '#FFFFFF' : 'transparent',
+        fg: S.group === g ? '#101720' : '#4B5563',
+        bd: S.group === g ? '#7D8799' : 'transparent',
+        sh: S.group === g ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => this.setState({ group: g })
+      })),
+
+      legend: [
+        { sample: '—', label: 'Not staffed', bg: '#FFFFFF', fg: '#667085', border: '1px solid #CBD2DC', hatch: 'none' },
+        { sample: '45%', label: 'Part time', bg: '#F6F7F9', fg: '#101720', border: '1px solid #E4E7EC', hatch: 'none' },
+        { sample: '80%', label: 'Partly allocated', bg: '#F1F3F7', fg: '#101720', border: '1px solid #E4E7EC', hatch: 'none' },
+        { sample: '100%', label: 'Fully allocated', bg: '#E8F0FE', fg: '#101720', border: '1px solid #BBD0F6', hatch: 'none' },
+        { sample: '⚠115', label: 'Over 100% — hatch + ⚠', bg: '#FBF0DC', fg: '#8A5200', border: '1px solid #E0C089', hatch: HATCH_DARK },
+        { sample: '✕145', label: 'Over 120% — dense hatch + ✕', bg: '#FDE9E7', fg: '#B3261E', border: '1.5px solid #B3261E', hatch: HATCH_HEAVY }
+      ],
+
+      contrast: [
+        { sample: '—', desc: 'Not staffed — surface/base with content/tertiary em dash. No number, because 0% and “no assignment” are the same fact here.', bg: '#FFFFFF', fg: '#667085', border: '1px solid #CBD2DC', hatch: 'none', ratio: '4.97:1' },
+        { sample: '45%', desc: 'Part time (1–49%) — surface/app fill, content/primary figure.', bg: '#F6F7F9', fg: '#101720', border: '1px solid #E4E7EC', hatch: 'none', ratio: '16.94:1' },
+        { sample: '80%', desc: 'Partly allocated (50–79%) — surface/sunken fill, content/primary figure.', bg: '#F1F3F7', fg: '#101720', border: '1px solid #E4E7EC', hatch: 'none', ratio: '16.22:1' },
+        { sample: '100%', desc: 'Fully allocated (80–100%) — accent/subtle fill, weight 600. The healthy target, so it is the only calm blue in the grid.', bg: '#E8F0FE', fg: '#101720', border: '1px solid #BBD0F6', hatch: 'none', ratio: '15.72:1' },
+        { sample: '⚠115', desc: 'Over-allocated (101–120%) — warning/subtle fill, 42%-opacity hatch at 135°, ⚠ glyph. The figure sits on a solid chip of the cell’s own fill, so the hatch never crosses a glyph: the ratio below is the worst case, not an average.', bg: '#FBF0DC', fg: '#8A5200', border: '1px solid #E0C089', hatch: HATCH_DARK, ratio: '5.66:1' },
+        { sample: '✕145', desc: 'Severe (over 120%) — danger/subtle fill, denser 55% hatch, ✕ glyph, 1.5px danger border so it survives greyscale and a projector. Figure on a solid chip again.', bg: '#FDE9E7', fg: '#B3261E', border: '1.5px solid #B3261E', hatch: HATCH_HEAVY, ratio: '5.60:1' },
+        { sample: '120', desc: 'Focused cell — 2px accent ring at 2px offset over any fill; against the white gap it measures 6.39:1 and against the darkest cell fill 4.6:1.', bg: '#FBF0DC', fg: '#8A5200', border: '2px solid #0B57D0', hatch: 'none', ratio: '6.39:1' }
+      ],
+
+      rules: [
+        'The number is always printed. A cell never communicates by fill alone — remove every colour and the grid still reads, which is exactly what the Excel export and the greyscale print do.',
+        'Hatch angle and density encode severity independently of hue: 3px/42% at 101–120%, 2px/55% above 120%. The figure is drawn on a solid 2px-radius chip of the cell’s own fill, so no stripe ever crosses a glyph — the stated ratios are the worst case a reader can meet, not an average across the stripe pattern.',
+        'Over-allocation is exceptional on purpose: five people — the three ABAP developers, the integration architect and the data-migration lead — inside two pressure windows, integration test (W40–46) and cutover (W72–78). A grid where every row is flagged has no exception to find.',
+        'Capacity is a property of the person, not the cell: the row header carries the peak and the count of over-allocated weeks, so a conflict is findable without scrolling 104 columns.',
+        'Column width is fixed at 52px — enough for “145%” at 11.5px tabular without truncation. Density is changed by hiding weeks (filter to a phase window), never by shrinking the cell.',
+        'Windowing is two-dimensional: ~15 rows × ~20 columns exist in the DOM out of 4,368 possible cells. Scroll position is the single source of truth, held on the scrolling element.',
+        'Editing is in place at the cell’s exact bounds and commits on Enter; the row header’s peak and the average recompute immediately, so the consequence of the edit is visible in the same glance.',
+        'Grouping by workstream or region inserts non-selectable group rows; the cursor skips them, and the announcement never reads a group row as a resource.',
+        'Leave, public holidays and non-working weeks are not drawn as 0% — a future revision marks them with a distinct “LV” token so “not booked” and “not available” never look identical.'
+      ],
+
+      keys: [
+        { k: '← → ↑ ↓', v: 'Move the cell cursor. Group rows are skipped. The grid scrolls to keep the cell in view on both axes.' },
+        { k: 'PgUp/PgDn', v: 'Move 13 weeks — one quarter — at a time.' },
+        { k: 'Home / End', v: 'First and last week of the programme on the current row.' },
+        { k: 'Enter', v: 'Edit the focused cell in place; Enter again commits and announces the new value with its over-allocation delta.' },
+        { k: '↑ ↓ (edit)', v: 'Adjust by 10 points, clamped 0–160. Escape reverts to the stored value.' },
+        { k: 'N', v: 'Jump to the next over-allocated cell after the cursor, announcing who and which week.' }
+      ],
+
+      sayExamples: [
+        { k: '→', v: 'Arun Prakash, W41 beginning 12 Oct, 120 percent, over-allocated, over by 20 points.' },
+        { k: 'Enter', v: 'Editing Arun Prakash, W41. Up and down arrows change by 10 points. Enter commits, Escape cancels.' },
+        { k: 'Enter (commit)', v: 'Set Arun Prakash, W41 to 130 percent. Saved locally, 1 change pending sync. Over-allocated by 30 points.' },
+        { k: 'N', v: 'Next conflict: Priya Raghavan, W44 beginning 2 Nov, 145 percent, severely over-allocated, over by 45 points.' }
+      ],
+
+      a11y: [
+        { k: 'Grid', v: 'role="grid" with aria-rowcount 42 and aria-colcount 104 describing the whole dataset, not the rendered window. One tab stop; a roving tabindex marks the focused cell.' },
+        { k: 'Cell name', v: 'Every cell carries a full aria-label — person, week, date, percentage, state and the over-allocation delta — so nothing the fill or hatch encodes is available only visually.' },
+        { k: 'Row header', v: 'The resource column is role="rowheader" and includes role, region and day rate, so a cell read in isolation still identifies who and at what cost.' },
+        { k: 'Live region', v: '#matrix-status is role="status" aria-live="polite" aria-atomic="true" and is written on cursor move, edit entry, each 10-point adjustment, commit, cancel and conflict jump. It is shown visibly here for review; in the product it is visually hidden.' },
+        { k: 'Hatch', v: 'The hatch layer is aria-hidden and sits below a solid text chip, so it is a redundant encoding of a number that is already printed at full contrast and already in the accessible name.' },
+        { k: 'Editing', v: 'The cell gains aria-expanded during edit; commit failures keep focus in the cell, set aria-invalid and describe the reason (“Allocation must be between 0 and 160”).' },
+        { k: 'Zoom / 320px', v: 'At 320px the matrix becomes a per-resource week list — one resource, 104 rows of week and percentage — rather than a two-dimensional scroll, satisfying WCAG 1.4.10 without losing any figure.' }
+      ],
+
+      darkWeeks: ['W38', 'W39', 'W40', 'W41', 'W42', 'W43'],
+      darkRows: [
+        { name: 'Rajesh Menon', cells: [
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '80%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '—', bg: '#0E1116', fg: '#8592A6', fw: 400, hatch: 'none' },
+          { t: '60%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' }
+        ] },
+        { name: 'Arun Prakash', cells: [
+          { t: '90%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '⚠115%', bg: '#33240B', fg: '#E9B45A', fw: 600, hatch: HATCH_LIGHT },
+          { t: '⚠120%', bg: '#33240B', fg: '#E9B45A', fw: 600, hatch: HATCH_LIGHT },
+          { t: '✕145%', bg: '#3A1512', fg: '#FF8A80', fw: 600, hatch: HATCH_LIGHT },
+          { t: '⚠110%', bg: '#33240B', fg: '#E9B45A', fw: 600, hatch: HATCH_LIGHT },
+          { t: '80%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' }
+        ] },
+        { name: 'Nguyen Thi Lan', cells: [
+          { t: '—', bg: '#0E1116', fg: '#8592A6', fw: 400, hatch: 'none' },
+          { t: '40%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '60%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '60%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' }
+        ] },
+        { name: 'Siti Nurhaliza', cells: [
+          { t: '50%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '50%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '100%', bg: '#16294A', fg: '#E9EEF6', fw: 600, hatch: 'none' },
+          { t: '⚠105%', bg: '#33240B', fg: '#E9B45A', fw: 600, hatch: HATCH_LIGHT },
+          { t: '90%', bg: '#1B222C', fg: '#E9EEF6', fw: 400, hatch: 'none' }
+        ] }
+      ],
+
+      greyRows: [
+        { name: 'Rajesh Menon', cells: [
+          { t: '100%', g: '', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: 'none' },
+          { t: '80%', g: '', bg: '#F1F3F7', fg: '#101720', fw: 400, hatch: 'none' },
+          { t: '100%', g: '', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: 'none' },
+          { t: '—', g: '', bg: '#FFFFFF', fg: '#667085', fw: 400, hatch: 'none' },
+          { t: '60%', g: '', bg: '#F1F3F7', fg: '#101720', fw: 400, hatch: 'none' },
+          { t: '100%', g: '', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: 'none' }
+        ] },
+        { name: 'Arun Prakash', cells: [
+          { t: '90%', g: '', bg: '#F1F3F7', fg: '#101720', fw: 400, hatch: 'none' },
+          { t: '115%', g: '⚠', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: HATCH_DARK },
+          { t: '120%', g: '⚠', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: HATCH_DARK },
+          { t: '145%', g: '✕', bg: '#CBD2DC', fg: '#101720', fw: 600, hatch: HATCH_HEAVY },
+          { t: '110%', g: '⚠', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: HATCH_DARK },
+          { t: '80%', g: '', bg: '#F1F3F7', fg: '#101720', fw: 400, hatch: 'none' }
+        ] },
+        { name: 'Siti Nurhaliza', cells: [
+          { t: '50%', g: '', bg: '#F6F7F9', fg: '#101720', fw: 400, hatch: 'none' },
+          { t: '100%', g: '', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: 'none' },
+          { t: '100%', g: '', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: 'none' },
+          { t: '105%', g: '⚠', bg: '#E4E7EC', fg: '#101720', fw: 600, hatch: HATCH_DARK },
+          { t: '90%', g: '', bg: '#F1F3F7', fg: '#101720', fw: 400, hatch: 'none' },
+          { t: '—', g: '', bg: '#FFFFFF', fg: '#667085', fw: 400, hatch: 'none' }
+        ] }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/composites.html
+++ b/docs/design/composites.html
@@ -1,0 +1,859 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; text-decoration:underline; text-underline-offset:2px; }
+  a:hover { color:#08429E; }
+  button, input { font-family:inherit; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { animation-duration:1ms !important; transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1440px;margin:0 auto;padding:72px 40px 40px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 3 of 5</div>
+  <h1 style="margin:14px 0 0;font-size:44px;line-height:50px;font-weight:600;letter-spacing:-0.025em;max-width:22ch;text-wrap:pretty">Composites: the structures screens are made of</h1>
+  <p style="margin:20px 0 0;max-width:70ch;font-size:16px;line-height:26px;color:#4B5563;text-wrap:pretty">Fourteen composites assembled entirely from layer-2 primitives and layer-1 tokens. Each names the primitives it is built from, its spacing in token units, and its behaviour under the loads Cockpit actually carries — 1,200 tasks, 80 phases, nine concurrent editors.</p>
+</header>
+
+<section style="max-width:1440px;margin:0 auto;padding:16px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">A — App shell</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Top bar, primary nav, contextual sub-nav</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Anatomy: <span style="font-family:'IBM Plex Mono',monospace;font-size:13px">[top bar h56] → [primary nav h44] → [sub-nav h40] → [content]</span> = 140px of chrome, fixed. Below 1024px the sub-nav becomes a horizontally scrolling strip; below 768px the primary nav collapses into the top bar’s menu button. The sync chip never collapses — it is the one element guaranteed present at every width.</p>
+
+  <div style="margin-top:24px;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#F6F7F9">
+    <div style="display:flex;align-items:center;gap:16px;height:56px;padding:0 16px;background:#FFFFFF;border-bottom:1px solid #CBD2DC">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:6px;background:#101720;color:#FFFFFF;font-size:13px;font-weight:600">C</span>
+        <span style="font-size:15px;font-weight:600;letter-spacing:-0.01em">Cockpit</span>
+      </div>
+      <div style="height:24px;width:1px;background:#CBD2DC"></div>
+      <button style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;cursor:pointer">
+        <span style="font-size:13px;font-weight:500;color:#101720">S/4HANA Migration — Sarawak Energy</span>
+        <span style="font-size:9px;color:#4B5563">▼</span>
+      </button>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 8px;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:12px;font-weight:500;color:#4B5563">EDITOR</span>
+      <div style="flex:1;display:flex;justify-content:center">
+        <div style="display:flex;align-items:center;gap:8px;width:100%;max-width:420px;height:32px;padding:0 10px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span>
+          <span style="flex:1;font-size:13px;color:#667085">Search tasks, resources, phases…</span>
+          <kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#FFFFFF;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">⌘K</kbd>
+        </div>
+      </div>
+      <div style="display:flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB">
+        <span style="font-size:11px;color:#0A7A47" aria-hidden="true">✓</span>
+        <span style="font-size:12px;font-weight:500;color:#0A7A47">Synced</span>
+        <span style="font-size:11px;color:#0A7A47;font-variant-numeric:tabular-nums">14:32</span>
+      </div>
+      <div style="display:flex">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:11px;font-weight:600;border:2px solid #FFFFFF">RM</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#E3F5EB;color:#0A7A47;font-size:11px;font-weight:600;border:2px solid #FFFFFF;margin-left:-6px">AR</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#F1F3F7;color:#4B5563;font-size:11px;font-weight:600;border:2px solid #FFFFFF;margin-left:-6px">+4</span>
+      </div>
+      <button aria-label="Account" style="width:32px;height:32px;border-radius:999px;border:1px solid #7D8799;background:#FBF0DC;color:#8A5200;font-size:12px;font-weight:600;cursor:pointer">CW</button>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:4px;height:44px;padding:0 16px;background:#FFFFFF;border-bottom:1px solid #E4E7EC">
+      <sc-for list="{{ primaryNav }}" as="n" hint-placeholder-count="6">
+        <span style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 12px;border-radius:6px;background:{{ n.bg }};color:{{ n.fg }};font-size:13px;font-weight:{{ n.fw }};border:1px solid {{ n.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px" aria-hidden="true">{{ n.g }}</span>{{ n.label }}</span>
+      </sc-for>
+      <div style="margin-left:auto;display:flex;gap:8px">
+        <button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;color:#101720;cursor:pointer">Baseline</button>
+        <button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;font-size:13px;font-weight:500;color:#FFFFFF;cursor:pointer">Generate proposal</button>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:18px;height:40px;padding:0 16px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <sc-for list="{{ subNav }}" as="s" hint-placeholder-count="6">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:40px;font-size:13px;font-weight:{{ s.fw }};color:{{ s.fg }};box-shadow:{{ s.bar }}">{{ s.label }}<sc-if value="{{ s.count }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:999px;background:#E4E7EC;font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.count }}</span></sc-if></span>
+      </sc-for>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span>Base currency <span style="font-weight:500;color:#101720">MYR</span></span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span>Cost visibility <span style="font-weight:500;color:#101720">Level 2 of 3</span></span>
+      </div>
+    </div>
+
+    <div style="padding:20px 16px;min-height:120px;background:#F6F7F9">
+      <div style="font-size:12px;line-height:18px;color:#667085">Content region. Scrolls independently; the three chrome rows are sticky. Focus order is top bar → primary nav → sub-nav → content, and a persistent “Skip to content” link precedes the logo.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Shell — dark</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+        <div style="display:flex;align-items:center;gap:12px;height:48px;padding:0 12px;background:#171C24;border-bottom:1px solid #333C4A">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:5px;background:#E9EEF6;color:#0B1220;font-size:12px;font-weight:600">C</span>
+          <span style="font-size:13px;font-weight:600;color:#E9EEF6">S/4HANA Migration</span>
+          <div style="flex:1"></div>
+          <span style="display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 9px;border-radius:999px;background:#0F2E22;border:1px solid #2C6B4E;font-size:12px;font-weight:500;color:#56D69A"><span aria-hidden="true">✓</span>Synced</span>
+        </div>
+        <div style="display:flex;gap:4px;height:40px;align-items:center;padding:0 12px;background:#171C24;border-bottom:1px solid #232A35">
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;background:#16294A;border:1px solid #2F4E82;color:#7FB0FF;font-size:13px;font-weight:600">Timeline</span>
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;color:#AFBACA;font-size:13px">Resources</span>
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;color:#AFBACA;font-size:13px">Cost</span>
+        </div>
+        <div style="height:36px;background:#0A0D12;display:flex;align-items:center;padding:0 12px;font-size:12px;color:#8592A6">Sub-nav on surface/sunken — the only place dark uses the sunken step in chrome</div>
+      </div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Shell rules</h3>
+      <sc-for list="{{ shellRules }}" as="r" hint-placeholder-count="5">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:10px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#0B57D0;line-height:20px">§</span><div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">B — Data table</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">One table, every capability</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Row height 40 (compact 32), sticky header, no vertical rules, no zebra. Numeric columns are right-aligned tabular; the first column is sticky when horizontal scrolling starts. Composed from: Checkbox · Button · Icon button · Dropdown menu · Chip · Status pill · Avatar · Pagination · Skeleton.</p>
+
+  <div style="margin-top:24px;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#FFFFFF">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;border-bottom:1px solid #E4E7EC;flex-wrap:wrap">
+      <div style="display:flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;min-width:200px">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span><span style="font-size:13px;color:#101720">basis</span>
+      </div>
+      <sc-for list="{{ filterChips }}" as="c" hint-placeholder-count="3">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 6px 0 10px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">{{ c }}<span aria-label="Remove filter" style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:3px;background:#D6E4FD;font-size:11px;cursor:pointer">×</span></span>
+      </sc-for>
+      <button style="height:28px;padding:0 8px;border-radius:4px;border:1px dashed #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#4B5563;cursor:pointer">+ Add filter</button>
+      <button style="height:28px;padding:0 8px;border-radius:4px;border:none;background:transparent;font-size:12px;font-weight:500;color:#0B57D0;cursor:pointer">Clear all</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:8px">
+        <button style="display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Saved view: <span style="font-weight:600">Subcontractors</span> <span style="font-size:9px">▼</span></button>
+        <button style="display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Columns <span style="font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">7 / 11</span></button>
+        <button style="height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Export</button>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:14px;padding:8px 16px;background:#E8F0FE;border-bottom:1px solid #BBD0F6">
+      <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:12px;font-weight:600">–</span>
+      <span style="font-size:13px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">3 of 42 resources selected</span>
+      <span style="width:1px;height:18px;background:#BBD0F6"></span>
+      <sc-for list="{{ bulkActions }}" as="b" hint-placeholder-count="4">
+        <button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid {{ b.bd }};background:{{ b.bg }};font-size:13px;font-weight:500;color:{{ b.fg }};cursor:pointer">{{ b.label }}</button>
+      </sc-for>
+      <button style="margin-left:auto;height:28px;padding:0 8px;border-radius:4px;border:none;background:transparent;font-size:13px;color:#0B57D0;cursor:pointer">Clear selection · Esc</button>
+    </div>
+
+    <div style="overflow-x:auto">
+      <div style="min-width:1080px">
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;gap:0;background:#F1F3F7;border-bottom:1px solid #CBD2DC;position:sticky;top:0">
+          <sc-for list="{{ columns }}" as="c" hint-placeholder-count="9">
+            <div style="display:flex;align-items:center;gap:6px;height:36px;padding:0 12px;justify-content:{{ c.just }};border-right:1px solid #E4E7EC;position:relative">
+              <span style="font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:{{ c.fg }}">{{ c.label }}</span>
+              <span style="font-size:10px;color:#0B57D0">{{ c.sort }}</span>
+              <span style="position:absolute;right:-2px;top:8px;bottom:8px;width:4px;cursor:col-resize;background:{{ c.grip }}"></span>
+            </div>
+          </sc-for>
+        </div>
+
+        <sc-for list="{{ rows }}" as="r" hint-placeholder-count="8">
+          <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;align-items:center;height:40px;border-bottom:1px solid #E4E7EC;background:{{ r.bg }};box-shadow:{{ r.bar }}">
+            <div style="display:flex;align-items:center;justify-content:center"><span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:{{ r.cbBg }};border:1px solid {{ r.cbBd }};color:#FFFFFF;font-size:11px;font-weight:600">{{ r.cb }}</span></div>
+            <div style="display:flex;align-items:center;gap:8px;padding:0 12px;min-width:0">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:none;border-radius:999px;background:{{ r.avBg }};color:{{ r.avFg }};font-size:10px;font-weight:600">{{ r.initials }}</span>
+              <span style="font-size:13px;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+            </div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.role }}</div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;font-variant-numeric:tabular-nums">{{ r.region }}</div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.stream }}</div>
+            <div style="padding:0 12px;text-align:right;font-size:13px;font-weight:500;color:{{ r.rateFg }};font-variant-numeric:tabular-nums;background:{{ r.rateBg }};border:{{ r.rateBd }};height:{{ r.rateH }};display:flex;align-items:center;justify-content:flex-end;border-radius:4px;margin:0 6px">{{ r.rate }}</div>
+            <div style="padding:0 12px;text-align:right;font-size:13px;color:#101720;font-variant-numeric:tabular-nums">{{ r.alloc }}</div>
+            <div style="padding:0 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ r.pillBg }};color:{{ r.pillFg }};border:1px solid {{ r.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ r.pillG }}</span>{{ r.pill }}</span></div>
+            <div style="display:flex;align-items:center;justify-content:center;color:#4B5563;font-size:14px">⋯</div>
+          </div>
+        </sc-for>
+
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;align-items:center;height:40px;border-bottom:1px solid #E4E7EC">
+          <div></div>
+          <div style="display:flex;align-items:center;gap:8px;padding:0 12px"><div style="width:24px;height:24px;border-radius:999px;background:#E4E7EC"></div><div style="height:12px;width:60%;border-radius:2px;background:#E4E7EC"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:70%;border-radius:2px;background:#E4E7EC"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:60%;border-radius:2px;background:#EDEFF3"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:50%;border-radius:2px;background:#EDEFF3"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:70%;border-radius:2px;background:#E4E7EC;margin-left:auto"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:50%;border-radius:2px;background:#EDEFF3;margin-left:auto"></div></div>
+          <div style="padding:0 12px"><div style="height:16px;width:70%;border-radius:4px;background:#E4E7EC"></div></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:16px;padding:10px 16px;border-top:1px solid #CBD2DC;background:#FFFFFF;flex-wrap:wrap">
+      <span style="font-size:13px;color:#4B5563;font-variant-numeric:tabular-nums">1–8 of 42</span>
+      <div style="display:flex;gap:4px">
+        <sc-for list="{{ pages }}" as="p" hint-placeholder-count="6">
+          <span style="display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;padding:0 8px;border-radius:6px;background:{{ p.bg }};color:{{ p.fg }};border:1px solid {{ p.bd }};font-size:13px;font-weight:500;font-variant-numeric:tabular-nums">{{ p.label }}</span>
+        </sc-for>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:#4B5563">Rows <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 8px;border-radius:6px;border:1px solid #CBD2DC;color:#101720;font-variant-numeric:tabular-nums">25 <span style="font-size:9px">▼</span></span></div>
+      <div style="margin-left:auto;font-size:12px;color:#667085">Virtualized variant: above 200 rows pagination is replaced by windowed scrolling — 12 rows rendered either side of the viewport, a sticky group header per phase, and a scrollbar overlay marking the selected rows.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Inline cell edit</h3>
+      <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:1fr 110px;height:36px;align-items:center;background:#F1F3F7;font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563"><span style="padding:0 10px">Resource</span><span style="padding:0 10px;text-align:right">Day rate</span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC"><span style="padding:0 10px;font-size:13px">Nguyen Thi Lan</span><span style="padding:0 10px;text-align:right;font-size:13px;font-variant-numeric:tabular-nums">1,300</span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC;background:#FFFFFF"><span style="padding:0 10px;font-size:13px">Arun Prakash</span><span style="padding:0 4px"><span style="display:flex;align-items:center;height:32px;padding:0 8px;border-radius:4px;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;background:#FFFFFF;font-size:13px;font-weight:500;justify-content:flex-end;font-variant-numeric:tabular-nums">1,150</span></span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC"><span style="padding:0 10px;font-size:13px">Siti Nurhaliza</span><span style="padding:0 10px;text-align:right;font-size:13px;font-variant-numeric:tabular-nums">2,200</span></div>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">Enter or double-click opens the editor in place at the cell’s exact bounds, so nothing shifts. Enter commits and moves down; Tab commits and moves right; Escape reverts. A failed commit keeps the editor open, turns the border status/danger and puts the reason in a popover below.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Column show/hide</h3>
+      <div style="border:1px solid #CBD2DC;border-radius:6px;box-shadow:0 4px 12px rgba(16,23,32,.10);overflow:hidden">
+        <div style="padding:8px 10px;border-bottom:1px solid #E4E7EC;font-size:12px;font-weight:600;color:#101720">Columns · drag to reorder</div>
+        <sc-for list="{{ colToggle }}" as="c" hint-placeholder-count="6">
+          <div style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid #E4E7EC">
+            <span style="color:#98A2B3;font-size:12px;cursor:grab">⠿</span>
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:2px;background:{{ c.bg }};border:1px solid {{ c.bd }};color:#FFFFFF;font-size:10px">{{ c.tick }}</span>
+            <span style="font-size:13px;color:{{ c.fg }}">{{ c.label }}</span>
+            <sc-if value="{{ c.locked }}" hint-placeholder-val="{{ false }}"><span style="margin-left:auto;font-size:11px;color:#667085">locked</span></sc-if>
+          </div>
+        </sc-for>
+        <div style="padding:8px 10px;display:flex;gap:8px"><button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;cursor:pointer">Reset</button><button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12px;cursor:pointer">Save as view</button></div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Table rules</h3>
+      <sc-for list="{{ tableRules }}" as="r" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+    <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Data table — dark</h3>
+    <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+      <div style="display:grid;grid-template-columns:40px 1.6fr 1.2fr 110px 120px;background:#0A0D12;border-bottom:1px solid #333C4A">
+        <div></div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Resource</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Role</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;justify-content:flex-end;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#7FB0FF">Day rate ▼</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Status</div>
+      </div>
+      <sc-for list="{{ darkRows }}" as="r" hint-placeholder-count="4">
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.2fr 110px 120px;align-items:center;height:40px;background:{{ r.bg }};border-bottom:1px solid #232A35;box-shadow:{{ r.bar }}">
+          <div style="display:flex;justify-content:center"><span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:{{ r.cbBg }};border:1px solid {{ r.cbBd }};color:#0B1220;font-size:11px;font-weight:600">{{ r.cb }}</span></div>
+          <div style="padding:0 12px;font-size:13px;color:#E9EEF6">{{ r.name }}</div>
+          <div style="padding:0 12px;font-size:13px;color:#AFBACA">{{ r.role }}</div>
+          <div style="padding:0 12px;text-align:right;font-size:13px;font-weight:500;color:#E9EEF6;font-variant-numeric:tabular-nums">{{ r.rate }}</div>
+          <div style="padding:0 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ r.pillBg }};color:{{ r.pillFg }};border:1px solid {{ r.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ r.pillG }}</span>{{ r.pill }}</span></div>
+        </div>
+      </sc-for>
+    </div>
+    <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Selected rows in dark use accent/subtle <span style="font-family:'IBM Plex Mono',monospace">#16294A</span> plus a 2px accent leading bar — the fill alone is only 1.4:1 against surface/raised, which is why the bar is mandatory rather than decorative.</div>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — shell &amp; table</div>
+    <sc-for list="{{ a11yTable }}" as="a" hint-placeholder-count="6">
+      <div style="display:grid;grid-template-columns:180px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">C — Overlays</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Modal, stacked modal, drawer</h2>
+
+  <div style="display:grid;grid-template-columns:1.25fr 1fr;gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:28px;position:relative;overflow:hidden">
+      <div style="position:absolute;inset:0;background:rgba(16,23,32,.48)"></div>
+      <div style="position:relative;background:#FFFFFF;border-radius:8px;box-shadow:0 16px 48px rgba(16,23,32,.20);max-width:640px;margin:0 auto">
+        <div style="display:flex;align-items:flex-start;gap:16px;padding:20px 24px 16px">
+          <div style="flex:1">
+            <h3 style="margin:0;font-size:20px;line-height:28px;font-weight:600;letter-spacing:-0.015em">Add task to “Realize”</h3>
+            <p style="margin:6px 0 0;font-size:13px;line-height:20px;color:#4B5563">Dates default to the phase window and the Malaysia (MY) working calendar.</p>
+          </div>
+          <button aria-label="Close" style="width:32px;height:32px;flex:none;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#4B5563;font-size:14px;cursor:pointer">×</button>
+        </div>
+        <div style="padding:4px 24px 20px;border-top:1px solid #E4E7EC">
+          <div style="padding-top:20px;display:flex;flex-direction:column;gap:16px">
+            <div>
+              <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Task name <span style="color:#B3261E" aria-hidden="true">*</span></label>
+              <div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;font-size:14px">Chart of accounts workshop</div>
+            </div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+              <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Start</label><div style="display:flex;align-items:center;justify-content:space-between;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">07 Sep 2026 <span style="font-family:'IBM Plex Mono',monospace;color:#667085">▦</span></div></div>
+              <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Finish</label><div style="display:flex;align-items:center;justify-content:space-between;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">18 Sep 2026 <span style="font-family:'IBM Plex Mono',monospace;color:#667085">▦</span></div></div>
+            </div>
+            <div style="display:flex;gap:16px;font-size:12px;color:#4B5563"><span><span style="font-weight:600;color:#101720">8</span> working days</span><span style="color:#8A5200">1 public holiday excluded — 15 Sep, Malaysia Day</span></div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px;padding:14px 24px;border-top:1px solid #E4E7EC;background:#F6F7F9;border-radius:0 0 8px 8px">
+          <span style="font-size:12px;color:#667085">Saved locally as you type</span>
+          <div style="margin-left:auto;display:flex;gap:8px">
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:none;background:transparent;font-size:14px;font-weight:500;color:#0B57D0;cursor:pointer">Cancel</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Add task</button>
+          </div>
+        </div>
+      </div>
+
+      <div style="position:relative;margin:20px auto 0;max-width:420px;background:#FFFFFF;border-radius:8px;box-shadow:0 16px 48px rgba(16,23,32,.20);border-top:3px solid #B3261E">
+        <div style="padding:20px 24px 8px">
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#B3261E;margin-bottom:6px">Dialog 2 of 2 — stacked</div>
+          <h3 style="margin:0;font-size:18px;line-height:26px;font-weight:600">Delete phase “Realization”?</h3>
+          <p style="margin:8px 0 0;font-size:13px;line-height:20px;color:#4B5563">Its <span style="font-weight:600;color:#101720">24 tasks</span>, <span style="font-weight:600;color:#101720">9 resource assignments</span> and <span style="font-weight:600;color:#101720">3 milestones</span> will be removed. Dependencies from Explore will be left dangling and must be reconnected. This cannot be undone after the next sync.</p>
+        </div>
+        <div style="padding:12px 24px 16px">
+          <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Type the phase name to confirm</label>
+          <div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;color:#667085">Realization</div>
+        </div>
+        <div style="display:flex;justify-content:flex-end;gap:8px;padding:14px 24px;border-top:1px solid #E4E7EC;background:#F6F7F9;border-radius:0 0 8px 8px">
+          <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:14px;font-weight:500;box-shadow:0 0 0 2px #F6F7F9,0 0 0 4px #0B57D0;cursor:pointer">Cancel</button>
+          <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #B3261E;background:#B3261E;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Delete phase</button>
+        </div>
+      </div>
+      <div style="position:relative;text-align:center;font-size:12px;color:#FFFFFF;margin-top:14px">Focus rests on Cancel — never on the destructive action. The parent dialog is inert and its scrim has dropped to 24%.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Sizes</h3>
+        <sc-for list="{{ modalSizes }}" as="m" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:150px 1fr;gap:14px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ m.token }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563">{{ m.use }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Modal rules</h3>
+        <sc-for list="{{ modalRules }}" as="r" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;line-height:22px;font-weight:600;color:#E9EEF6">Modal — dark</h3>
+        <div style="background:#171C24;border:1px solid #333C4A;border-radius:8px;box-shadow:0 16px 48px rgba(0,0,0,.76);overflow:hidden">
+          <div style="padding:16px 18px 12px"><div style="font-size:16px;font-weight:600;color:#E9EEF6">Delete phase “Realization”?</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:6px">Its 24 tasks and 9 resource assignments will be removed.</div></div>
+          <div style="display:flex;justify-content:flex-end;gap:8px;padding:12px 18px;background:#0A0D12;border-top:1px solid #232A35"><button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #748196;background:#171C24;color:#E9EEF6;font-size:13px;cursor:pointer">Cancel</button><button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #FF8A80;background:#FF8A80;color:#2A0A07;font-size:13px;font-weight:500;cursor:pointer">Delete phase</button></div>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Dark scrim is <span style="font-family:'IBM Plex Mono',monospace">rgba(4,6,10,.64)</span> — deeper than light, because a dark modal on a dark canvas needs the separation that a shadow cannot provide.</div>
+      </div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:0;overflow:hidden">
+      <div style="display:flex;height:340px">
+        <div style="flex:1;padding:16px;font-size:12px;color:#667085;line-height:18px">Canvas stays live — the Gantt behind a right drawer is still scrollable, and the selected row keeps its accent bar.</div>
+        <div style="width:340px;background:#FFFFFF;border-left:1px solid #CBD2DC;box-shadow:-8px 0 28px rgba(16,23,32,.14);display:flex;flex-direction:column">
+          <div style="display:flex;align-items:flex-start;gap:10px;padding:14px 16px;border-bottom:1px solid #E4E7EC">
+            <div style="flex:1"><div style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Task · Realize</div><div style="font-size:16px;font-weight:600;line-height:22px;margin-top:2px">Chart of accounts workshop</div></div>
+            <button aria-label="Close drawer" style="width:28px;height:28px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#4B5563;cursor:pointer">×</button>
+          </div>
+          <div style="display:flex;gap:16px;padding:0 16px;border-bottom:1px solid #E4E7EC">
+            <sc-for list="{{ tabs }}" as="t" hint-placeholder-count="5">
+              <span style="display:inline-flex;align-items:center;gap:6px;height:38px;font-size:13px;font-weight:500;color:#4B5563">{{ t.label }}</span>
+            </sc-for>
+          </div>
+          <div style="padding:14px 16px;display:flex;flex-direction:column;gap:12px;flex:1">
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Dates</span><span style="font-variant-numeric:tabular-nums">07 – 18 Sep 2026</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Effort</span><span style="font-variant-numeric:tabular-nums">8 working days · 64 h</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Assigned</span><span>Aisyah Rahman · 80%</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Cost</span><span style="font-variant-numeric:tabular-nums">MYR 15,360</span></div>
+          </div>
+          <div style="display:flex;gap:8px;padding:12px 16px;border-top:1px solid #E4E7EC;background:#F6F7F9"><button style="flex:1;height:36px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Duplicate</button><button style="flex:1;height:36px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Save</button></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+        <div style="height:96px;padding:16px;font-size:12px;color:#667085">Bottom drawer — wide and short content, the canvas keeps its full width.</div>
+        <div style="background:#FFFFFF;border-top:1px solid #CBD2DC;box-shadow:0 -8px 28px rgba(16,23,32,.14)">
+          <div style="display:flex;justify-content:center;padding:5px 0"><div style="width:44px;height:4px;border-radius:999px;background:#CBD2DC"></div></div>
+          <div style="display:flex;align-items:center;gap:12px;padding:0 16px 10px"><div style="font-size:15px;font-weight:600">Critical path — 6 tasks, 0 days float</div><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:#FDE9E7;color:#B3261E;border:1px solid #F0B5AF;font-size:11px;font-weight:500"><span aria-hidden="true">✕</span>2 late</span><button style="margin-left:auto;height:28px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:12px;cursor:pointer">Collapse</button></div>
+          <div style="display:flex;gap:8px;padding:0 16px 14px;overflow-x:auto">
+            <sc-for list="{{ criticalChain }}" as="c" hint-placeholder-count="5">
+              <span style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1.5px solid {{ c.bd }};background:{{ c.bg }};font-size:12px;font-weight:500;color:{{ c.fg }};white-space:nowrap">{{ c.label }}<span style="font-variant-numeric:tabular-nums;color:#4B5563">{{ c.days }}</span></span>
+            </sc-for>
+          </div>
+        </div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Drawer rules</h3>
+        <sc-for list="{{ drawerRules }}" as="r" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Tabs — states</h3>
+        <div style="display:flex;gap:20px;border-bottom:1px solid #CBD2DC">
+          <sc-for list="{{ tabStates }}" as="t" hint-placeholder-count="5">
+            <span style="display:inline-flex;align-items:center;gap:6px;height:40px;font-size:13px;font-weight:{{ t.fw }};color:{{ t.fg }};box-shadow:{{ t.bar }};border-radius:{{ t.r }};padding:{{ t.p }};background:{{ t.bg }}">{{ t.label }}<sc-if value="{{ t.count }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:999px;background:#E4E7EC;font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">{{ t.count }}</span></sc-if></span>
+          </sc-for>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">Selected carries weight 600 plus a 2px accent underline. Disabled tabs are never used — a tab with nothing in it shows its empty state instead, because a disabled tab hides the fact that the section exists.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">D — Finding things</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Command palette &amp; global search</h2>
+
+  <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:28px;position:relative">
+      <div style="position:absolute;inset:0;background:rgba(16,23,32,.48);border-radius:8px"></div>
+      <div style="position:relative;max-width:620px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 8px 28px rgba(16,23,32,.14);overflow:hidden">
+        <div style="display:flex;align-items:center;gap:10px;height:48px;padding:0 16px;border-bottom:1px solid #E4E7EC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:15px;color:#667085">⌕</span>
+          <span style="flex:1;font-size:15px;color:#101720">cut</span>
+          <kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">Esc</kbd>
+        </div>
+        <div style="max-height:344px;overflow-y:auto">
+          <sc-for list="{{ paletteGroups }}" as="g" hint-placeholder-count="4">
+            <div>
+              <div style="padding:8px 16px 4px;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;background:#F6F7F9">{{ g.group }}</div>
+              <sc-for list="{{ g.items }}" as="i" hint-placeholder-count="3">
+                <div style="display:flex;align-items:center;gap:12px;padding:8px 16px;border-bottom:1px solid #E4E7EC;background:{{ i.bg }};box-shadow:{{ i.bar }}">
+                  <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#4B5563;width:16px">{{ i.icon }}</span>
+                  <span style="flex:1;min-width:0"><span style="display:block;font-size:14px;line-height:20px;color:#101720">{{ i.label }}</span><span style="display:block;font-size:12px;line-height:17px;color:#667085">{{ i.hint }}</span></span>
+                  <sc-if value="{{ i.kbd }}" hint-placeholder-val="{{ false }}"><kbd style="display:inline-flex;align-items:center;height:20px;padding:0 6px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">{{ i.kbd }}</kbd></sc-if>
+                </div>
+              </sc-for>
+            </div>
+          </sc-for>
+        </div>
+        <div style="display:flex;align-items:center;gap:14px;padding:8px 16px;background:#F6F7F9;border-top:1px solid #E4E7EC;font-size:11px;color:#4B5563">
+          <span>↑↓ move</span><span>↵ open</span><span>⌘↵ open in drawer</span><span>Tab filter by type</span><span style="margin-left:auto;font-variant-numeric:tabular-nums">9 results</span>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 10px;font-size:16px;line-height:22px;font-weight:600">Palette behaviour</h3>
+        <div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">Opens on ⌘K from anywhere including inside a modal. Empty query shows five recent destinations and the three actions most used in this project — never a generic list. Results are grouped by kind and always in the same order: Actions, Go to, Tasks, Resources, Phases, Documents. Typing narrows within 120ms on local data; remote groups append with their own spinner rather than delaying the whole list. The active row carries a 2px accent leading bar in addition to its fill.</div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 10px;font-size:16px;line-height:22px;font-weight:600">Global search — grouped results page</h3>
+        <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+          <sc-for list="{{ searchGroups }}" as="s" hint-placeholder-count="4">
+            <div style="display:flex;align-items:center;gap:12px;padding:10px 12px;border-bottom:1px solid #E4E7EC">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:6px;background:{{ s.bg }};color:{{ s.fg }};font-family:'IBM Plex Mono',monospace;font-size:13px">{{ s.icon }}</span>
+              <span style="flex:1"><span style="display:block;font-size:13px;font-weight:500;color:#101720">{{ s.label }}</span><span style="display:block;font-size:12px;color:#667085">{{ s.hint }}</span></span>
+              <span style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.count }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">The results page keeps the same grouping and adds per-group filters. A group with zero matches is listed with “0” rather than omitted, so the user learns the search covered it.</div>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;font-weight:600;color:#E9EEF6">Palette — dark</h3>
+        <div style="background:#171C24;border:1px solid #333C4A;border-radius:8px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;height:42px;padding:0 14px;border-bottom:1px solid #232A35"><span style="font-family:'IBM Plex Mono',monospace;color:#8592A6">⌕</span><span style="font-size:14px;color:#E9EEF6">cut</span></div>
+          <div style="padding:6px 14px;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#8592A6;background:#0A0D12">Tasks · 4 matches</div>
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 14px;background:#16294A;box-shadow:inset 2px 0 0 #7FB0FF"><span style="font-size:13px;color:#E9EEF6">Cutover rehearsal</span><span style="margin-left:auto;font-size:12px;color:#AFBACA">Deploy · 12 Jan 2027</span></div>
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 14px"><span style="font-size:13px;color:#E9EEF6">Cutover dress rehearsal 2</span><span style="margin-left:auto;font-size:12px;color:#AFBACA">Deploy · 19 Jan 2027</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">E — Telling the user something</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Toasts and inline banners</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">A toast is for something that just happened and is now over. A banner is for a condition that persists. If the user must act, it is a banner — toasts disappear and conditions do not.</p>
+
+  <div style="display:grid;grid-template-columns:420px 1fr;gap:16px;margin-top:24px;align-items:start">
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <sc-for list="{{ toasts }}" as="t" hint-placeholder-count="4">
+        <div style="display:flex;gap:12px;background:{{ t.bg }};border:1px solid {{ t.bd }};border-left:3px solid {{ t.accent }};border-radius:8px;padding:12px 14px;box-shadow:0 16px 48px rgba(16,23,32,.20)">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;border-radius:999px;color:{{ t.accent }};font-size:12px;font-weight:600" aria-hidden="true">{{ t.g }}</span>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;line-height:19px;font-weight:600;color:#101720">{{ t.title }}</div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:2px;text-wrap:pretty">{{ t.body }}</div>
+            <button style="margin-top:8px;height:28px;padding:0 10px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#101720;cursor:pointer">{{ t.action }}</button>
+          </div>
+          <button aria-label="Dismiss" style="width:24px;height:24px;flex:none;border-radius:4px;border:none;background:transparent;color:#4B5563;font-size:13px;cursor:pointer">×</button>
+        </div>
+      </sc-for>
+      <div style="font-size:12px;line-height:18px;color:#4B5563;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:14px">Stack bottom-right, 8px apart, newest at the bottom, maximum three — a fourth collapses the oldest into “+2 more” which opens the notification list. Info and success auto-dismiss at 6s; warning and error persist. Hover, focus or a screen-reader visit pauses the timer, and the timer restarts rather than resumes.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:12px">
+      <sc-for list="{{ banners }}" as="b" hint-placeholder-count="4">
+        <div style="display:flex;align-items:flex-start;gap:12px;background:{{ b.bg }};border:1px solid {{ b.bd }};border-radius:8px;padding:12px 14px">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;color:{{ b.fg }};font-size:12px;font-weight:600" aria-hidden="true">{{ b.g }}</span>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;line-height:19px;font-weight:600;color:{{ b.fg }}">{{ b.title }}</div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:2px;text-wrap:pretty">{{ b.body }}</div>
+          </div>
+          <button style="height:28px;padding:0 10px;flex:none;border-radius:4px;border:1px solid {{ b.bd }};background:#FFFFFF;font-size:12px;font-weight:500;color:{{ b.fg }};cursor:pointer">{{ b.action }}</button>
+        </div>
+      </sc-for>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;align-items:flex-start;gap:12px;background:#33240B;border:1px solid #7A5A22;border-radius:8px;padding:12px 14px">
+          <span style="color:#E9B45A;font-size:12px" aria-hidden="true">⚠</span>
+          <div style="flex:1"><div style="font-size:13px;font-weight:600;color:#E9B45A">Working offline — 148 changes queued locally.</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:2px">They will sync when the connection returns. Nothing has been lost.</div></div>
+          <button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #7A5A22;background:#171C24;font-size:12px;font-weight:500;color:#E9B45A;cursor:pointer">Retry now</button>
+        </div>
+        <div style="display:flex;gap:12px;background:#171C24;border:1px solid #232A35;border-left:3px solid #56D69A;border-radius:8px;padding:12px 14px;box-shadow:0 16px 48px rgba(0,0,0,.76)">
+          <span style="color:#56D69A;font-size:12px" aria-hidden="true">✓</span>
+          <div style="flex:1"><div style="font-size:13px;font-weight:600;color:#E9EEF6">Baseline v4 saved</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:2px">1,184 tasks captured at 14:32.</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">F — Empty states</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Four states, four designs</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">They differ in structure, not only in words: first-run is centred and instructional with two paths forward; no-results stays inside the table with the toolbar live; error is left-aligned with a reference code; no-permission is a bordered panel that names the level held and the level required.</p>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:24px">
+    <sc-for list="{{ emptyStates }}" as="e" hint-placeholder-count="4">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+        <div style="padding:8px 16px;background:#F1F3F7;border-bottom:1px solid #E4E7EC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">{{ e.kind }}</div>
+        <div style="padding:32px 28px;text-align:{{ e.align }}">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:8px;background:{{ e.bg }};border:1px solid {{ e.bd }};color:{{ e.tone }};font-size:18px" aria-hidden="true">{{ e.glyph }}</span>
+          <h3 style="margin:14px 0 0;font-size:18px;line-height:26px;font-weight:600;letter-spacing:-0.01em">{{ e.title }}</h3>
+          <p style="margin:8px auto 0;font-size:13.5px;line-height:21px;color:#4B5563;max-width:52ch;text-wrap:pretty">{{ e.body }}</p>
+          <div style="display:flex;gap:8px;margin-top:18px;justify-content:{{ e.just }}">
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">{{ e.primary }}</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;color:#101720;font-size:14px;font-weight:500;cursor:pointer">{{ e.secondary }}</button>
+          </div>
+        </div>
+        <div style="padding:10px 16px;border-top:1px solid #E4E7EC;background:#F6F7F9;font-size:12px;line-height:18px;color:#667085;text-wrap:pretty">{{ e.foot }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 96px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">G — Forms</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Field, group, section, error summary</h2>
+
+  <div style="display:grid;grid-template-columns:1.1fr 1fr;gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <div style="background:#FDE9E7;border:1px solid #B3261E;border-radius:6px;padding:14px 16px">
+        <div style="font-size:14px;font-weight:600;color:#B3261E">3 fields need attention before this task can be saved</div>
+        <div style="display:flex;flex-direction:column;gap:4px;margin-top:8px">
+          <sc-for list="{{ errorList }}" as="e" hint-placeholder-count="3">
+            <div style="font-size:13px;line-height:20px;color:#4B5563"><span style="color:#B3261E;text-decoration:underline;text-underline-offset:2px;font-weight:500">{{ e.field }}</span> — {{ e.msg }}</div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="margin-top:24px">
+        <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Schedule</h3>
+        <p style="margin:4px 0 0;font-size:13px;line-height:20px;color:#4B5563">Dates use the Malaysia (MY) working calendar. Required fields are marked *.</p>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:16px;margin-top:16px">
+        <div>
+          <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Task name <span style="color:#B3261E" aria-hidden="true">*</span></label>
+          <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;color:#667085">e.g. Chart of accounts workshop<span style="margin-left:auto;color:#B3261E">✕</span></div>
+          <div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Enter a name so the task can be found in search.</div>
+        </div>
+        <div style="display:grid;grid-template-columns:160px 160px;gap:16px">
+          <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Start *</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">07 Sep 2026</div><div style="min-height:16px"></div></div>
+          <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Finish *</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;font-variant-numeric:tabular-nums;color:#101720">01 Sep 2026</div><div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Finish is before start.</div></div>
+        </div>
+        <div style="height:1px;background:#E4E7EC;margin:8px 0"></div>
+        <div>
+          <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Staffing</h3>
+          <p style="margin:4px 0 12px;font-size:13px;line-height:20px;color:#4B5563">Allocation is a share of a working day, so 150% means overtime and needs delivery-manager approval.</p>
+          <div style="display:grid;grid-template-columns:1fr 96px;gap:16px;align-items:start">
+            <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Resource</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px">Aisyah Rahman — FI/CO, MY</div></div>
+            <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Allocation *</label><div style="display:flex;align-items:center;justify-content:flex-end;gap:4px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;font-variant-numeric:tabular-nums">220<span style="color:#4B5563;font-size:12px">%</span></div></div>
+          </div>
+          <div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Allocation must be between 0 and 150. You entered 220.</div>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:24px;padding-top:16px;border-top:1px solid #E4E7EC">
+        <button style="height:36px;padding:0 14px;border-radius:6px;border:none;background:transparent;font-size:14px;font-weight:500;color:#0B57D0;cursor:pointer">Cancel</button>
+        <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Save task</button>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Form rules</h3>
+        <sc-for list="{{ formRules }}" as="r" hint-placeholder-count="6">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;font-weight:600;color:#E9EEF6">Form — dark</h3>
+        <label style="display:block;font-size:12px;font-weight:500;color:#E9EEF6;margin-bottom:4px">Allocation *</label>
+        <div style="display:flex;align-items:center;justify-content:flex-end;gap:4px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #FF8A80;background:#3A1512;font-size:14px;color:#E9EEF6;font-variant-numeric:tabular-nums">220<span style="color:#AFBACA;font-size:12px">%</span></div>
+        <div style="font-size:12px;line-height:16px;color:#FF8A80;margin-top:4px">Allocation must be between 0 and 150. You entered 220.</div>
+        <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:12px">Dark error fill is status/danger/subtle <span style="font-family:'IBM Plex Mono',monospace">#3A1512</span> — dark enough that content/primary still reads at 12.4:1 inside it, which an inverted light-red tint would not achieve.</div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — composites</div>
+        <sc-for list="{{ a11yComposites }}" as="a" hint-placeholder-count="9">
+          <div style="display:grid;grid-template-columns:150px 1fr;gap:14px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:12.5px;line-height:19px">
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+            <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1520,&quot;height&quot;:940}}">
+class Component extends DCLogic {
+  renderVals() {
+    const primaryNav = [
+      { label: 'Timeline', g: '▤', bg: '#E8F0FE', fg: '#0B57D0', fw: 600, bd: '#BBD0F6' },
+      { label: 'Resources', g: '◑', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Cost', g: '≡', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Org chart', g: '⌗', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Architecture', g: '◇', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Insights', g: '◔', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' }
+    ];
+
+    const subNav = [
+      { label: 'Gantt', fw: 600, fg: '#101720', bar: 'inset 0 -2px 0 #0B57D0', count: '' },
+      { label: 'Phases', fw: 500, fg: '#4B5563', bar: 'none', count: '12' },
+      { label: 'Tasks', fw: 500, fg: '#4B5563', bar: 'none', count: '1,184' },
+      { label: 'Milestones', fw: 500, fg: '#4B5563', bar: 'none', count: '23' },
+      { label: 'Dependencies', fw: 500, fg: '#4B5563', bar: 'none', count: '' },
+      { label: 'Baseline', fw: 500, fg: '#4B5563', bar: 'none', count: '' }
+    ];
+
+    const shellRules = [
+      'The top bar is the only global surface: project switcher, global search, sync chip, presence, account. Nothing project-specific ever moves into it.',
+      'Primary nav is destinations; sub-nav is views of the current destination. If an item changes what data you see rather than where you are, it belongs in the filter bar, not the nav.',
+      'The role badge (EDITOR / VIEWER) sits beside the project name because permission changes what every control below it does. A VIEWER sees the same layout with commit actions replaced by a single "Request edit access" button — never a screen of disabled buttons.',
+      'Cost visibility level is shown in the sub-nav bar at all times, so a masked figure is always explainable from the same screen.',
+      'At 768px the primary nav collapses into a menu button; at 320px the project switcher truncates to the project code (PRJ-2291) and the sync chip drops to its glyph plus one word.'
+    ];
+
+    const filterChips = ['Workstream: Technical', 'Region: MY, SG', 'Allocation > 80%'];
+
+    const bulkActions = [
+      { label: 'Assign to phase', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Set allocation', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Change rate card', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Remove from project', bg: '#FDE9E7', fg: '#B3261E', bd: '#F0B5AF' }
+    ];
+
+    const columns = [
+      { label: '', just: 'center', fg: '#4B5563', sort: '', grip: 'transparent' },
+      { label: 'Resource', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Role', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Region', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Workstream', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Day rate MYR', just: 'flex-end', fg: '#0B57D0', sort: '▼', grip: '#CBD2DC' },
+      { label: 'Alloc.', just: 'flex-end', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Status', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: '', just: 'center', fg: '#4B5563', sort: '', grip: 'transparent' }
+    ];
+
+    const R = (name, role, region, stream, rate, alloc, pill, o) => Object.assign({
+      name, role, region, stream, rate, alloc,
+      initials: name.split(' ').map(w => w[0]).slice(0, 2).join(''),
+      avBg: '#F1F3F7', avFg: '#4B5563', bg: '#FFFFFF', bar: 'none',
+      cb: '', cbBg: '#FFFFFF', cbBd: '#7D8799',
+      rateFg: '#101720', rateBg: 'transparent', rateBd: 'none', rateH: '40px',
+      pill, pillG: '✓', pillBg: '#E3F5EB', pillFg: '#0A7A47', pillBd: '#9AD9BB'
+    }, o || {});
+
+    const rows = [
+      R('Rajesh Menon', 'Solution Architect', 'MY', 'Technical', '3,200', '100%', 'On track', { avBg: '#E8F0FE', avFg: '#0B57D0' }),
+      R('Goh Mei Yee', 'Integration Architect', 'SG', 'Integration', '3,800', '80%', 'On track', { avBg: '#E3F5EB', avFg: '#0A7A47' }),
+      R('Arun Prakash', 'ABAP Developer', 'IN', 'Technical', '1,150', '120%', 'At risk', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0', pillG: '⚠', pillBg: '#FBF0DC', pillFg: '#8A5200', pillBd: '#E0C089', avBg: '#FBF0DC', avFg: '#8A5200' }),
+      R('Nguyen Thi Lan', 'Security Consultant', 'VN', 'Technical', '1,300', '60%', 'On track', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0' }),
+      R('Daniel Okafor', 'Data Migration Lead', 'MY', 'Data Migration', '2,700', '100%', 'Late', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0', pillG: '✕', pillBg: '#FDE9E7', pillFg: '#B3261E', pillBd: '#F0B5AF' }),
+      R('Aisyah Rahman', 'FI/CO Consultant', 'MY', 'Finance', '2,400', '80%', 'On track', { bg: '#F6F7F9', rateBg: '#FFFFFF', rateBd: '1px solid #7D8799', rateH: '28px' }),
+      R('Chan Wei Ling', 'Delivery Manager', 'MY', 'PMO', '2,900', '50%', 'On track', {}),
+      R('Farah Nasution', 'Change Manager', 'MY', 'Change Mgmt', '2,100', '40%', 'Not started', { pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' })
+    ];
+
+    const pages = [
+      { label: '‹', bg: '#FFFFFF', fg: '#98A2B3', bd: '#E4E7EC' },
+      { label: '1', bg: '#0B57D0', fg: '#FFFFFF', bd: '#0B57D0' },
+      { label: '2', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '3', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '…', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { label: '6', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '›', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' }
+    ];
+
+    const colToggle = [
+      { label: 'Resource', tick: '✓', bg: '#98A2B3', bd: '#98A2B3', fg: '#4B5563', locked: true },
+      { label: 'Role', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Region', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Day rate MYR', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Day rate (native)', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false },
+      { label: 'Intercompany markup', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false },
+      { label: 'Utilisation to date', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false }
+    ];
+
+    const tableRules = [
+      'Sort is single-column by default; Shift+click adds a second key and the header shows “1 ▼ / 2 ▲”. The active sort column’s header text turns accent — plus the arrow, so it is not colour alone.',
+      'Column resize has a keyboard equivalent: focus the header, then Alt+←/→ resizes in 16px steps, announced as “Day rate, 148 pixels”.',
+      'Selection: click selects one, Shift+click a range, Cmd/Ctrl+click adds. Space toggles the focused row. The header checkbox selects the loaded page only and says so.',
+      'The bulk-action bar replaces the filter bar rather than stacking beneath it, so the table never loses vertical space, and it announces the count politely on every change.',
+      'Empty and error states render inside the table body, keeping header and toolbar operational so the user can undo the filter that emptied it.',
+      'Saved views persist filters, sort, column set, widths and density; they are per-user unless shared, and a shared view shows its owner’s avatar in the menu.'
+    ];
+
+    const darkRows = [
+      { name: 'Rajesh Menon', role: 'Solution Architect', rate: '3,200', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'On track', pillG: '✓', pillBg: '#0F2E22', pillFg: '#56D69A', pillBd: '#2C6B4E' },
+      { name: 'Arun Prakash', role: 'ABAP Developer', rate: '1,150', bg: '#16294A', bar: 'inset 2px 0 0 #7FB0FF', cb: '✓', cbBg: '#7FB0FF', cbBd: '#7FB0FF', pill: 'At risk', pillG: '⚠', pillBg: '#33240B', pillFg: '#E9B45A', pillBd: '#7A5A22' },
+      { name: 'Daniel Okafor', role: 'Data Migration Lead', rate: '2,700', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'Late', pillG: '✕', pillBg: '#3A1512', pillFg: '#FF8A80', pillBd: '#8A3A33' },
+      { name: 'Farah Nasution', role: 'Change Manager', rate: '2,100', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'Not started', pillG: '●', pillBg: '#1B222C', pillFg: '#AFBACA', pillBd: '#333C4A' }
+    ];
+
+    const a11yTable = [
+      { k: 'App shell', v: 'header > nav[aria-label="Primary"] > nav[aria-label="Timeline views"] > main[id="content"]. A skip link targets #content and is the first tab stop. Route changes move focus to the <h1> of the new screen and announce it politely.' },
+      { k: 'Sync chip', v: 'A button (it opens the sync detail popover) whose accessible name is the full state sentence: “Synced, last at 14:32. 0 changes pending.” Every transition posts to a single polite live region; conflict and permanent-error post assertively.' },
+      { k: 'Data table', v: 'Native table semantics with role="grid" when cells are editable. aria-rowcount/aria-colcount reflect the full dataset, not the rendered window, so virtualization is invisible to assistive tech.' },
+      { k: 'Sortable header', v: 'The header cell contains a button; aria-sort="ascending|descending|none" on the th. Activating announces “Day rate, sorted descending, 42 rows”.' },
+      { k: 'Row selection', v: 'aria-selected on the row and a real checkbox inside it. Roving tabindex: one tab stop for the grid, arrows move the cell cursor, Home/End to row bounds, Ctrl+Home to the first cell.' },
+      { k: 'Inline edit', v: 'The cell keeps role="gridcell" and gains aria-expanded while editing. Commit announces the new value; failure moves focus back to the editor with aria-invalid and a described-by error.' },
+      { k: 'Bulk bar', v: 'role="region" aria-label="Bulk actions" placed immediately after the table in DOM order so it is reachable by Tab from the last selected row; Escape returns focus to that row and clears the selection.' }
+    ];
+
+    const modalSizes = [
+      { token: 'modal/sm 420', use: 'Confirmations and single-field prompts. No scroll — if it scrolls, it is the wrong size.' },
+      { token: 'modal/md 640', use: 'The default. Create task, edit resource, invite collaborator.' },
+      { token: 'modal/lg 880', use: 'Two-column forms and side-by-side comparison — conflict resolution lives here.' },
+      { token: 'modal/fullscreen', use: 'Proposal preview and architecture export. Keeps a top bar with Close and the document title; scrim is not used.' }
+    ];
+
+    const modalRules = [
+      'Max height 80vh; the body scrolls while header and footer stay fixed. A scrolled body shows a 1px border/default line on the header, appearing only once content is behind it.',
+      'Focus moves to the first interactive element on open — never to the Close button, and never to a destructive action. Escape closes; the trigger regains focus.',
+      'Stacking is capped at two. The second modal shifts down 24px, the parent drops to 24% scrim opacity and becomes inert. A third request replaces the second and announces the swap.',
+      'Footer button order is [tertiary Cancel] [primary Confirm], right-aligned, with the destructive variant swapping the primary for Button/Danger.',
+      'A modal never contains a second scroll region, a nested tab set, or a data table longer than 8 rows — those belong in a drawer or a screen.'
+    ];
+
+    const drawerRules = [
+      'Right drawer: 400 / 520 / 720 widths, full height under the top bar, used for the details of a selected object — a task, a resource, an approval. It does not block the canvas: the Gantt behind it stays scrollable and the selected row stays visible.',
+      'Bottom drawer: 320px tall, used for the critical-path panel and the conflict list, where the content is wide and short. It resizes by dragging its top edge, with Alt+↑/↓ as the keyboard equivalent in 32px steps.',
+      'Both are non-modal by default — no scrim, focus is not trapped, and the user can keep working. They become modal only when they own unsaved edits, and then they say so in the header.',
+      'Closing with unsaved changes raises a modal/sm confirm naming the object: “Discard changes to ‘Cutover rehearsal’?”'
+    ];
+
+    const tabs = [
+      { label: 'Overview', on: true },
+      { label: 'Assignments', on: false, count: '14' },
+      { label: 'Rate', on: false },
+      { label: 'Availability', on: false },
+      { label: 'History', on: false, count: '38' }
+    ];
+
+    const paletteGroups = [
+      { group: 'Actions', items: [
+        { icon: '+', label: 'Create phase', hint: 'in S/4HANA Migration', kbd: 'P' },
+        { icon: '+', label: 'Create task under “Realize”', hint: '', kbd: 'T' },
+        { icon: '⤒', label: 'Set baseline from current plan', hint: 'replaces baseline v3 · 14 Aug', kbd: '' }
+      ] },
+      { group: 'Go to', items: [
+        { icon: '▤', label: 'Timeline', hint: '', kbd: 'G then T' },
+        { icon: '≡', label: 'Cost dashboard', hint: 'level 2 of 3 visible', kbd: 'G then C' },
+        { icon: '⌗', label: 'Org chart', hint: '', kbd: 'G then O' }
+      ] },
+      { group: 'Tasks · 4 matches', items: [
+        { icon: '▸', label: 'Cutover rehearsal', hint: 'Deploy · 12–16 Jan 2027 · Daniel Okafor', kbd: '↵', bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0' },
+        { icon: '▸', label: 'Cutover dress rehearsal 2', hint: 'Deploy · 19–21 Jan 2027 · at risk', kbd: '' }
+      ] },
+      { group: 'Resources · 1 match', items: [
+        { icon: '◐', label: 'Chan Wei Ling', hint: 'Delivery Manager · MY · 2,900/day', kbd: '' }
+      ] }
+    ];
+
+    const toasts = [
+      { g: '✓', title: 'Baseline v4 saved', body: '1,184 tasks captured at 14:32. Comparison is now against v4.', bg: '#FFFFFF', bd: '#9AD9BB', accent: '#0A7A47', action: 'Undo' },
+      { g: 'i', title: 'Proposal ready', body: 'Sarawak Energy — S/4HANA proposal.pptx, 34 slides.', bg: '#FFFFFF', bd: '#BBD0F6', accent: '#0B57D0', action: 'Download' },
+      { g: '⚠', title: 'Arun Prakash is over-allocated', body: '120% across weeks 42–46 after this change.', bg: '#FFFFFF', bd: '#E0C089', accent: '#8A5200', action: 'Review' },
+      { g: '✕', title: 'Import failed — 12 of 340 rows rejected', body: 'Rows without a role could not be matched to the rate card. Nothing was imported.', bg: '#FFFFFF', bd: '#F0B5AF', accent: '#B3261E', action: 'View report' }
+    ];
+
+    const banners = [
+      { g: 'i', title: 'You are viewing baseline v3, not the current plan.', body: 'Edits are disabled while a baseline is displayed.', bg: '#E8F0FE', bd: '#BBD0F6', fg: '#0B57D0', action: 'Return to current' },
+      { g: '⚠', title: 'Working offline — 148 changes queued locally.', body: 'They will sync when the connection returns. Nothing has been lost.', bg: '#FBF0DC', bd: '#E0C089', fg: '#8A5200', action: 'Retry now' },
+      { g: '✕', title: 'Two people edited “Data cleansing sign-off”.', body: 'Choose which version to keep before this task can sync.', bg: '#FDE9E7', bd: '#F0B5AF', fg: '#B3261E', action: 'Resolve conflict' },
+      { g: '✓', title: 'Rate card 2026-H2 applied to 42 resources.', body: 'Total cost changed by +MYR 184,200 (+3.1%).', bg: '#E3F5EB', bd: '#9AD9BB', fg: '#0A7A47', action: 'See breakdown' }
+    ];
+
+    const emptyStates = [
+      { kind: 'First run', align: 'center', just: 'center', glyph: '▤', title: 'Build the timeline', body: 'Start with the five SAP Activate phases, or import a plan you already have. Tasks, dependencies and resources can be added once phases exist.', primary: 'Add the Activate phases', secondary: 'Import from Excel', tone: '#0B57D0', bg: '#E8F0FE', bd: '#BBD0F6', foot: 'Teaches the first step. Never shown with a sad face or an apology — nothing is wrong.' },
+      { kind: 'No results', align: 'center', just: 'center', glyph: '⌕', title: 'No tasks match these filters', body: '3 filters are active: Workstream Technical, Region MY and SG, Allocation over 80%. Removing the allocation filter would show 46 tasks.', primary: 'Remove allocation filter', secondary: 'Clear all filters', tone: '#4B5563', bg: '#F1F3F7', bd: '#CBD2DC', foot: 'Names the filters, and quantifies the fix. The toolbar above stays live so the user can act.' },
+      { kind: 'Error', align: 'left', just: 'flex-start', glyph: '✕', title: 'The plan could not be loaded', body: 'The server did not respond within 30 seconds. Your local copy is intact and 148 queued changes are safe.', primary: 'Try again', secondary: 'Work from local copy', tone: '#B3261E', bg: '#FDE9E7', bd: '#F0B5AF', foot: 'States what happened, what it means for their data, and two ways forward. Reference PRJ-2291 / 14:32 is shown for support.' },
+      { kind: 'No permission', align: 'left', just: 'flex-start', glyph: '🔒', title: 'Cost figures are hidden at your visibility level', body: 'You have level 1 of 3. Rates, margin and the cost breakdown need level 2. The timeline and resource plan are unaffected.', primary: 'Request level 2', secondary: 'Who can approve this?', tone: '#4B5563', bg: '#F1F3F7', bd: '#7D8799', foot: 'Deliberate, not broken: it names the level held, the level required, and what is still available.' }
+    ];
+
+    const formRules = [
+      'One column. Two columns only for genuinely paired fields — start/finish, rate/currency — and they collapse to one below 768px.',
+      'Labels sit above their field, always visible. Placeholder text is an example, never a label, and never the only description.',
+      'Field width signals expected input: a 3-character region code is not 480px wide. Widths come from the space ramp: 96 / 160 / 240 / 360 / full.',
+      'Validation runs on blur, then on every change once a field has errored, so corrections clear immediately. Never on keystroke for a field that has not yet errored.',
+      'The error summary appears above the form on failed submit, is focused programmatically, and lists each error as a link to its field.',
+      'Section = heading + optional description + fields, separated by space/8. Group = related fields at space/4. Field = label + control + helper at space/1.'
+    ];
+
+    const errorList = [
+      { field: 'Task name', msg: 'Enter a name so the task can be found in search.' },
+      { field: 'Finish date', msg: 'Finish is before start. Choose a date on or after 07 Sep 2026.' },
+      { field: 'Allocation', msg: 'Allocation must be between 0 and 150. You entered 220.' }
+    ];
+
+    const a11yComposites = [
+      { k: 'Modal', v: 'role="dialog" aria-modal="true", labelled by its title id and described by its lead paragraph. Focus is trapped, the background is inert, and scroll is locked on the body only. On close, focus returns to the trigger — or, if the trigger no longer exists, to the nearest surviving heading.' },
+      { k: 'Stacked modal', v: 'The parent gets inert and aria-hidden. Escape closes only the top modal. The stack is announced as “Delete phase, dialog 2 of 2”.' },
+      { k: 'Drawer', v: 'role="complementary" when non-modal, role="dialog" aria-modal when it owns unsaved edits. Opening moves focus to the drawer heading; closing returns it to the row that opened it.' },
+      { k: 'Tabs', v: 'role="tablist" with roving tabindex; arrows move and activate, Home/End jump, and each panel is role="tabpanel" labelled by its tab. Panels are not removed from the DOM on switch when they hold form state.' },
+      { k: 'Command palette', v: 'role="combobox" over role="listbox", with aria-activedescendant — focus never leaves the input. Groups are role="group" with aria-label. Result count is announced politely after a 300ms settle.' },
+      { k: 'Toast', v: 'A single role="status" region for info and success; role="alert" for warning and error. Max 3 visible, newest at the bottom, auto-dismiss 6s for info/success only — warnings and errors persist until dismissed. Hovering or focusing pauses the timer.' },
+      { k: 'Banner', v: 'role="status" for info/success, role="alert" for warning/error, placed at the top of the region it concerns rather than the top of the page, so it is not detached from what it describes.' },
+      { k: 'Empty state', v: 'The region keeps its heading level. The illustration glyph is aria-hidden; the state is carried by the heading and body text. No-permission and error states are announced when they replace loaded content.' },
+      { k: 'Form', v: 'Each field is label + control + aria-describedby. The error summary is role="alert" tabindex="-1" and focused on failed submit; each entry is an anchor to the field id. aria-invalid on every failed field.' }
+    ];
+
+    return { primaryNav, subNav, shellRules, filterChips, bulkActions, columns, rows, pages, colToggle, tableRules, darkRows, a11yTable,
+      criticalChain: [
+        { label: 'Data cleansing sign-off', days: '0d float', bg: '#FDE9E7', bd: '#B3261E', fg: '#B3261E' },
+        { label: 'Mock conversion 3', days: '0d', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' },
+        { label: 'Integration test cycle 2', days: '0d', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' },
+        { label: 'Cutover rehearsal', days: '0d', bg: '#FBF0DC', bd: '#8A5200', fg: '#8A5200' },
+        { label: 'Go-live', days: '—', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' }
+      ],
+      tabStates: [
+        { label: 'Overview', fw: 600, fg: '#101720', bar: 'inset 0 -2px 0 #0B57D0', r: '0', p: '0', bg: 'transparent', count: '' },
+        { label: 'Assignments', fw: 500, fg: '#4B5563', bar: 'none', r: '0', p: '0', bg: 'transparent', count: '14' },
+        { label: 'Rate', fw: 500, fg: '#101720', bar: 'none', r: '4px', p: '0 8px', bg: '#F1F3F7', count: '' },
+        { label: 'Availability', fw: 500, fg: '#4B5563', bar: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', r: '4px', p: '0 8px', bg: 'transparent', count: '' },
+        { label: 'History', fw: 500, fg: '#4B5563', bar: 'none', r: '0', p: '0', bg: 'transparent', count: '38' }
+      ],
+      searchGroups: [
+        { icon: '▸', label: 'Tasks', hint: 'Cutover rehearsal, Cutover dress rehearsal 2, Cutover comms…', count: '4', bg: '#E8F0FE', fg: '#0B57D0' },
+        { icon: '▤', label: 'Phases', hint: 'Deploy — contains 3 matching tasks', count: '1', bg: '#F1F3F7', fg: '#4B5563' },
+        { icon: '◐', label: 'Resources', hint: 'No resource name or role matches “cut”', count: '0', bg: '#F1F3F7', fg: '#4B5563' },
+        { icon: '▦', label: 'Documents', hint: 'Cutover plan v2.docx · Cutover runbook.xlsx', count: '2', bg: '#F1F3F7', fg: '#4B5563' }
+      ],
+      modalSizes, modalRules, drawerRules, tabs, paletteGroups, toasts, banners, emptyStates, formRules, errorList, a11yComposites };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/composites2.html
+++ b/docs/design/composites2.html
@@ -1,0 +1,948 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; text-decoration:underline; text-underline-offset:2px; }
+  a:hover { color:#08429E; }
+  button, input { font-family:inherit; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { animation-duration:1ms !important; transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1440px;margin:0 auto;padding:72px 40px 40px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 3 of 5</div>
+  <h1 style="margin:14px 0 0;font-size:44px;line-height:50px;font-weight:600;letter-spacing:-0.025em;max-width:22ch;text-wrap:pretty">Composites: the structures screens are made of</h1>
+  <p style="margin:20px 0 0;max-width:70ch;font-size:16px;line-height:26px;color:#4B5563;text-wrap:pretty">Fourteen composites assembled entirely from layer-2 primitives and layer-1 tokens. Each names the primitives it is built from, its spacing in token units, and its behaviour under the loads Cockpit actually carries — 1,200 tasks, 80 phases, nine concurrent editors.</p>
+</header>
+
+<section style="max-width:1440px;margin:0 auto;padding:16px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">A — App shell</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Top bar, primary nav, contextual sub-nav</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Anatomy: <span style="font-family:'IBM Plex Mono',monospace;font-size:13px">[top bar h56] → [primary nav h44] → [sub-nav h40] → [content]</span> = 140px of chrome, fixed. Below 1024px the sub-nav becomes a horizontally scrolling strip; below 768px the primary nav collapses into the top bar’s menu button. The sync chip never collapses — it is the one element guaranteed present at every width.</p>
+
+  <div style="margin-top:24px;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#F6F7F9">
+    <div style="display:flex;align-items:center;gap:16px;height:56px;padding:0 16px;background:#FFFFFF;border-bottom:1px solid #CBD2DC">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:6px;background:#101720;color:#FFFFFF;font-size:13px;font-weight:600">C</span>
+        <span style="font-size:15px;font-weight:600;letter-spacing:-0.01em">Cockpit</span>
+      </div>
+      <div style="height:24px;width:1px;background:#CBD2DC"></div>
+      <button style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;cursor:pointer">
+        <span style="font-size:13px;font-weight:500;color:#101720">S/4HANA Migration — Sarawak Energy</span>
+        <span style="font-size:9px;color:#4B5563">▼</span>
+      </button>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 8px;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:12px;font-weight:500;color:#4B5563">EDITOR</span>
+      <div style="flex:1;display:flex;justify-content:center">
+        <div style="display:flex;align-items:center;gap:8px;width:100%;max-width:420px;height:32px;padding:0 10px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span>
+          <span style="flex:1;font-size:13px;color:#667085">Search tasks, resources, phases…</span>
+          <kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#FFFFFF;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">⌘K</kbd>
+        </div>
+      </div>
+      <div style="display:flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB">
+        <span style="font-size:11px;color:#0A7A47" aria-hidden="true">✓</span>
+        <span style="font-size:12px;font-weight:500;color:#0A7A47">Synced</span>
+        <span style="font-size:11px;color:#0A7A47;font-variant-numeric:tabular-nums">14:32</span>
+      </div>
+      <div style="display:flex">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:11px;font-weight:600;border:2px solid #FFFFFF">RM</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#E3F5EB;color:#0A7A47;font-size:11px;font-weight:600;border:2px solid #FFFFFF;margin-left:-6px">AR</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#F1F3F7;color:#4B5563;font-size:11px;font-weight:600;border:2px solid #FFFFFF;margin-left:-6px">+4</span>
+      </div>
+      <button aria-label="Account" style="width:32px;height:32px;border-radius:999px;border:1px solid #7D8799;background:#FBF0DC;color:#8A5200;font-size:12px;font-weight:600;cursor:pointer">CW</button>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:4px;height:44px;padding:0 16px;background:#FFFFFF;border-bottom:1px solid #E4E7EC">
+      <sc-for list="{{ primaryNav }}" as="n" hint-placeholder-count="6">
+        <span style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 12px;border-radius:6px;background:{{ n.bg }};color:{{ n.fg }};font-size:13px;font-weight:{{ n.fw }};border:1px solid {{ n.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px" aria-hidden="true">{{ n.g }}</span>{{ n.label }}</span>
+      </sc-for>
+      <div style="margin-left:auto;display:flex;gap:8px">
+        <button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;color:#101720;cursor:pointer">Baseline</button>
+        <button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;font-size:13px;font-weight:500;color:#FFFFFF;cursor:pointer">Generate proposal</button>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:18px;height:40px;padding:0 16px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <sc-for list="{{ subNav }}" as="s" hint-placeholder-count="6">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:40px;font-size:13px;font-weight:{{ s.fw }};color:{{ s.fg }};box-shadow:{{ s.bar }}">{{ s.label }}<sc-if value="{{ s.count }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:999px;background:#E4E7EC;font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.count }}</span></sc-if></span>
+      </sc-for>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span>Base currency <span style="font-weight:500;color:#101720">MYR</span></span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span>Cost visibility <span style="font-weight:500;color:#101720">Level 2 of 3</span></span>
+      </div>
+    </div>
+
+    <div style="padding:20px 16px;min-height:120px;background:#F6F7F9">
+      <div style="font-size:12px;line-height:18px;color:#667085">Content region. Scrolls independently; the three chrome rows are sticky. Focus order is top bar → primary nav → sub-nav → content, and a persistent “Skip to content” link precedes the logo.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Shell — dark</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+        <div style="display:flex;align-items:center;gap:12px;height:48px;padding:0 12px;background:#171C24;border-bottom:1px solid #333C4A">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:5px;background:#E9EEF6;color:#0B1220;font-size:12px;font-weight:600">C</span>
+          <span style="font-size:13px;font-weight:600;color:#E9EEF6">S/4HANA Migration</span>
+          <div style="flex:1"></div>
+          <span style="display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 9px;border-radius:999px;background:#0F2E22;border:1px solid #2C6B4E;font-size:12px;font-weight:500;color:#56D69A"><span aria-hidden="true">✓</span>Synced</span>
+        </div>
+        <div style="display:flex;gap:4px;height:40px;align-items:center;padding:0 12px;background:#171C24;border-bottom:1px solid #232A35">
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;background:#16294A;border:1px solid #2F4E82;color:#7FB0FF;font-size:13px;font-weight:600">Timeline</span>
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;color:#AFBACA;font-size:13px">Resources</span>
+          <span style="height:28px;padding:0 10px;display:inline-flex;align-items:center;border-radius:6px;color:#AFBACA;font-size:13px">Cost</span>
+        </div>
+        <div style="height:36px;background:#0A0D12;display:flex;align-items:center;padding:0 12px;font-size:12px;color:#8592A6">Sub-nav on surface/sunken — the only place dark uses the sunken step in chrome</div>
+      </div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Shell rules</h3>
+      <sc-for list="{{ shellRules }}" as="r" hint-placeholder-count="5">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:10px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#0B57D0;line-height:20px">§</span><div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">B — Data table</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">One table, every capability</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Row height 40 (compact 32), sticky header, no vertical rules, no zebra. Numeric columns are right-aligned tabular; the first column is sticky when horizontal scrolling starts. Composed from: Checkbox · Button · Icon button · Dropdown menu · Chip · Status pill · Avatar · Pagination · Skeleton.</p>
+
+  <div style="margin-top:24px;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#FFFFFF">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;border-bottom:1px solid #E4E7EC;flex-wrap:wrap">
+      <div style="display:flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;min-width:200px">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span><span style="font-size:13px;color:#101720">basis</span>
+      </div>
+      <sc-for list="{{ filterChips }}" as="c" hint-placeholder-count="3">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 6px 0 10px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">{{ c }}<span aria-label="Remove filter" style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:3px;background:#D6E4FD;font-size:11px;cursor:pointer">×</span></span>
+      </sc-for>
+      <button style="height:28px;padding:0 8px;border-radius:4px;border:1px dashed #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#4B5563;cursor:pointer">+ Add filter</button>
+      <button style="height:28px;padding:0 8px;border-radius:4px;border:none;background:transparent;font-size:12px;font-weight:500;color:#0B57D0;cursor:pointer">Clear all</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:8px">
+        <button style="display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Saved view: <span style="font-weight:600">Subcontractors</span> <span style="font-size:9px">▼</span></button>
+        <button style="display:inline-flex;align-items:center;gap:6px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Columns <span style="font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">7 / 11</span></button>
+        <button style="height:32px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:13px;color:#101720;cursor:pointer">Export</button>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:14px;padding:8px 16px;background:#E8F0FE;border-bottom:1px solid #BBD0F6">
+      <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:12px;font-weight:600">–</span>
+      <span style="font-size:13px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">3 of 42 resources selected</span>
+      <span style="width:1px;height:18px;background:#BBD0F6"></span>
+      <sc-for list="{{ bulkActions }}" as="b" hint-placeholder-count="4">
+        <button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid {{ b.bd }};background:{{ b.bg }};font-size:13px;font-weight:500;color:{{ b.fg }};cursor:pointer">{{ b.label }}</button>
+      </sc-for>
+      <button style="margin-left:auto;height:28px;padding:0 8px;border-radius:4px;border:none;background:transparent;font-size:13px;color:#0B57D0;cursor:pointer">Clear selection · Esc</button>
+    </div>
+
+    <div style="overflow-x:auto">
+      <div style="min-width:1080px">
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;gap:0;background:#F1F3F7;border-bottom:1px solid #CBD2DC;position:sticky;top:0">
+          <sc-for list="{{ columns }}" as="c" hint-placeholder-count="9">
+            <div style="display:flex;align-items:center;gap:6px;height:36px;padding:0 12px;justify-content:{{ c.just }};border-right:1px solid #E4E7EC;position:relative">
+              <span style="font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:{{ c.fg }}">{{ c.label }}</span>
+              <span style="font-size:10px;color:#0B57D0">{{ c.sort }}</span>
+              <span style="position:absolute;right:-2px;top:8px;bottom:8px;width:4px;cursor:col-resize;background:{{ c.grip }}"></span>
+            </div>
+          </sc-for>
+        </div>
+
+        <sc-for list="{{ rows }}" as="r" hint-placeholder-count="8">
+          <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;align-items:center;height:40px;border-bottom:1px solid #E4E7EC;background:{{ r.bg }};box-shadow:{{ r.bar }}">
+            <div style="display:flex;align-items:center;justify-content:center"><span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:{{ r.cbBg }};border:1px solid {{ r.cbBd }};color:#FFFFFF;font-size:11px;font-weight:600">{{ r.cb }}</span></div>
+            <div style="display:flex;align-items:center;gap:8px;padding:0 12px;min-width:0">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:none;border-radius:999px;background:{{ r.avBg }};color:{{ r.avFg }};font-size:10px;font-weight:600">{{ r.initials }}</span>
+              <span style="font-size:13px;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+            </div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.role }}</div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;font-variant-numeric:tabular-nums">{{ r.region }}</div>
+            <div style="padding:0 12px;font-size:13px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.stream }}</div>
+            <div style="padding:0 12px;text-align:right;font-size:13px;font-weight:500;color:{{ r.rateFg }};font-variant-numeric:tabular-nums;background:{{ r.rateBg }};border:{{ r.rateBd }};height:{{ r.rateH }};display:flex;align-items:center;justify-content:flex-end;border-radius:4px;margin:0 6px">{{ r.rate }}</div>
+            <div style="padding:0 12px;text-align:right;font-size:13px;color:#101720;font-variant-numeric:tabular-nums">{{ r.alloc }}</div>
+            <div style="padding:0 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ r.pillBg }};color:{{ r.pillFg }};border:1px solid {{ r.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ r.pillG }}</span>{{ r.pill }}</span></div>
+            <div style="display:flex;align-items:center;justify-content:center;color:#4B5563;font-size:14px">⋯</div>
+          </div>
+        </sc-for>
+
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.3fr 72px 1fr 110px 100px 120px 44px;align-items:center;height:40px;border-bottom:1px solid #E4E7EC">
+          <div></div>
+          <div style="display:flex;align-items:center;gap:8px;padding:0 12px"><div style="width:24px;height:24px;border-radius:999px;background:#E4E7EC"></div><div style="height:12px;width:60%;border-radius:2px;background:#E4E7EC"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:70%;border-radius:2px;background:#E4E7EC"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:60%;border-radius:2px;background:#EDEFF3"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:50%;border-radius:2px;background:#EDEFF3"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:70%;border-radius:2px;background:#E4E7EC;margin-left:auto"></div></div>
+          <div style="padding:0 12px"><div style="height:12px;width:50%;border-radius:2px;background:#EDEFF3;margin-left:auto"></div></div>
+          <div style="padding:0 12px"><div style="height:16px;width:70%;border-radius:4px;background:#E4E7EC"></div></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:16px;padding:10px 16px;border-top:1px solid #CBD2DC;background:#FFFFFF;flex-wrap:wrap">
+      <span style="font-size:13px;color:#4B5563;font-variant-numeric:tabular-nums">1–8 of 42</span>
+      <div style="display:flex;gap:4px">
+        <sc-for list="{{ pages }}" as="p" hint-placeholder-count="6">
+          <span style="display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;padding:0 8px;border-radius:6px;background:{{ p.bg }};color:{{ p.fg }};border:1px solid {{ p.bd }};font-size:13px;font-weight:500;font-variant-numeric:tabular-nums">{{ p.label }}</span>
+        </sc-for>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:#4B5563">Rows <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 8px;border-radius:6px;border:1px solid #CBD2DC;color:#101720;font-variant-numeric:tabular-nums">25 <span style="font-size:9px">▼</span></span></div>
+      <div style="margin-left:auto;font-size:12px;color:#667085">Virtualized variant: above 200 rows pagination is replaced by windowed scrolling — 12 rows rendered either side of the viewport, a sticky group header per phase, and a scrollbar overlay marking the selected rows.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Inline cell edit</h3>
+      <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:1fr 110px;height:36px;align-items:center;background:#F1F3F7;font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563"><span style="padding:0 10px">Resource</span><span style="padding:0 10px;text-align:right">Day rate</span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC"><span style="padding:0 10px;font-size:13px">Nguyen Thi Lan</span><span style="padding:0 10px;text-align:right;font-size:13px;font-variant-numeric:tabular-nums">1,300</span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC;background:#FFFFFF"><span style="padding:0 10px;font-size:13px">Arun Prakash</span><span style="padding:0 4px"><span style="display:flex;align-items:center;height:32px;padding:0 8px;border-radius:4px;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;background:#FFFFFF;font-size:13px;font-weight:500;justify-content:flex-end;font-variant-numeric:tabular-nums">1,150</span></span></div>
+        <div style="display:grid;grid-template-columns:1fr 110px;height:40px;align-items:center;border-top:1px solid #E4E7EC"><span style="padding:0 10px;font-size:13px">Siti Nurhaliza</span><span style="padding:0 10px;text-align:right;font-size:13px;font-variant-numeric:tabular-nums">2,200</span></div>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">Enter or double-click opens the editor in place at the cell’s exact bounds, so nothing shifts. Enter commits and moves down; Tab commits and moves right; Escape reverts. A failed commit keeps the editor open, turns the border status/danger and puts the reason in a popover below.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Column show/hide</h3>
+      <div style="border:1px solid #CBD2DC;border-radius:6px;box-shadow:0 4px 12px rgba(16,23,32,.10);overflow:hidden">
+        <div style="padding:8px 10px;border-bottom:1px solid #E4E7EC;font-size:12px;font-weight:600;color:#101720">Columns · drag to reorder</div>
+        <sc-for list="{{ colToggle }}" as="c" hint-placeholder-count="6">
+          <div style="display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid #E4E7EC">
+            <span style="color:#98A2B3;font-size:12px;cursor:grab">⠿</span>
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:2px;background:{{ c.bg }};border:1px solid {{ c.bd }};color:#FFFFFF;font-size:10px">{{ c.tick }}</span>
+            <span style="font-size:13px;color:{{ c.fg }}">{{ c.label }}</span>
+            <sc-if value="{{ c.locked }}" hint-placeholder-val="{{ false }}"><span style="margin-left:auto;font-size:11px;color:#667085">locked</span></sc-if>
+          </div>
+        </sc-for>
+        <div style="padding:8px 10px;display:flex;gap:8px"><button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;cursor:pointer">Reset</button><button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12px;cursor:pointer">Save as view</button></div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+      <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Table rules</h3>
+      <sc-for list="{{ tableRules }}" as="r" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+    <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Data table — dark</h3>
+    <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+      <div style="display:grid;grid-template-columns:40px 1.6fr 1.2fr 110px 120px;background:#0A0D12;border-bottom:1px solid #333C4A">
+        <div></div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Resource</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Role</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;justify-content:flex-end;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#7FB0FF">Day rate ▼</div>
+        <div style="padding:0 12px;height:36px;display:flex;align-items:center;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">Status</div>
+      </div>
+      <sc-for list="{{ darkRows }}" as="r" hint-placeholder-count="4">
+        <div style="display:grid;grid-template-columns:40px 1.6fr 1.2fr 110px 120px;align-items:center;height:40px;background:{{ r.bg }};border-bottom:1px solid #232A35;box-shadow:{{ r.bar }}">
+          <div style="display:flex;justify-content:center"><span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:{{ r.cbBg }};border:1px solid {{ r.cbBd }};color:#0B1220;font-size:11px;font-weight:600">{{ r.cb }}</span></div>
+          <div style="padding:0 12px;font-size:13px;color:#E9EEF6">{{ r.name }}</div>
+          <div style="padding:0 12px;font-size:13px;color:#AFBACA">{{ r.role }}</div>
+          <div style="padding:0 12px;text-align:right;font-size:13px;font-weight:500;color:#E9EEF6;font-variant-numeric:tabular-nums">{{ r.rate }}</div>
+          <div style="padding:0 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ r.pillBg }};color:{{ r.pillFg }};border:1px solid {{ r.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ r.pillG }}</span>{{ r.pill }}</span></div>
+        </div>
+      </sc-for>
+    </div>
+    <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Selected rows in dark use accent/subtle <span style="font-family:'IBM Plex Mono',monospace">#16294A</span> plus a 2px accent leading bar — the fill alone is only 1.4:1 against surface/raised, which is why the bar is mandatory rather than decorative.</div>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — shell &amp; table</div>
+    <sc-for list="{{ a11yTable }}" as="a" hint-placeholder-count="6">
+      <div style="display:grid;grid-template-columns:180px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">C — Overlays</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Modal, stacked modal, drawer</h2>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(420px,1fr));gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:28px;position:relative;overflow:hidden">
+      <div style="position:absolute;inset:0;background:rgba(16,23,32,.48)"></div>
+      <div style="position:relative;background:#FFFFFF;border-radius:8px;box-shadow:0 16px 48px rgba(16,23,32,.20);max-width:640px;margin:0 auto">
+        <div style="display:flex;align-items:flex-start;gap:16px;padding:20px 24px 16px">
+          <div style="flex:1">
+            <h3 style="margin:0;font-size:20px;line-height:28px;font-weight:600;letter-spacing:-0.015em">Add task to “Realize”</h3>
+            <p style="margin:6px 0 0;font-size:13px;line-height:20px;color:#4B5563">Dates default to the phase window and the Malaysia (MY) working calendar.</p>
+          </div>
+          <button aria-label="Close" style="width:32px;height:32px;flex:none;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#4B5563;font-size:14px;cursor:pointer">×</button>
+        </div>
+        <div style="padding:4px 24px 20px;border-top:1px solid #E4E7EC">
+          <div style="padding-top:20px;display:flex;flex-direction:column;gap:16px">
+            <div>
+              <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Task name <span style="color:#B3261E" aria-hidden="true">*</span></label>
+              <div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;font-size:14px">Chart of accounts workshop</div>
+            </div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+              <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Start</label><div style="display:flex;align-items:center;justify-content:space-between;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">07 Sep 2026 <span style="font-family:'IBM Plex Mono',monospace;color:#667085">▦</span></div></div>
+              <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Finish</label><div style="display:flex;align-items:center;justify-content:space-between;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">18 Sep 2026 <span style="font-family:'IBM Plex Mono',monospace;color:#667085">▦</span></div></div>
+            </div>
+            <div style="display:flex;gap:16px;font-size:12px;color:#4B5563"><span><span style="font-weight:600;color:#101720">8</span> working days</span><span style="color:#8A5200">1 public holiday excluded — 15 Sep, Malaysia Day</span></div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px;padding:14px 24px;border-top:1px solid #E4E7EC;background:#F6F7F9;border-radius:0 0 8px 8px">
+          <span style="font-size:12px;color:#667085">Saved locally as you type</span>
+          <div style="margin-left:auto;display:flex;gap:8px">
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:none;background:transparent;font-size:14px;font-weight:500;color:#0B57D0;cursor:pointer">Cancel</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Add task</button>
+          </div>
+        </div>
+      </div>
+
+      <div style="position:relative;margin:20px auto 0;max-width:420px;background:#FFFFFF;border-radius:8px;box-shadow:0 16px 48px rgba(16,23,32,.20);border-top:3px solid #B3261E">
+        <div style="padding:20px 24px 8px">
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#B3261E;margin-bottom:6px">Dialog 2 of 2 — stacked</div>
+          <h3 style="margin:0;font-size:18px;line-height:26px;font-weight:600">Delete phase “Realization”?</h3>
+          <p style="margin:8px 0 0;font-size:13px;line-height:20px;color:#4B5563">Its <span style="font-weight:600;color:#101720">24 tasks</span>, <span style="font-weight:600;color:#101720">9 resource assignments</span> and <span style="font-weight:600;color:#101720">3 milestones</span> will be removed. Dependencies from Explore will be left dangling and must be reconnected. This cannot be undone after the next sync.</p>
+        </div>
+        <div style="padding:12px 24px 16px">
+          <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Type the phase name to confirm</label>
+          <div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;color:#667085">Realization</div>
+        </div>
+        <div style="display:flex;justify-content:flex-end;gap:8px;padding:14px 24px;border-top:1px solid #E4E7EC;background:#F6F7F9;border-radius:0 0 8px 8px">
+          <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:14px;font-weight:500;box-shadow:0 0 0 2px #F6F7F9,0 0 0 4px #0B57D0;cursor:pointer">Cancel</button>
+          <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #B3261E;background:#B3261E;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Delete phase</button>
+        </div>
+      </div>
+      <div style="position:relative;text-align:center;font-size:12px;color:#FFFFFF;margin-top:14px">Focus rests on Cancel — never on the destructive action. The parent dialog is inert and its scrim has dropped to 24%.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Sizes</h3>
+        <sc-for list="{{ modalSizes }}" as="m" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:150px 1fr;gap:14px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ m.token }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563">{{ m.use }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Modal rules</h3>
+        <sc-for list="{{ modalRules }}" as="r" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;line-height:22px;font-weight:600;color:#E9EEF6">Modal — dark</h3>
+        <div style="background:#171C24;border:1px solid #333C4A;border-radius:8px;box-shadow:0 16px 48px rgba(0,0,0,.76);overflow:hidden">
+          <div style="padding:16px 18px 12px"><div style="font-size:16px;font-weight:600;color:#E9EEF6">Delete phase “Realization”?</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:6px">Its 24 tasks and 9 resource assignments will be removed.</div></div>
+          <div style="display:flex;justify-content:flex-end;gap:8px;padding:12px 18px;background:#0A0D12;border-top:1px solid #232A35"><button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #748196;background:#171C24;color:#E9EEF6;font-size:13px;cursor:pointer">Cancel</button><button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #FF8A80;background:#FF8A80;color:#2A0A07;font-size:13px;font-weight:500;cursor:pointer">Delete phase</button></div>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Dark scrim is <span style="font-family:'IBM Plex Mono',monospace">rgba(4,6,10,.64)</span> — deeper than light, because a dark modal on a dark canvas needs the separation that a shadow cannot provide.</div>
+      </div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(380px,1fr));gap:16px;margin-top:16px">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:0;overflow:hidden">
+      <div style="padding:10px 14px;font-size:12px;line-height:18px;color:#4B5563;border-bottom:1px solid #CBD2DC;background:#FFFFFF">Right drawer — the canvas behind it stays live and scrollable, and the selected row keeps its accent bar.</div>
+      <div style="display:flex;height:340px">
+        <div style="width:56px;flex:none;background:#F1F3F7"></div>
+        <div style="flex:1;min-width:0;background:#FFFFFF;border-left:1px solid #CBD2DC;box-shadow:-8px 0 28px rgba(16,23,32,.14);display:flex;flex-direction:column">
+          <div style="display:flex;align-items:flex-start;gap:10px;padding:14px 16px;border-bottom:1px solid #E4E7EC">
+            <div style="flex:1"><div style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Task · Realize</div><div style="font-size:16px;font-weight:600;line-height:22px;margin-top:2px">Chart of accounts workshop</div></div>
+            <button aria-label="Close drawer" style="width:28px;height:28px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#4B5563;cursor:pointer">×</button>
+          </div>
+          <div style="display:flex;gap:14px;padding:0 16px;border-bottom:1px solid #E4E7EC;overflow-x:auto">
+            <sc-for list="{{ tabs }}" as="t" hint-placeholder-count="5">
+              <span style="display:inline-flex;align-items:center;gap:6px;height:38px;flex:none;white-space:nowrap;font-size:13px;font-weight:500;color:#4B5563">{{ t.label }}</span>
+            </sc-for>
+          </div>
+          <div style="padding:14px 16px;display:flex;flex-direction:column;gap:12px;flex:1">
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Dates</span><span style="font-variant-numeric:tabular-nums">07 – 18 Sep 2026</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Effort</span><span style="font-variant-numeric:tabular-nums">8 working days · 64 h</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Assigned</span><span>Aisyah Rahman · 80%</span></div>
+            <div style="display:grid;grid-template-columns:96px 1fr;gap:8px;font-size:13px"><span style="color:#4B5563">Cost</span><span style="font-variant-numeric:tabular-nums">MYR 15,360</span></div>
+          </div>
+          <div style="display:flex;gap:8px;padding:12px 16px;border-top:1px solid #E4E7EC;background:#F6F7F9"><button style="flex:1;height:36px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Duplicate</button><button style="flex:1;height:36px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Save</button></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+        <div style="height:96px;padding:16px;font-size:12px;color:#667085">Bottom drawer — wide and short content, the canvas keeps its full width.</div>
+        <div style="background:#FFFFFF;border-top:1px solid #CBD2DC;box-shadow:0 -8px 28px rgba(16,23,32,.14)">
+          <div style="display:flex;justify-content:center;padding:5px 0"><div style="width:44px;height:4px;border-radius:999px;background:#CBD2DC"></div></div>
+          <div style="display:flex;align-items:center;gap:12px;padding:0 16px 10px"><div style="font-size:15px;font-weight:600">Critical path — 6 tasks, 0 days float</div><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:#FDE9E7;color:#B3261E;border:1px solid #F0B5AF;font-size:11px;font-weight:500"><span aria-hidden="true">✕</span>2 late</span><button style="margin-left:auto;height:28px;padding:0 10px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;font-size:12px;cursor:pointer">Collapse</button></div>
+          <div style="display:flex;gap:8px;padding:0 16px 14px;overflow-x:auto">
+            <sc-for list="{{ criticalChain }}" as="c" hint-placeholder-count="5">
+              <span style="display:inline-flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1.5px solid {{ c.bd }};background:{{ c.bg }};font-size:12px;font-weight:500;color:{{ c.fg }};white-space:nowrap">{{ c.label }}<span style="font-variant-numeric:tabular-nums;color:#4B5563">{{ c.days }}</span></span>
+            </sc-for>
+          </div>
+        </div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Drawer rules</h3>
+        <sc-for list="{{ drawerRules }}" as="r" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Tabs — states</h3>
+        <div style="display:flex;gap:20px;border-bottom:1px solid #CBD2DC">
+          <sc-for list="{{ tabStates }}" as="t" hint-placeholder-count="5">
+            <span style="display:inline-flex;align-items:center;gap:6px;height:40px;font-size:13px;font-weight:{{ t.fw }};color:{{ t.fg }};box-shadow:{{ t.bar }};border-radius:{{ t.r }};padding:{{ t.p }};background:{{ t.bg }}">{{ t.label }}<sc-if value="{{ t.count }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:999px;background:#E4E7EC;font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">{{ t.count }}</span></sc-if></span>
+          </sc-for>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">Selected carries weight 600 plus a 2px accent underline. Disabled tabs are never used — a tab with nothing in it shows its empty state instead, because a disabled tab hides the fact that the section exists.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">D — Finding things</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Command palette &amp; global search</h2>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(420px,1fr));gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#F1F3F7;border:1px solid #CBD2DC;border-radius:8px;padding:28px;position:relative">
+      <div style="position:absolute;inset:0;background:rgba(16,23,32,.48);border-radius:8px"></div>
+      <div style="position:relative;max-width:620px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 8px 28px rgba(16,23,32,.14);overflow:hidden">
+        <div style="display:flex;align-items:center;gap:10px;height:48px;padding:0 16px;border-bottom:1px solid #E4E7EC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:15px;color:#667085">⌕</span>
+          <span style="flex:1;font-size:15px;color:#101720">cut</span>
+          <kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">Esc</kbd>
+        </div>
+        <div style="max-height:344px;overflow-y:auto">
+          <sc-for list="{{ paletteGroups }}" as="g" hint-placeholder-count="4">
+            <div>
+              <div style="padding:8px 16px 4px;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;background:#F6F7F9">{{ g.group }}</div>
+              <sc-for list="{{ g.items }}" as="i" hint-placeholder-count="3">
+                <div style="display:flex;align-items:center;gap:12px;padding:8px 16px;border-bottom:1px solid #E4E7EC;background:{{ i.bg }};box-shadow:{{ i.bar }}">
+                  <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#4B5563;width:16px">{{ i.icon }}</span>
+                  <span style="flex:1;min-width:0"><span style="display:block;font-size:14px;line-height:20px;color:#101720">{{ i.label }}</span><span style="display:block;font-size:12px;line-height:17px;color:#667085">{{ i.hint }}</span></span>
+                  <sc-if value="{{ i.kbd }}" hint-placeholder-val="{{ false }}"><kbd style="display:inline-flex;align-items:center;height:20px;padding:0 6px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">{{ i.kbd }}</kbd></sc-if>
+                </div>
+              </sc-for>
+            </div>
+          </sc-for>
+        </div>
+        <div style="display:flex;align-items:center;gap:14px;padding:8px 16px;background:#F6F7F9;border-top:1px solid #E4E7EC;font-size:11px;color:#4B5563">
+          <span>↑↓ move</span><span>↵ open</span><span>⌘↵ open in drawer</span><span>Tab filter by type</span><span style="margin-left:auto;font-variant-numeric:tabular-nums">9 results</span>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 10px;font-size:16px;line-height:22px;font-weight:600">Palette behaviour</h3>
+        <div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">Opens on ⌘K from anywhere including inside a modal. Empty query shows five recent destinations and the three actions most used in this project — never a generic list. Results are grouped by kind and always in the same order: Actions, Go to, Tasks, Resources, Phases, Documents. Typing narrows within 120ms on local data; remote groups append with their own spinner rather than delaying the whole list. The active row carries a 2px accent leading bar in addition to its fill.</div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 10px;font-size:16px;line-height:22px;font-weight:600">Global search — grouped results page</h3>
+        <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+          <sc-for list="{{ searchGroups }}" as="s" hint-placeholder-count="4">
+            <div style="display:flex;align-items:center;gap:12px;padding:10px 12px;border-bottom:1px solid #E4E7EC">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:6px;background:{{ s.bg }};color:{{ s.fg }};font-family:'IBM Plex Mono',monospace;font-size:13px">{{ s.icon }}</span>
+              <span style="flex:1"><span style="display:block;font-size:13px;font-weight:500;color:#101720">{{ s.label }}</span><span style="display:block;font-size:12px;color:#667085">{{ s.hint }}</span></span>
+              <span style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.count }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:10px">The results page keeps the same grouping and adds per-group filters. A group with zero matches is listed with “0” rather than omitted, so the user learns the search covered it.</div>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;font-weight:600;color:#E9EEF6">Palette — dark</h3>
+        <div style="background:#171C24;border:1px solid #333C4A;border-radius:8px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;height:42px;padding:0 14px;border-bottom:1px solid #232A35"><span style="font-family:'IBM Plex Mono',monospace;color:#8592A6">⌕</span><span style="font-size:14px;color:#E9EEF6">cut</span></div>
+          <div style="padding:6px 14px;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#8592A6;background:#0A0D12">Tasks · 4 matches</div>
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 14px;background:#16294A;box-shadow:inset 2px 0 0 #7FB0FF"><span style="font-size:13px;color:#E9EEF6">Cutover rehearsal</span><span style="margin-left:auto;font-size:12px;color:#AFBACA">Deploy · 12 Jan 2027</span></div>
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 14px"><span style="font-size:13px;color:#E9EEF6">Cutover dress rehearsal 2</span><span style="margin-left:auto;font-size:12px;color:#AFBACA">Deploy · 19 Jan 2027</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">E — Telling the user something</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Toasts and inline banners</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">A toast is for something that just happened and is now over. A banner is for a condition that persists. If the user must act, it is a banner — toasts disappear and conditions do not.</p>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(400px,1fr));gap:16px;margin-top:24px;align-items:start">
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <sc-for list="{{ toasts }}" as="t" hint-placeholder-count="4">
+        <div style="display:flex;gap:12px;background:{{ t.bg }};border:1px solid {{ t.bd }};border-left:3px solid {{ t.accent }};border-radius:8px;padding:12px 14px;box-shadow:0 16px 48px rgba(16,23,32,.20)">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;border-radius:999px;color:{{ t.accent }};font-size:12px;font-weight:600" aria-hidden="true">{{ t.g }}</span>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;line-height:19px;font-weight:600;color:#101720">{{ t.title }}</div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:2px;text-wrap:pretty">{{ t.body }}</div>
+            <button style="margin-top:8px;height:28px;padding:0 10px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#101720;cursor:pointer">{{ t.action }}</button>
+          </div>
+          <button aria-label="Dismiss" style="width:24px;height:24px;flex:none;border-radius:4px;border:none;background:transparent;color:#4B5563;font-size:13px;cursor:pointer">×</button>
+        </div>
+      </sc-for>
+      <div style="font-size:12px;line-height:18px;color:#4B5563;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:14px">Stack bottom-right, 8px apart, newest at the bottom, maximum three — a fourth collapses the oldest into “+2 more” which opens the notification list. Info and success auto-dismiss at 6s; warning and error persist. Hover, focus or a screen-reader visit pauses the timer, and the timer restarts rather than resumes.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:12px">
+      <sc-for list="{{ banners }}" as="b" hint-placeholder-count="4">
+        <div style="display:flex;align-items:flex-start;gap:12px;background:{{ b.bg }};border:1px solid {{ b.bd }};border-radius:8px;padding:12px 14px">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;color:{{ b.fg }};font-size:12px;font-weight:600" aria-hidden="true">{{ b.g }}</span>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;line-height:19px;font-weight:600;color:{{ b.fg }}">{{ b.title }}</div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:2px;text-wrap:pretty">{{ b.body }}</div>
+          </div>
+          <button style="height:28px;padding:0 10px;flex:none;border-radius:4px;border:1px solid {{ b.bd }};background:#FFFFFF;font-size:12px;font-weight:500;color:{{ b.fg }};cursor:pointer">{{ b.action }}</button>
+        </div>
+      </sc-for>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;align-items:flex-start;gap:12px;background:#33240B;border:1px solid #7A5A22;border-radius:8px;padding:12px 14px">
+          <span style="color:#E9B45A;font-size:12px" aria-hidden="true">⚠</span>
+          <div style="flex:1"><div style="font-size:13px;font-weight:600;color:#E9B45A">Working offline — 148 changes queued locally.</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:2px">They will sync when the connection returns. Nothing has been lost.</div></div>
+          <button style="height:28px;padding:0 10px;border-radius:4px;border:1px solid #7A5A22;background:#171C24;font-size:12px;font-weight:500;color:#E9B45A;cursor:pointer">Retry now</button>
+        </div>
+        <div style="display:flex;gap:12px;background:#171C24;border:1px solid #232A35;border-left:3px solid #56D69A;border-radius:8px;padding:12px 14px;box-shadow:0 16px 48px rgba(0,0,0,.76)">
+          <span style="color:#56D69A;font-size:12px" aria-hidden="true">✓</span>
+          <div style="flex:1"><div style="font-size:13px;font-weight:600;color:#E9EEF6">Baseline v4 saved</div><div style="font-size:12.5px;line-height:19px;color:#AFBACA;margin-top:2px">1,184 tasks captured at 14:32.</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">F — Empty states</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Four states, four designs</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">They differ in structure, not only in words: first-run is centred and instructional with two paths forward; no-results stays inside the table with the toolbar live; error is left-aligned with a reference code; no-permission is a bordered panel that names the level held and the level required.</p>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:24px">
+    <sc-for list="{{ emptyStates }}" as="e" hint-placeholder-count="4">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+        <div style="padding:8px 16px;background:#F1F3F7;border-bottom:1px solid #E4E7EC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">{{ e.kind }}</div>
+        <div style="padding:32px 28px;text-align:{{ e.align }}">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:8px;background:{{ e.bg }};border:1px solid {{ e.bd }};color:{{ e.tone }};font-size:18px" aria-hidden="true">{{ e.glyph }}</span>
+          <h3 style="margin:14px 0 0;font-size:18px;line-height:26px;font-weight:600;letter-spacing:-0.01em">{{ e.title }}</h3>
+          <p style="margin:8px auto 0;font-size:13.5px;line-height:21px;color:#4B5563;max-width:52ch;text-wrap:pretty">{{ e.body }}</p>
+          <div style="display:flex;gap:8px;margin-top:18px;justify-content:{{ e.just }}">
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">{{ e.primary }}</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;color:#101720;font-size:14px;font-weight:500;cursor:pointer">{{ e.secondary }}</button>
+          </div>
+        </div>
+        <div style="padding:10px 16px;border-top:1px solid #E4E7EC;background:#F6F7F9;font-size:12px;line-height:18px;color:#667085;text-wrap:pretty">{{ e.foot }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1440px;margin:0 auto;padding:64px 40px 96px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">G — Forms</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Field, group, section, error summary</h2>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(420px,1fr));gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <div style="background:#FDE9E7;border:1px solid #B3261E;border-radius:6px;padding:14px 16px">
+        <div style="font-size:14px;font-weight:600;color:#B3261E">3 fields need attention before this task can be saved</div>
+        <div style="display:flex;flex-direction:column;gap:4px;margin-top:8px">
+          <sc-for list="{{ errorList }}" as="e" hint-placeholder-count="3">
+            <div style="font-size:13px;line-height:20px;color:#4B5563"><span style="color:#B3261E;text-decoration:underline;text-underline-offset:2px;font-weight:500">{{ e.field }}</span> — {{ e.msg }}</div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="margin-top:24px">
+        <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Schedule</h3>
+        <p style="margin:4px 0 0;font-size:13px;line-height:20px;color:#4B5563">Dates use the Malaysia (MY) working calendar. Required fields are marked *.</p>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:16px;margin-top:16px">
+        <div>
+          <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Task name <span style="color:#B3261E" aria-hidden="true">*</span></label>
+          <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;color:#667085">e.g. Chart of accounts workshop<span style="margin-left:auto;color:#B3261E">✕</span></div>
+          <div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Enter a name so the task can be found in search.</div>
+        </div>
+        <div style="display:grid;grid-template-columns:160px 160px;gap:16px">
+          <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Start *</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px;font-variant-numeric:tabular-nums">07 Sep 2026</div><div style="min-height:16px"></div></div>
+          <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Finish *</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;font-variant-numeric:tabular-nums;color:#101720">01 Sep 2026</div><div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Finish is before start.</div></div>
+        </div>
+        <div style="height:1px;background:#E4E7EC;margin:8px 0"></div>
+        <div>
+          <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Staffing</h3>
+          <p style="margin:4px 0 12px;font-size:13px;line-height:20px;color:#4B5563">Allocation is a share of a working day, so 150% means overtime and needs delivery-manager approval.</p>
+          <div style="display:grid;grid-template-columns:1fr 96px;gap:16px;align-items:start">
+            <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Resource</label><div style="display:flex;align-items:center;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:14px">Aisyah Rahman — FI/CO, MY</div></div>
+            <div><label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">Allocation *</label><div style="display:flex;align-items:center;justify-content:flex-end;gap:4px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #B3261E;background:#FDE9E7;font-size:14px;font-variant-numeric:tabular-nums">220<span style="color:#4B5563;font-size:12px">%</span></div></div>
+          </div>
+          <div style="font-size:12px;line-height:16px;color:#B3261E;margin-top:4px">Allocation must be between 0 and 150. You entered 220.</div>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:24px;padding-top:16px;border-top:1px solid #E4E7EC">
+        <button style="height:36px;padding:0 14px;border-radius:6px;border:none;background:transparent;font-size:14px;font-weight:500;color:#0B57D0;cursor:pointer">Cancel</button>
+        <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Save task</button>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Form rules</h3>
+        <sc-for list="{{ formRules }}" as="r" hint-placeholder-count="6">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:5px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px">
+        <h3 style="margin:0 0 12px;font-size:15px;font-weight:600;color:#E9EEF6">Form — dark</h3>
+        <label style="display:block;font-size:12px;font-weight:500;color:#E9EEF6;margin-bottom:4px">Allocation *</label>
+        <div style="display:flex;align-items:center;justify-content:flex-end;gap:4px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #FF8A80;background:#3A1512;font-size:14px;color:#E9EEF6;font-variant-numeric:tabular-nums">220<span style="color:#AFBACA;font-size:12px">%</span></div>
+        <div style="font-size:12px;line-height:16px;color:#FF8A80;margin-top:4px">Allocation must be between 0 and 150. You entered 220.</div>
+        <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:12px">Dark error fill is status/danger/subtle <span style="font-family:'IBM Plex Mono',monospace">#3A1512</span> — dark enough that content/primary still reads at 12.4:1 inside it, which an inverted light-red tint would not achieve.</div>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+        <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — composites</div>
+        <sc-for list="{{ a11yComposites }}" as="a" hint-placeholder-count="9">
+          <div style="display:grid;grid-template-columns:150px 1fr;gap:14px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:12.5px;line-height:19px">
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+            <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+<section style="max-width:1440px;margin:-64px auto 0;padding:64px 40px 96px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">H — Live regions</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">What the product says out loud</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Principle P3 says nothing important is implied. For a sighted user the sync chip carries that; for a screen-reader user it is carried entirely by these three regions. Every asynchronous event in Cockpit has exactly one owner, one region, one politeness level and one exact string.</p>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;margin-top:24px">
+    <sc-for list="{{ regions }}" as="r" hint-placeholder-count="3">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:14px;font-weight:500;color:#0B57D0">{{ r.id }}</div>
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;line-height:18px;color:#101720;background:#F1F3F7;border:1px solid #E4E7EC;border-radius:4px;padding:8px 10px;margin-top:10px;word-break:break-word">{{ r.role }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:10px;text-wrap:pretty"><span style="font-weight:600;color:#101720">Where — </span>{{ r.where }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:8px;text-wrap:pretty"><span style="font-weight:600;color:#101720">Carries — </span>{{ r.use }}</div>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+    <div style="display:grid;grid-template-columns:1.15fr 0.75fr 0.7fr 2.1fr 1.7fr;gap:14px;padding:10px 20px;background:#F1F3F7;border-bottom:1px solid #CBD2DC;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">
+      <div>Event</div><div>Owner</div><div>Region</div><div>Announced text — verbatim</div><div>Timing rule</div>
+    </div>
+    <sc-for list="{{ announcements }}" as="a" hint-placeholder-count="13">
+      <div style="display:grid;grid-template-columns:1.15fr 0.75fr 0.7fr 2.1fr 1.7fr;gap:14px;padding:12px 20px;border-bottom:1px solid #E4E7EC;align-items:start">
+        <div style="font-size:13px;line-height:19px;font-weight:500;color:#101720">{{ a.ev }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563">{{ a.owner }}</div>
+        <div><span style="display:inline-flex;align-items:center;height:20px;padding:0 6px;border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:11px;background:{{ a.pillBg }};color:{{ a.pillFg }};border:1px solid {{ a.pillBd }}">{{ a.pol }}</span><div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-top:4px">{{ a.region }}</div></div>
+        <div style="font-size:12.5px;line-height:19px;color:#101720;text-wrap:pretty">{{ a.text }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.timing }}</div>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(400px,1fr));gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">No duplicate announcements</h3>
+      <sc-for list="{{ dupeRules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Worked example — one sync round trip</h3>
+      <div style="display:flex;flex-direction:column;gap:0">
+        <sc-for list="{{ trace }}" as="t" hint-placeholder-count="7">
+          <div style="display:grid;grid-template-columns:64px 1fr;gap:12px;padding:8px 0;border-top:1px solid #E4E7EC">
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#667085;font-variant-numeric:tabular-nums">{{ t.t }}</div>
+            <div>
+              <div style="font-size:13px;line-height:19px;color:#101720">{{ t.what }}</div>
+              <div style="font-size:12.5px;line-height:19px;color:{{ t.fg }};margin-top:2px">{{ t.said }}</div>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#667085;margin-top:12px;padding-top:12px;border-top:1px solid #E4E7EC">Four visual changes, two announcements. The chip’s intermediate flicker and the toast that mirrors the chip both stay silent — which is the whole point of a single owner per event.</div>
+    </div>
+  </div>
+</section></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1520,&quot;height&quot;:940}}">
+class Component extends DCLogic {
+  renderVals() {
+    const primaryNav = [
+      { label: 'Timeline', g: '▤', bg: '#E8F0FE', fg: '#0B57D0', fw: 600, bd: '#BBD0F6' },
+      { label: 'Resources', g: '◑', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Cost', g: '≡', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Org chart', g: '⌗', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Architecture', g: '◇', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' },
+      { label: 'Insights', g: '◔', bg: 'transparent', fg: '#4B5563', fw: 500, bd: 'transparent' }
+    ];
+
+    const subNav = [
+      { label: 'Gantt', fw: 600, fg: '#101720', bar: 'inset 0 -2px 0 #0B57D0', count: '' },
+      { label: 'Phases', fw: 500, fg: '#4B5563', bar: 'none', count: '12' },
+      { label: 'Tasks', fw: 500, fg: '#4B5563', bar: 'none', count: '1,184' },
+      { label: 'Milestones', fw: 500, fg: '#4B5563', bar: 'none', count: '23' },
+      { label: 'Dependencies', fw: 500, fg: '#4B5563', bar: 'none', count: '' },
+      { label: 'Baseline', fw: 500, fg: '#4B5563', bar: 'none', count: '' }
+    ];
+
+    const shellRules = [
+      'The top bar is the only global surface: project switcher, global search, sync chip, presence, account. Nothing project-specific ever moves into it.',
+      'Primary nav is destinations; sub-nav is views of the current destination. If an item changes what data you see rather than where you are, it belongs in the filter bar, not the nav.',
+      'The role badge (EDITOR / VIEWER) sits beside the project name because permission changes what every control below it does. A VIEWER sees the same layout with commit actions replaced by a single "Request edit access" button — never a screen of disabled buttons.',
+      'Cost visibility level is shown in the sub-nav bar at all times, so a masked figure is always explainable from the same screen.',
+      'At 768px the primary nav collapses into a menu button; at 320px the project switcher truncates to the project code (PRJ-2291) and the sync chip drops to its glyph plus one word.'
+    ];
+
+    const filterChips = ['Workstream: Technical', 'Region: MY, SG', 'Allocation > 80%'];
+
+    const bulkActions = [
+      { label: 'Assign to phase', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Set allocation', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Change rate card', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799' },
+      { label: 'Remove from project', bg: '#FDE9E7', fg: '#B3261E', bd: '#F0B5AF' }
+    ];
+
+    const columns = [
+      { label: '', just: 'center', fg: '#4B5563', sort: '', grip: 'transparent' },
+      { label: 'Resource', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Role', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Region', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Workstream', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Day rate MYR', just: 'flex-end', fg: '#0B57D0', sort: '▼', grip: '#CBD2DC' },
+      { label: 'Alloc.', just: 'flex-end', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: 'Status', just: 'flex-start', fg: '#4B5563', sort: '', grip: '#CBD2DC' },
+      { label: '', just: 'center', fg: '#4B5563', sort: '', grip: 'transparent' }
+    ];
+
+    const R = (name, role, region, stream, rate, alloc, pill, o) => Object.assign({
+      name, role, region, stream, rate, alloc,
+      initials: name.split(' ').map(w => w[0]).slice(0, 2).join(''),
+      avBg: '#F1F3F7', avFg: '#4B5563', bg: '#FFFFFF', bar: 'none',
+      cb: '', cbBg: '#FFFFFF', cbBd: '#7D8799',
+      rateFg: '#101720', rateBg: 'transparent', rateBd: 'none', rateH: '40px',
+      pill, pillG: '✓', pillBg: '#E3F5EB', pillFg: '#0A7A47', pillBd: '#9AD9BB'
+    }, o || {});
+
+    const rows = [
+      R('Rajesh Menon', 'Solution Architect', 'MY', 'Technical', '3,200', '100%', 'On track', { avBg: '#E8F0FE', avFg: '#0B57D0' }),
+      R('Goh Mei Yee', 'Integration Architect', 'SG', 'Integration', '3,800', '80%', 'On track', { avBg: '#E3F5EB', avFg: '#0A7A47' }),
+      R('Arun Prakash', 'ABAP Developer', 'IN', 'Technical', '1,150', '120%', 'At risk', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0', pillG: '⚠', pillBg: '#FBF0DC', pillFg: '#8A5200', pillBd: '#E0C089', avBg: '#FBF0DC', avFg: '#8A5200' }),
+      R('Nguyen Thi Lan', 'Security Consultant', 'VN', 'Technical', '1,300', '60%', 'On track', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0' }),
+      R('Daniel Okafor', 'Data Migration Lead', 'MY', 'Data Migration', '2,700', '100%', 'Late', { bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0', cb: '✓', cbBg: '#0B57D0', cbBd: '#0B57D0', pillG: '✕', pillBg: '#FDE9E7', pillFg: '#B3261E', pillBd: '#F0B5AF' }),
+      R('Aisyah Rahman', 'FI/CO Consultant', 'MY', 'Finance', '2,400', '80%', 'On track', { bg: '#F6F7F9', rateBg: '#FFFFFF', rateBd: '1px solid #7D8799', rateH: '28px' }),
+      R('Chan Wei Ling', 'Delivery Manager', 'MY', 'PMO', '2,900', '50%', 'On track', {}),
+      R('Farah Nasution', 'Change Manager', 'MY', 'Change Mgmt', '2,100', '40%', 'Not started', { pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' })
+    ];
+
+    const pages = [
+      { label: '‹', bg: '#FFFFFF', fg: '#98A2B3', bd: '#E4E7EC' },
+      { label: '1', bg: '#0B57D0', fg: '#FFFFFF', bd: '#0B57D0' },
+      { label: '2', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '3', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '…', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { label: '6', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' },
+      { label: '›', bg: '#FFFFFF', fg: '#101720', bd: '#CBD2DC' }
+    ];
+
+    const colToggle = [
+      { label: 'Resource', tick: '✓', bg: '#98A2B3', bd: '#98A2B3', fg: '#4B5563', locked: true },
+      { label: 'Role', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Region', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Day rate MYR', tick: '✓', bg: '#0B57D0', bd: '#0B57D0', fg: '#101720', locked: false },
+      { label: 'Day rate (native)', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false },
+      { label: 'Intercompany markup', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false },
+      { label: 'Utilisation to date', tick: '', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', locked: false }
+    ];
+
+    const tableRules = [
+      'Sort is single-column by default; Shift+click adds a second key and the header shows “1 ▼ / 2 ▲”. The active sort column’s header text turns accent — plus the arrow, so it is not colour alone.',
+      'Column resize has a keyboard equivalent: focus the header, then Alt+←/→ resizes in 16px steps, announced as “Day rate, 148 pixels”.',
+      'Selection: click selects one, Shift+click a range, Cmd/Ctrl+click adds. Space toggles the focused row. The header checkbox selects the loaded page only and says so.',
+      'The bulk-action bar replaces the filter bar rather than stacking beneath it, so the table never loses vertical space, and it announces the count politely on every change.',
+      'Empty and error states render inside the table body, keeping header and toolbar operational so the user can undo the filter that emptied it.',
+      'Saved views persist filters, sort, column set, widths and density; they are per-user unless shared, and a shared view shows its owner’s avatar in the menu.'
+    ];
+
+    const darkRows = [
+      { name: 'Rajesh Menon', role: 'Solution Architect', rate: '3,200', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'On track', pillG: '✓', pillBg: '#0F2E22', pillFg: '#56D69A', pillBd: '#2C6B4E' },
+      { name: 'Arun Prakash', role: 'ABAP Developer', rate: '1,150', bg: '#16294A', bar: 'inset 2px 0 0 #7FB0FF', cb: '✓', cbBg: '#7FB0FF', cbBd: '#7FB0FF', pill: 'At risk', pillG: '⚠', pillBg: '#33240B', pillFg: '#E9B45A', pillBd: '#7A5A22' },
+      { name: 'Daniel Okafor', role: 'Data Migration Lead', rate: '2,700', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'Late', pillG: '✕', pillBg: '#3A1512', pillFg: '#FF8A80', pillBd: '#8A3A33' },
+      { name: 'Farah Nasution', role: 'Change Manager', rate: '2,100', bg: '#171C24', bar: 'none', cb: '', cbBg: '#171C24', cbBd: '#748196', pill: 'Not started', pillG: '●', pillBg: '#1B222C', pillFg: '#AFBACA', pillBd: '#333C4A' }
+    ];
+
+    const a11yTable = [
+      { k: 'App shell', v: 'header > nav[aria-label="Primary"] > nav[aria-label="Timeline views"] > main[id="content"]. A skip link targets #content and is the first tab stop. Route changes move focus to the <h1> of the new screen and announce it politely.' },
+      { k: 'Sync chip', v: 'A button (it opens the sync detail popover) whose accessible name is the full state sentence: “Synced, last at 14:32. 0 changes pending.” Every transition posts to a single polite live region; conflict and permanent-error post assertively.' },
+      { k: 'Data table', v: 'Native table semantics with role="grid" when cells are editable. aria-rowcount/aria-colcount reflect the full dataset, not the rendered window, so virtualization is invisible to assistive tech.' },
+      { k: 'Sortable header', v: 'The header cell contains a button; aria-sort="ascending|descending|none" on the th. Activating announces “Day rate, sorted descending, 42 rows”.' },
+      { k: 'Row selection', v: 'aria-selected on the row and a real checkbox inside it. Roving tabindex: one tab stop for the grid, arrows move the cell cursor, Home/End to row bounds, Ctrl+Home to the first cell.' },
+      { k: 'Inline edit', v: 'The cell keeps role="gridcell" and gains aria-expanded while editing. Commit announces the new value; failure moves focus back to the editor with aria-invalid and a described-by error.' },
+      { k: 'Bulk bar', v: 'role="region" aria-label="Bulk actions" placed immediately after the table in DOM order so it is reachable by Tab from the last selected row; Escape returns focus to that row and clears the selection.' }
+    ];
+
+    const modalSizes = [
+      { token: 'modal/sm 420', use: 'Confirmations and single-field prompts. No scroll — if it scrolls, it is the wrong size.' },
+      { token: 'modal/md 640', use: 'The default. Create task, edit resource, invite collaborator.' },
+      { token: 'modal/lg 880', use: 'Two-column forms and side-by-side comparison — conflict resolution lives here.' },
+      { token: 'modal/fullscreen', use: 'Proposal preview and architecture export. Keeps a top bar with Close and the document title; scrim is not used.' }
+    ];
+
+    const modalRules = [
+      'Max height 80vh; the body scrolls while header and footer stay fixed. A scrolled body shows a 1px border/default line on the header, appearing only once content is behind it.',
+      'Focus moves to the first interactive element on open — never to the Close button, and never to a destructive action. Escape closes; the trigger regains focus.',
+      'Stacking is capped at two. The second modal shifts down 24px, the parent drops to 24% scrim opacity and becomes inert. A third request replaces the second and announces the swap.',
+      'Footer button order is [tertiary Cancel] [primary Confirm], right-aligned, with the destructive variant swapping the primary for Button/Danger.',
+      'A modal never contains a second scroll region, a nested tab set, or a data table longer than 8 rows — those belong in a drawer or a screen.'
+    ];
+
+    const drawerRules = [
+      'Right drawer: 400 / 520 / 720 widths, full height under the top bar, used for the details of a selected object — a task, a resource, an approval. It does not block the canvas: the Gantt behind it stays scrollable and the selected row stays visible.',
+      'Bottom drawer: 320px tall, used for the critical-path panel and the conflict list, where the content is wide and short. It resizes by dragging its top edge, with Alt+↑/↓ as the keyboard equivalent in 32px steps.',
+      'Both are non-modal by default — no scrim, focus is not trapped, and the user can keep working. They become modal only when they own unsaved edits, and then they say so in the header.',
+      'Closing with unsaved changes raises a modal/sm confirm naming the object: “Discard changes to ‘Cutover rehearsal’?”'
+    ];
+
+    const tabs = [
+      { label: 'Overview', on: true },
+      { label: 'Assignments', on: false, count: '14' },
+      { label: 'Rate', on: false },
+      { label: 'Availability', on: false },
+      { label: 'History', on: false, count: '38' }
+    ];
+
+    const paletteGroups = [
+      { group: 'Actions', items: [
+        { icon: '+', label: 'Create phase', hint: 'in S/4HANA Migration', kbd: 'P' },
+        { icon: '+', label: 'Create task under “Realize”', hint: '', kbd: 'T' },
+        { icon: '⤒', label: 'Set baseline from current plan', hint: 'replaces baseline v3 · 14 Aug', kbd: '' }
+      ] },
+      { group: 'Go to', items: [
+        { icon: '▤', label: 'Timeline', hint: '', kbd: 'G then T' },
+        { icon: '≡', label: 'Cost dashboard', hint: 'level 2 of 3 visible', kbd: 'G then C' },
+        { icon: '⌗', label: 'Org chart', hint: '', kbd: 'G then O' }
+      ] },
+      { group: 'Tasks · 4 matches', items: [
+        { icon: '▸', label: 'Cutover rehearsal', hint: 'Deploy · 12–16 Jan 2027 · Daniel Okafor', kbd: '↵', bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0' },
+        { icon: '▸', label: 'Cutover dress rehearsal 2', hint: 'Deploy · 19–21 Jan 2027 · at risk', kbd: '' }
+      ] },
+      { group: 'Resources · 1 match', items: [
+        { icon: '◐', label: 'Chan Wei Ling', hint: 'Delivery Manager · MY · 2,900/day', kbd: '' }
+      ] }
+    ];
+
+    const toasts = [
+      { g: '✓', title: 'Baseline v4 saved', body: '1,184 tasks captured at 14:32. Comparison is now against v4.', bg: '#FFFFFF', bd: '#9AD9BB', accent: '#0A7A47', action: 'Undo' },
+      { g: 'i', title: 'Proposal ready', body: 'Sarawak Energy — S/4HANA proposal.pptx, 34 slides.', bg: '#FFFFFF', bd: '#BBD0F6', accent: '#0B57D0', action: 'Download' },
+      { g: '⚠', title: 'Arun Prakash is over-allocated', body: '120% across weeks 42–46 after this change.', bg: '#FFFFFF', bd: '#E0C089', accent: '#8A5200', action: 'Review' },
+      { g: '✕', title: 'Import failed — 12 of 340 rows rejected', body: 'Rows without a role could not be matched to the rate card. Nothing was imported.', bg: '#FFFFFF', bd: '#F0B5AF', accent: '#B3261E', action: 'View report' }
+    ];
+
+    const banners = [
+      { g: 'i', title: 'You are viewing baseline v3, not the current plan.', body: 'Edits are disabled while a baseline is displayed.', bg: '#E8F0FE', bd: '#BBD0F6', fg: '#0B57D0', action: 'Return to current' },
+      { g: '⚠', title: 'Working offline — 148 changes queued locally.', body: 'They will sync when the connection returns. Nothing has been lost.', bg: '#FBF0DC', bd: '#E0C089', fg: '#8A5200', action: 'Retry now' },
+      { g: '✕', title: 'Two people edited “Data cleansing sign-off”.', body: 'Choose which version to keep before this task can sync.', bg: '#FDE9E7', bd: '#F0B5AF', fg: '#B3261E', action: 'Resolve conflict' },
+      { g: '✓', title: 'Rate card 2026-H2 applied to 42 resources.', body: 'Total cost changed by +MYR 184,200 (+3.1%).', bg: '#E3F5EB', bd: '#9AD9BB', fg: '#0A7A47', action: 'See breakdown' }
+    ];
+
+    const emptyStates = [
+      { kind: 'First run', align: 'center', just: 'center', glyph: '▤', title: 'Build the timeline', body: 'Start with the five SAP Activate phases, or import a plan you already have. Tasks, dependencies and resources can be added once phases exist.', primary: 'Add the Activate phases', secondary: 'Import from Excel', tone: '#0B57D0', bg: '#E8F0FE', bd: '#BBD0F6', foot: 'Teaches the first step. Never shown with a sad face or an apology — nothing is wrong.' },
+      { kind: 'No results', align: 'center', just: 'center', glyph: '⌕', title: 'No tasks match these filters', body: '3 filters are active: Workstream Technical, Region MY and SG, Allocation over 80%. Removing the allocation filter would show 46 tasks.', primary: 'Remove allocation filter', secondary: 'Clear all filters', tone: '#4B5563', bg: '#F1F3F7', bd: '#CBD2DC', foot: 'Names the filters, and quantifies the fix. The toolbar above stays live so the user can act.' },
+      { kind: 'Error', align: 'left', just: 'flex-start', glyph: '✕', title: 'The plan could not be loaded', body: 'The server did not respond within 30 seconds. Your local copy is intact and 148 queued changes are safe.', primary: 'Try again', secondary: 'Work from local copy', tone: '#B3261E', bg: '#FDE9E7', bd: '#F0B5AF', foot: 'States what happened, what it means for their data, and two ways forward. Reference PRJ-2291 / 14:32 is shown for support.' },
+      { kind: 'No permission', align: 'left', just: 'flex-start', glyph: '🔒', title: 'Cost figures are hidden at your visibility level', body: 'You have level 1 of 3. Rates, margin and the cost breakdown need level 2. The timeline and resource plan are unaffected.', primary: 'Request level 2', secondary: 'Who can approve this?', tone: '#4B5563', bg: '#F1F3F7', bd: '#7D8799', foot: 'Deliberate, not broken: it names the level held, the level required, and what is still available.' }
+    ];
+
+    const formRules = [
+      'One column. Two columns only for genuinely paired fields — start/finish, rate/currency — and they collapse to one below 768px.',
+      'Labels sit above their field, always visible. Placeholder text is an example, never a label, and never the only description.',
+      'Field width signals expected input: a 3-character region code is not 480px wide. Widths come from the space ramp: 96 / 160 / 240 / 360 / full.',
+      'Validation runs on blur, then on every change once a field has errored, so corrections clear immediately. Never on keystroke for a field that has not yet errored.',
+      'The error summary appears above the form on failed submit, is focused programmatically, and lists each error as a link to its field.',
+      'Section = heading + optional description + fields, separated by space/8. Group = related fields at space/4. Field = label + control + helper at space/1.'
+    ];
+
+    const errorList = [
+      { field: 'Task name', msg: 'Enter a name so the task can be found in search.' },
+      { field: 'Finish date', msg: 'Finish is before start. Choose a date on or after 07 Sep 2026.' },
+      { field: 'Allocation', msg: 'Allocation must be between 0 and 150. You entered 220.' }
+    ];
+
+    const regions = [
+      { id: '#sr-status', role: 'role="status" aria-live="polite" aria-atomic="true"', where: 'Last child of the app shell, after <main>. Rendered once per session and never unmounted — a region that mounts with its message is not announced.', use: 'Every routine, expected, non-blocking event: sync transitions, saves, undo, filter and selection counts, view changes.' },
+      { id: '#sr-alert', role: 'role="alert" aria-live="assertive" aria-atomic="true"', where: 'Sibling of #sr-status, immediately after it.', use: 'Only three classes of event: a conflict needing resolution, a permanent sync failure, and a destructive action completing. Nothing else is allowed to interrupt.' },
+      { id: '#sr-log', role: 'role="log" aria-live="polite" aria-relevant="additions text"', where: 'Inside the notification centre panel, present whether the panel is open or not.', use: 'Long-running batch results that arrive as a series — import row outcomes, bulk rate-card application, export generation steps.' }
+    ];
+
+    const announcements = [
+      { ev: 'Edit committed locally', owner: 'Sync chip', region: '#sr-status', pol: 'polite', text: '“Saved locally. 1 change pending sync.”', timing: 'Coalesced: announced at most once every 5 s, with the running count. Rapid typing produces one announcement, not forty.' },
+      { ev: 'Sync started', owner: 'Sync chip', region: '#sr-status', pol: 'polite', text: '“Syncing 148 changes.”', timing: 'Suppressed entirely if the sync completes within 400 ms — a flicker the user never saw is not worth interrupting a screen reader for.' },
+      { ev: 'Sync succeeded', owner: 'Sync chip', region: '#sr-status', pol: 'polite', text: '“Synced. All 148 changes saved to the server at 14:32.”', timing: 'Immediate. Replaces any pending “Syncing” text in the same region.' },
+      { ev: 'Went offline', owner: 'Sync chip', region: '#sr-status', pol: 'polite', text: '“Offline. Editing continues; 148 changes are queued locally.”', timing: 'Announced after a 2 s confirmation window so a one-second dropout stays silent.' },
+      { ev: 'Back online, queue draining', owner: 'Sync chip', region: '#sr-status', pol: 'polite', text: '“Back online. Sending 148 queued changes.”', timing: 'Immediate on reconnect.' },
+      { ev: 'Conflict detected', owner: 'Conflict banner', region: '#sr-alert', pol: 'assertive', text: '“Sync stopped. Two people edited ‘Data cleansing sign-off’. Choose a version to keep. Press G then R to open conflict resolution.”', timing: 'Immediate, once per conflict set. A second conflict inside 10 s updates the count instead of re-announcing: “3 conflicts need resolution.”' },
+      { ev: 'Permanent sync error', owner: 'Sync chip', region: '#sr-alert', pol: 'assertive', text: '“Sync failed permanently. The server rejected 148 changes. Your local copy is intact. Reference PRJ-2291 / 14:32.”', timing: 'Immediate; the chip stops retrying and the message persists until dismissed.' },
+      { ev: 'Undo', owner: 'Undo handler', region: '#sr-status', pol: 'polite', text: '“Undone: moved ‘Cutover rehearsal’ back to 12 January. 1 change pending sync.”', timing: 'Immediate. Names the object and the restored value, never a bare “Undone”.' },
+      { ev: 'Redo', owner: 'Undo handler', region: '#sr-status', pol: 'polite', text: '“Redone: moved ‘Cutover rehearsal’ to 19 January.”', timing: 'Immediate.' },
+      { ev: 'Import complete', owner: 'Import job', region: '#sr-log', pol: 'polite', text: '“Import finished. 328 of 340 rows added. 12 rows rejected because their role is not on the rate card. Report available.”', timing: 'On completion only. Progress is not announced; the progress bar carries aria-valuenow instead.' },
+      { ev: 'Destructive action completed', owner: 'Action handler', region: '#sr-alert', pol: 'assertive', text: '“Phase ‘Realization’ deleted with 24 tasks and 9 assignments. Undo is available for 30 seconds.”', timing: 'Immediate, because the undo window is time-limited and a polite queue could outlast it.' },
+      { ev: 'Filter or selection changed', owner: 'Table', region: '#sr-status', pol: 'polite', text: '“46 tasks shown. 3 of 42 resources selected.”', timing: 'Debounced 300 ms so dragging a slider or typing in search announces once at rest.' },
+      { ev: 'Baseline saved', owner: 'Action handler', region: '#sr-status', pol: 'polite', text: '“Baseline v4 saved. 1,184 tasks captured. Comparison is now against v4.”', timing: 'Immediate.' }
+    ];
+
+    const dupeRules = [
+      'One event has exactly one announcing owner. The owner is the component that holds the authoritative state — for anything about sync, that is always the sync chip, never the toast.',
+      'A toast that mirrors an owned event renders with aria-hidden="true" on its text and posts nothing. It is a visual echo of an announcement that has already been made.',
+      'A toast that has no other owner (proposal ready, export downloaded) announces through #sr-status itself and carries no aria-hidden. Its action button stays focusable either way, because aria-hidden is on the text node, not the container.',
+      'Writing to a region always replaces its entire contents (aria-atomic="true"); text is never appended into #sr-status, which would re-read the previous sentence.',
+      'The same string written twice in a row is not re-announced. When a genuine repeat must be announced, the writer appends an invisible counter — “Synced. (2)” — rather than clearing and rewriting, which loses the message in some screen readers.',
+      'Assertive is a budget, not a channel: at most one assertive announcement per user action. If a destructive action also produces a conflict, only the conflict is assertive and the deletion drops to polite.',
+      'Nothing is announced for a state the user cannot perceive as changed — a background refresh that alters no visible value is silent, and its result appears only in the sync popover’s detail list.'
+    ];
+
+    const a11yComposites = [
+      { k: 'Modal', v: 'role="dialog" aria-modal="true", labelled by its title id and described by its lead paragraph. Focus is trapped, the background is inert, and scroll is locked on the body only. On close, focus returns to the trigger — or, if the trigger no longer exists, to the nearest surviving heading.' },
+      { k: 'Stacked modal', v: 'The parent gets inert and aria-hidden. Escape closes only the top modal. The stack is announced as “Delete phase, dialog 2 of 2”.' },
+      { k: 'Drawer', v: 'role="complementary" when non-modal, role="dialog" aria-modal when it owns unsaved edits. Opening moves focus to the drawer heading; closing returns it to the row that opened it.' },
+      { k: 'Tabs', v: 'role="tablist" with roving tabindex; arrows move and activate, Home/End jump, and each panel is role="tabpanel" labelled by its tab. Panels are not removed from the DOM on switch when they hold form state.' },
+      { k: 'Command palette', v: 'role="combobox" over role="listbox", with aria-activedescendant — focus never leaves the input. Groups are role="group" with aria-label. Result count is announced politely after a 300ms settle.' },
+      { k: 'Toast', v: 'A single role="status" region for info and success; role="alert" for warning and error. Max 3 visible, newest at the bottom, auto-dismiss 6s for info/success only — warnings and errors persist until dismissed. Hovering or focusing pauses the timer.' },
+      { k: 'Banner', v: 'role="status" for info/success, role="alert" for warning/error, placed at the top of the region it concerns rather than the top of the page, so it is not detached from what it describes.' },
+      { k: 'Empty state', v: 'The region keeps its heading level. The illustration glyph is aria-hidden; the state is carried by the heading and body text. No-permission and error states are announced when they replace loaded content.' },
+      { k: 'Form', v: 'Each field is label + control + aria-describedby. The error summary is role="alert" tabindex="-1" and focused on failed submit; each entry is an anchor to the field id. aria-invalid on every failed field.' }
+    ];
+
+    return { primaryNav, subNav, shellRules, filterChips, bulkActions, columns, rows, pages, colToggle, tableRules, darkRows, a11yTable,
+      criticalChain: [
+        { label: 'Data cleansing sign-off', days: '0d float', bg: '#FDE9E7', bd: '#B3261E', fg: '#B3261E' },
+        { label: 'Mock conversion 3', days: '0d', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' },
+        { label: 'Integration test cycle 2', days: '0d', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' },
+        { label: 'Cutover rehearsal', days: '0d', bg: '#FBF0DC', bd: '#8A5200', fg: '#8A5200' },
+        { label: 'Go-live', days: '—', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' }
+      ],
+      tabStates: [
+        { label: 'Overview', fw: 600, fg: '#101720', bar: 'inset 0 -2px 0 #0B57D0', r: '0', p: '0', bg: 'transparent', count: '' },
+        { label: 'Assignments', fw: 500, fg: '#4B5563', bar: 'none', r: '0', p: '0', bg: 'transparent', count: '14' },
+        { label: 'Rate', fw: 500, fg: '#101720', bar: 'none', r: '4px', p: '0 8px', bg: '#F1F3F7', count: '' },
+        { label: 'Availability', fw: 500, fg: '#4B5563', bar: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', r: '4px', p: '0 8px', bg: 'transparent', count: '' },
+        { label: 'History', fw: 500, fg: '#4B5563', bar: 'none', r: '0', p: '0', bg: 'transparent', count: '38' }
+      ],
+      searchGroups: [
+        { icon: '▸', label: 'Tasks', hint: 'Cutover rehearsal, Cutover dress rehearsal 2, Cutover comms…', count: '4', bg: '#E8F0FE', fg: '#0B57D0' },
+        { icon: '▤', label: 'Phases', hint: 'Deploy — contains 3 matching tasks', count: '1', bg: '#F1F3F7', fg: '#4B5563' },
+        { icon: '◐', label: 'Resources', hint: 'No resource name or role matches “cut”', count: '0', bg: '#F1F3F7', fg: '#4B5563' },
+        { icon: '▦', label: 'Documents', hint: 'Cutover plan v2.docx · Cutover runbook.xlsx', count: '2', bg: '#F1F3F7', fg: '#4B5563' }
+      ],
+      regions, announcements, dupeRules,
+      modalSizes, modalRules, drawerRules, tabs, paletteGroups, toasts, banners, emptyStates, formRules, errorList, a11yComposites };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/cost.html
+++ b/docs/design/cost.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1500px;margin:0 auto;padding:56px 32px 24px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4d of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Cost, margin and redaction</h1>
+  <p style="margin:16px 0 0;max-width:80ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Rate card, the GSR → RR → NSR → margin waterfall, out-of-pocket expenses and the 15% intercompany markup on cross-region resources. Switch the cost-visibility level below and watch redaction propagate: a masked line masks its subtotal and its total, and a partial sum is always labelled a visible subtotal — never a total.</p>
+</header>
+
+<section style="max-width:1500px;margin:0 auto;padding:0 32px">
+  <div style="display:flex;align-items:center;gap:12px;padding:12px 14px;border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;flex-wrap:wrap">
+    <span style="font-size:12px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Cost visibility</span>
+    <div role="radiogroup" aria-label="Cost visibility level" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+      <sc-for list="{{ levelCells }}" as="l" hint-placeholder-count="3">
+        <button onClick="{{ l.on }}" style="height:28px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ l.bg }};color:{{ l.fg }};border:1px solid {{ l.bd }};box-shadow:{{ l.sh }}">{{ l.label }}</button>
+      </sc-for>
+    </div>
+    <span style="font-size:12.5px;line-height:19px;color:#4B5563;max-width:58ch;text-wrap:pretty">{{ levelNote }}</span>
+    <div style="margin-left:auto;display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+      <sc-for list="{{ curCells }}" as="c" hint-placeholder-count="2">
+        <button onClick="{{ c.on }}" style="height:28px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ c.bg }};color:{{ c.fg }};border:1px solid {{ c.bd }};box-shadow:{{ c.sh }}">{{ c.label }}</button>
+      </sc-for>
+    </div>
+  </div>
+
+  <div id="cost-status" role="status" aria-live="polite" aria-atomic="true" style="margin-top:10px;display:flex;align-items:flex-start;gap:10px;padding:8px 14px;border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF">
+    <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">Announced</span>
+    <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 0">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="display:flex;align-items:baseline;gap:12px;padding:14px 16px;border-bottom:1px solid #CBD2DC;flex-wrap:wrap">
+      <h2 style="margin:0;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">Rate card — 2026-H2</h2>
+      <span style="font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ lineCount }} role–region lines · {{ headCount }} resources · {{ daysCount }} days · effective 01 Jul 2026</span>
+      <span style="margin-left:auto;font-size:11.5px;line-height:17px;color:#4B5563;text-align:right;font-variant-numeric:tabular-nums">FX locked at proposal issue, 07 Aug 2026 · 1 SGD = 3.4820 · 1 USD = 4.7150 · 1 EUR = 5.0480 MYR<br /><span style="color:#667085">Internal treasury rate. Re-locking needs delivery-manager approval and re-prices every converted figure.</span></span>
+    </div>
+    <div style="overflow-x:auto">
+      <div style="min-width:1180px">
+        <div style="display:grid;grid-template-columns:{{ gridCols }};background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+          <sc-for list="{{ rateCols }}" as="c" hint-placeholder-count="9">
+            <div style="padding:8px 12px;border-right:1px solid #E4E7EC;text-align:{{ c.align }}">
+              <span style="font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">{{ c.label }}</span>
+              <span style="display:block;font-size:10px;color:#667085">{{ c.sub }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <sc-for list="{{ rateRows }}" as="r" hint-placeholder-count="16">
+          <div style="display:grid;grid-template-columns:{{ gridCols }};align-items:center;min-height:38px;border-bottom:1px solid #E4E7EC;background:{{ r.bg }}">
+            <div style="padding:6px 12px;font-size:13px;color:#101720;display:flex;align-items:center;gap:8px">{{ r.role }}<sc-if value="{{ r.subcon }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:3px;background:#FBF0DC;border:1px solid #E0C089;font-size:10px;font-weight:600;color:#8A5200">SUBCON</span></sc-if></div>
+            <div style="padding:6px 12px;font-size:12.5px;color:#4B5563">{{ r.region }}</div>
+            <div style="padding:6px 12px;text-align:right;font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ r.heads }}</div>
+            <div style="padding:6px 12px;text-align:right;font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ r.days }}</div>
+            <sc-if value="{{ r.showNative }}" hint-placeholder-val="{{ true }}"><div style="padding:6px 12px;text-align:right;font-size:13px;color:#101720;font-variant-numeric:tabular-nums">{{ r.native }}</div></sc-if>
+            <sc-if value="{{ r.showNative }}" hint-placeholder-val="{{ true }}"><div style="padding:6px 12px;text-align:right;font-size:11.5px;color:#667085;font-variant-numeric:tabular-nums">{{ r.fx }}</div></sc-if>
+            <div style="padding:6px 12px;text-align:right;font-size:13px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">{{ r.myr }}</div>
+            <div style="padding:6px 12px;text-align:right;font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">
+              <sc-if value="{{ r.markupMasked }}" hint-placeholder-val="{{ false }}"><span role="img" aria-label="Intercompany markup restricted — needs cost visibility level 3. Request access." title="Restricted — needs cost visibility level 3" style="display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:3px;background:repeating-linear-gradient(135deg,#F1F3F7,#F1F3F7 4px,#E4E7EC 4px,#E4E7EC 8px);border:1px solid #7D8799;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563"><span aria-hidden="true">🔒 ▪▪▪</span></span></sc-if>
+              <sc-if value="{{ r.markupShown }}" hint-placeholder-val="{{ true }}">{{ r.markup }}</sc-if>
+            </div>
+            <div style="padding:6px 12px;text-align:right;font-size:13px;font-weight:600;color:#101720;font-variant-numeric:tabular-nums">
+              <sc-if value="{{ r.costMasked }}" hint-placeholder-val="{{ false }}"><span role="img" aria-label="{{ r.maskAria }}" title="{{ r.maskWhy }}" style="display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:3px;background:repeating-linear-gradient(135deg,#F1F3F7,#F1F3F7 4px,#E4E7EC 4px,#E4E7EC 8px);border:1px solid #7D8799;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563"><span aria-hidden="true">🔒 ▪▪▪,▪▪▪</span></span></sc-if>
+              <sc-if value="{{ r.costShown }}" hint-placeholder-val="{{ true }}">{{ r.cost }}</sc-if>
+            </div>
+          </div>
+        </sc-for>
+        <div style="display:grid;grid-template-columns:{{ gridCols }};align-items:center;min-height:44px;background:#F1F3F7;border-top:1.5px solid #101720">
+          <div style="padding:8px 12px;font-size:13px;font-weight:600">{{ totalLabel }}</div>
+          <div></div>
+          <div style="padding:8px 12px;text-align:right;font-size:12.5px;font-weight:600;font-variant-numeric:tabular-nums">{{ totalHeads }}</div>
+          <div style="padding:8px 12px;text-align:right;font-size:12.5px;font-weight:600;font-variant-numeric:tabular-nums">{{ totalDays }}</div>
+          <sc-if value="{{ showNative }}" hint-placeholder-val="{{ true }}"><div></div></sc-if>
+          <sc-if value="{{ showNative }}" hint-placeholder-val="{{ true }}"><div></div></sc-if>
+          <div style="padding:8px 12px;text-align:right;font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">blended {{ blended }}</div>
+          <div></div>
+          <div role="cell" aria-label="{{ totalAria }}" style="padding:8px 12px;text-align:right;font-size:13.5px;font-weight:700;font-variant-numeric:tabular-nums">
+            <sc-if value="{{ totalMasked }}" hint-placeholder-val="{{ false }}"><span role="img" aria-label="No programme total available. Every cost line is restricted at cost visibility level 1." style="display:inline-flex;align-items:center;gap:4px;padding:2px 6px;border-radius:3px;background:repeating-linear-gradient(135deg,#E4E7EC,#E4E7EC 4px,#CBD2DC 4px,#CBD2DC 8px);border:1px solid #7D8799;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563"><span aria-hidden="true">🔒 ▪▪,▪▪▪,▪▪▪</span></span></sc-if>
+            <sc-if value="{{ totalShown }}" hint-placeholder-val="{{ true }}">{{ totalCost }}</sc-if>
+          </div>
+        </div>
+        <sc-if value="{{ partialNote }}" hint-placeholder-val="{{ false }}">
+          <div style="display:flex;align-items:flex-start;gap:10px;padding:10px 14px;background:#F6F7F9;border-top:1px solid #CBD2DC">
+            <span aria-hidden="true" style="font-size:12px;color:#4B5563;padding-top:1px">🔒</span>
+            <span style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ partialNote }}</span>
+          </div>
+        </sc-if>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(460px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+        <h2 style="margin:0;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">Margin waterfall</h2>
+        <span style="font-size:12.5px;color:#4B5563">MYR · programme to date plus forecast</span>
+      </div>
+      <div role="table" aria-label="Margin waterfall" aria-rowcount="8" style="margin-top:16px">
+        <sc-for list="{{ waterfall }}" as="w" hint-placeholder-count="8">
+          <div role="row" style="display:grid;grid-template-columns:200px 1fr 168px;gap:12px;align-items:center;padding:8px 0;border-bottom:1px solid {{ w.rule }}">
+            <div role="rowheader">
+              <div style="font-size:13px;font-weight:{{ w.fw }};color:#101720">{{ w.label }}</div>
+              <div style="font-size:11px;line-height:16px;color:#667085;text-wrap:pretty">{{ w.note }}</div>
+            </div>
+            <div aria-hidden="true" style="position:relative;height:20px">
+              <div style="position:absolute;top:3px;left:{{ w.left }};width:{{ w.width }};height:14px;border-radius:2px;background:{{ w.fill }};border:{{ w.border }}"></div>
+              <sc-if value="{{ w.hatched }}" hint-placeholder-val="{{ false }}">
+                <div aria-hidden="true" style="position:absolute;top:3px;left:{{ w.left }};width:{{ w.width }};height:14px;border-radius:2px;background:repeating-linear-gradient(135deg,#F1F3F7,#F1F3F7 4px,#CBD2DC 4px,#CBD2DC 8px);border:1px solid #7D8799"></div>
+              </sc-if>
+            </div>
+            <div role="cell" aria-label="{{ w.aria }}" style="text-align:right;font-size:13.5px;font-weight:{{ w.fw }};color:{{ w.fg }};font-variant-numeric:tabular-nums">
+              <sc-if value="{{ w.masked }}" hint-placeholder-val="{{ false }}"><span aria-hidden="true" style="display:inline-flex;align-items:center;gap:4px;padding:2px 6px;border-radius:3px;background:repeating-linear-gradient(135deg,#F1F3F7,#F1F3F7 4px,#E4E7EC 4px,#E4E7EC 8px);border:1px solid #7D8799;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">🔒 {{ w.mask }}</span></sc-if>
+              <sc-if value="{{ w.shown }}" hint-placeholder-val="{{ true }}">{{ w.value }}</sc-if>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="margin-top:14px;padding:12px 14px;border-radius:6px;background:{{ marginBg }};border:1px solid {{ marginBd }}">
+        <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+          <span style="font-size:13px;font-weight:600;color:{{ marginFg }}">{{ marginTitle }}</span>
+          <span style="margin-left:auto;font-size:22px;font-weight:600;color:{{ marginFg }};font-variant-numeric:tabular-nums">{{ marginPct }}</span>
+        </div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:4px;text-wrap:pretty">{{ marginNote }}</div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+        <h2 style="margin:0 0 4px;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">Out-of-pocket expenses</h2>
+        <p style="margin:0 0 14px;font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">Pass-through at cost with receipts, invoiced monthly. Excluded from NSR and from the margin calculation — which is why margin is quoted on NSR and never on total invoiced value.</p>
+        <sc-for list="{{ oop }}" as="o" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:1fr 132px;gap:12px;padding:8px 0;border-top:1px solid #E4E7EC;align-items:baseline">
+            <div>
+              <div style="font-size:13px;color:#101720">{{ o.label }}</div>
+              <div style="font-size:11.5px;line-height:17px;color:#667085">{{ o.note }} · {{ o.pol }}</div>
+            </div>
+            <div style="text-align:right;font-size:13px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">{{ o.amt }}</div>
+          </div>
+        </sc-for>
+        <div style="display:grid;grid-template-columns:1fr 132px;gap:12px;padding:10px 0 0;border-top:1.5px solid #101720;margin-top:8px">
+          <div style="font-size:13px;font-weight:600">Total out-of-pocket — all 4 lines</div>
+          <div style="text-align:right;font-size:13.5px;font-weight:700;font-variant-numeric:tabular-nums">MYR 1,056,000</div>
+        </div>
+        <div style="font-size:11.5px;line-height:17px;color:#667085;margin-top:8px">Out-of-pocket is never redacted: it is invoiced to the client at cost, so it carries no margin information and hiding it would only obstruct the people approving it.</div>
+      </div>
+
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+        <h2 style="margin:0 0 12px;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">Redaction rules</h2>
+        <sc-for list="{{ redaction }}" as="r" hint-placeholder-count="7">
+          <div style="display:grid;grid-template-columns:126px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark — masked and visible figures</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:1.4fr 90px 130px;background:#0A0D12;border-bottom:1px solid #333C4A;font-size:10.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">
+          <div style="padding:7px 10px">Role</div><div style="padding:7px 10px;text-align:right">MYR rate</div><div style="padding:7px 10px;text-align:right">Line cost</div>
+        </div>
+        <div style="display:grid;grid-template-columns:1.4fr 90px 130px;border-bottom:1px solid #232A35"><div style="padding:8px 10px;font-size:12.5px;color:#E9EEF6">Solution Architect</div><div style="padding:8px 10px;text-align:right;font-size:12.5px;color:#E9EEF6;font-variant-numeric:tabular-nums">3,200</div><div style="padding:8px 10px;text-align:right;font-size:12.5px;font-weight:600;color:#E9EEF6;font-variant-numeric:tabular-nums">1,408,000</div></div>
+        <div style="display:grid;grid-template-columns:1.4fr 90px 130px;border-bottom:1px solid #232A35"><div style="padding:8px 10px;font-size:12.5px;color:#E9EEF6">Security Consultant <span style="display:inline-flex;align-items:center;height:16px;padding:0 5px;border-radius:3px;background:#33240B;border:1px solid #7A5A22;font-size:9.5px;font-weight:600;color:#E9B45A">SUBCON</span></div><div style="padding:8px 10px;text-align:right;font-size:12.5px;color:#E9EEF6;font-variant-numeric:tabular-nums">1,301</div><div style="padding:8px 10px;text-align:right"><span style="display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:3px;background:repeating-linear-gradient(135deg,#12161C,#12161C 4px,#232A35 4px,#232A35 8px);border:1px solid #748196;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#AFBACA"><span aria-hidden="true">🔒</span>▪▪▪,▪▪▪</span></div></div>
+        <div style="display:grid;grid-template-columns:1.4fr 90px 130px;background:#0A0D12;border-top:1px solid #748196"><div style="padding:9px 10px;font-size:12.5px;font-weight:600;color:#E9EEF6">Visible subtotal — 16 of 17</div><div></div><div style="padding:9px 10px;text-align:right;font-size:13px;font-weight:700;color:#E9EEF6;font-variant-numeric:tabular-nums">24,230,545</div></div>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">The mask in dark is a hatch of surface/sunken over surface/raised with a border/strong edge at 4.33:1 — visible as a deliberate object, while the hidden digits stay unreadable. Mask text sits at 8.71:1.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Number, currency and date formatting</h3>
+      <sc-for list="{{ formats }}" as="f" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ f.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ f.v }}</div></div>
+      </sc-for>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1500,&quot;height&quot;:960}}">
+const FX = { MYR: 1, SGD: 3.482, USD: 4.715, EUR: 5.048 };
+const RATES = [
+  { role: 'Programme Director', region: 'MY', cur: 'MYR', rate: 4000, heads: 1, days: 420, sub: false, cross: false },
+  { role: 'Delivery Manager', region: 'MY', cur: 'MYR', rate: 2900, heads: 1, days: 460, sub: false, cross: false },
+  { role: 'Solution Architect', region: 'MY', cur: 'MYR', rate: 3200, heads: 1, days: 440, sub: false, cross: false },
+  { role: 'Integration Architect', region: 'SG', cur: 'SGD', rate: 1091, heads: 1, days: 320, sub: false, cross: true },
+  { role: 'Integration Consultant', region: 'SG', cur: 'SGD', rate: 1091, heads: 2, days: 480, sub: false, cross: true },
+  { role: 'FI/CO Consultant', region: 'MY', cur: 'MYR', rate: 2400, heads: 4, days: 1080, sub: false, cross: false },
+  { role: 'MM/SD Consultant', region: 'MY', cur: 'MYR', rate: 2400, heads: 4, days: 1020, sub: false, cross: false },
+  { role: 'PP/QM Consultant', region: 'MY', cur: 'MYR', rate: 2500, heads: 1, days: 260, sub: false, cross: false },
+  { role: 'HCM Consultant', region: 'MY', cur: 'MYR', rate: 2300, heads: 3, days: 620, sub: false, cross: false },
+  { role: 'Basis Consultant', region: 'MY', cur: 'MYR', rate: 2600, heads: 2, days: 520, sub: false, cross: false },
+  { role: 'ABAP Developer', region: 'IN', cur: 'USD', rate: 233, heads: 3, days: 900, sub: false, cross: true },
+  { role: 'Data Migration Lead', region: 'MY', cur: 'MYR', rate: 2700, heads: 3, days: 700, sub: false, cross: false },
+  { role: 'Test Lead / Analyst', region: 'MY', cur: 'MYR', rate: 2200, heads: 4, days: 760, sub: false, cross: false },
+  { role: 'Change Manager / Training', region: 'MY', cur: 'MYR', rate: 2100, heads: 4, days: 540, sub: false, cross: false },
+  { role: 'Business Analyst', region: 'MY', cur: 'MYR', rate: 1800, heads: 4, days: 620, sub: false, cross: false },
+  { role: 'PMO Analyst', region: 'MY', cur: 'MYR', rate: 1400, heads: 3, days: 640, sub: false, cross: false },
+  { role: 'Security Consultant', region: 'VN', cur: 'USD', rate: 276, heads: 3, days: 520, sub: true, cross: true }
+];
+const MARKUP = 0.15;
+const fmt = (n) => Math.round(n).toLocaleString('en-MY');
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.state = {
+      level: 2, currency: 'native',
+      announce: 'Cost view ready at visibility level 2 of 3. Delivery cost is visible; intercompany markup and subcontractor cost are masked.'
+    };
+  }
+
+  say(m) { this.setState({ announce: m }); }
+
+  rowCost(r) {
+    const myr = Math.round(r.rate * FX[r.cur]);
+    const base = myr * r.days;
+    const markup = r.cross ? Math.round(base * MARKUP) : 0;
+    return { myr, base, markup, total: base + markup };
+  }
+
+  // Level 1: no money at all. Level 2: cost visible except subcontractor lines
+  // and the intercompany markup. Level 3: everything.
+  maskedRow(r) {
+    const L = this.state.level;
+    if (L === 1) return true;
+    if (L === 2 && r.sub) return true;
+    return false;
+  }
+  maskedMarkup(r) { return this.state.level < 3 && r.cross; }
+
+  renderVals() {
+    const S = this.state;
+    const L = S.level;
+
+    let visibleCost = 0, visibleLines = 0, maskedLines = 0, totalDays = 0, totalHeads = 0, allCost = 0;
+    const rateRows = RATES.map((r, i) => {
+      const c = this.rowCost(r);
+      const masked = this.maskedRow(r);
+      allCost += c.total; totalDays += r.days; totalHeads += r.heads;
+      if (masked) maskedLines++; else { visibleCost += c.total; visibleLines++; }
+      const nat = r.cur === 'MYR' ? fmt(r.rate) : r.cur + ' ' + fmt(r.rate);
+      return {
+        role: r.role, region: r.region, subcon: r.sub, showNative: S.currency === 'native',
+        heads: String(r.heads), days: fmt(r.days),
+        native: nat,
+        fx: r.cur === 'MYR' ? '—' : '× ' + FX[r.cur].toFixed(4),
+        myr: fmt(c.myr),
+        markup: r.cross ? '+' + fmt(c.markup) : '—',
+        markupMasked: this.maskedMarkup(r), markupShown: !this.maskedMarkup(r),
+        cost: fmt(c.total),
+        costMasked: masked, costShown: !masked,
+        maskWhy: L === 1 ? 'Restricted — needs cost visibility level 2' : 'Restricted — subcontractor cost needs level 3',
+        maskAria: (L === 1 ? 'Line cost restricted — needs cost visibility level 2. Request access.' : 'Subcontractor line cost restricted — needs cost visibility level 3. Request access.'),
+        bg: masked ? '#FBFCFD' : (i % 2 === 1 ? '#FFFFFF' : '#FFFFFF')
+      };
+    });
+
+    const anyMasked = maskedLines > 0;
+    const partialNote = !anyMasked ? '' :
+      (L === 1
+        ? 'All ' + RATES.length + ' cost lines are restricted at visibility level 1, so no total can be shown — not even a partial one. Effort in days and headcount are unrestricted and are the figures to plan with at this level.'
+        : 'Visible subtotal: MYR ' + fmt(visibleCost) + ' across ' + visibleLines + ' of ' + RATES.length + ' lines. ' + maskedLines + ' subcontractor line' + (maskedLines === 1 ? ' is' : 's are') + ' restricted at your level, so this is not the programme total and must not be quoted as one. Request level 3 from Chan Wei Ling to see the full figure.');
+
+    const gsr = 38600000;
+    const discount = -Math.round(gsr * 0.06);
+    const rr = gsr + discount;
+    const passThrough = -1980000;
+    const nsr = rr + passThrough;
+    const internalCost = -allCost;
+    const icTotal = RATES.reduce((a, r) => a + this.rowCost(r).markup, 0);
+    const margin = nsr + internalCost;
+    const marginPct = (margin / nsr) * 100;
+    const marginVisible = L === 3;
+    const FLOOR = 25;
+    const healthy = marginPct >= FLOOR;
+    const gap = Math.abs(marginPct - FLOOR).toFixed(1);
+
+    // Bars are drawn from the running balance on one scale (GSR = 100%).
+    const money = (v) => (v < 0 ? '\u2212 MYR ' : 'MYR ') + fmt(Math.abs(v));
+    const pctOf = (v) => Math.abs(v) / gsr * 100;
+    let running = 0;
+    const W = (label, note, value, kind, masked, maskGlyph) => {
+      let left, width;
+      if (kind === 'neg') { running += value; left = pctOf(running) + '%'; width = Math.max(1.2, pctOf(value)) + '%'; }
+      else { running = value; left = '0%'; width = Math.max(1.2, pctOf(value)) + '%'; }
+      const negTotal = kind === 'total' && value < 0;
+      return {
+        label, note, value: money(value),
+        aria: masked
+          ? label + ' restricted — needs cost visibility level 3. Request access.'
+          : label + ', ' + (value < 0 ? 'minus ' : '') + fmt(Math.abs(value)) + ' Malaysian ringgit.',
+        masked, shown: !masked, mask: maskGlyph,
+        fw: kind === 'total' ? 600 : 400,
+        fg: (kind === 'neg' || negTotal) ? '#B3261E' : '#101720',
+        rule: kind === 'total' ? '#101720' : '#E4E7EC',
+        left, width,
+        fill: masked ? '#F1F3F7' : (kind === 'neg' ? '#FDE9E7' : kind === 'total' ? (negTotal ? '#B3261E' : '#101720') : '#E8F0FE'),
+        border: masked ? '1px solid #7D8799' : (kind === 'neg' ? '1px solid #B3261E' : '1px solid #101720'),
+        hatched: masked
+      };
+    };
+
+    const waterfall = [
+      W('GSR', 'Gross sell rate \u00d7 effort, before any discount', gsr, 'pos', false, ''),
+      W('Less client discount', 'Negotiated 6.0% programme discount', discount, 'neg', false, ''),
+      W('RR', 'Realised revenue \u2014 what the client is invoiced for services', rr, 'total', false, ''),
+      W('Less pass-through', 'Subcontracted scope invoiced at cost, no margin', passThrough, 'neg', false, ''),
+      W('NSR', 'Net service revenue \u2014 the base for margin', nsr, 'total', false, ''),
+      W('Less delivery cost', 'All internal and subcontracted resource cost, at rate-card rates', internalCost, 'neg', L < 3, '\u25aa\u25aa,\u25aa\u25aa\u25aa,\u25aa\u25aa\u25aa'),
+      W('Less intercompany markup (included above)', '15% on SG, IN and VN resources billed across entities', -icTotal, 'neg', L < 3, '\u25aa\u25aa\u25aa,\u25aa\u25aa\u25aa'),
+      W('Margin', 'NSR less delivery cost', margin, 'total', !marginVisible, '\u25aa,\u25aa\u25aa\u25aa,\u25aa\u25aa\u25aa')
+    ];
+
+    return {
+      rateCols: [
+        { label: 'Role', sub: '', align: 'left' },
+        { label: 'Region', sub: '', align: 'left' },
+        { label: 'Heads', sub: '', align: 'right' },
+        { label: 'Days', sub: '', align: 'right' }
+      ].concat(S.currency === 'native' ? [
+        { label: 'Native rate', sub: 'per day', align: 'right' },
+        { label: 'FX', sub: '07 Aug', align: 'right' }
+      ] : []).concat([
+        { label: 'MYR rate', sub: 'per day', align: 'right' },
+        { label: 'IC markup', sub: '15% cross-region', align: 'right' },
+        { label: 'Line cost', sub: 'MYR', align: 'right' }
+      ]),
+      rateRows, partialNote,
+      lineCount: String(RATES.length),
+      headCount: String(totalHeads),
+      daysCount: fmt(totalDays),
+      gridCols: S.currency === 'native' ? '1.6fr 76px 56px 68px 128px 80px 124px 100px 136px' : '1.6fr 76px 56px 68px 124px 100px 136px',
+      showNative: S.currency === 'native',
+      totalHeads: String(totalHeads), totalDays: fmt(totalDays),
+      blended: fmt(allCost / totalDays) + '/day',
+      totalLabel: anyMasked ? (L === 1 ? 'No total available' : 'Visible subtotal — ' + visibleLines + ' of ' + RATES.length + ' lines') : 'Programme total — all ' + RATES.length + ' lines',
+      totalCost: 'MYR ' + fmt(L === 1 ? 0 : (anyMasked ? visibleCost : allCost)),
+      totalAria: L === 1
+        ? 'No programme total available. All ' + RATES.length + ' cost lines are restricted at cost visibility level 1.'
+        : (anyMasked
+            ? 'Visible subtotal, ' + fmt(visibleCost) + ' Malaysian ringgit, across ' + visibleLines + ' of ' + RATES.length + ' lines; ' + maskedLines + ' line restricted. Not the programme total.'
+            : 'Programme total, ' + fmt(allCost) + ' Malaysian ringgit, all ' + RATES.length + ' lines included.'),
+      totalMasked: L === 1, totalShown: L !== 1,
+      waterfall,
+      marginTitle: marginVisible ? (healthy ? 'Margin on NSR' : 'Margin on NSR is below the floor') : 'Margin is restricted at your level',
+      marginPct: marginVisible ? marginPct.toFixed(1) + '%' : '🔒 ▪▪.▪%',
+      marginBg: marginVisible ? (healthy ? '#E3F5EB' : (marginPct < 0 ? '#FDE9E7' : '#FBF0DC')) : '#F1F3F7',
+      marginBd: marginVisible ? (healthy ? '#9AD9BB' : (marginPct < 0 ? '#B3261E' : '#E0C089')) : '#7D8799',
+      marginFg: marginVisible ? (healthy ? '#0A7A47' : (marginPct < 0 ? '#B3261E' : '#8A5200')) : '#4B5563',
+      marginNote: marginVisible
+        ? (healthy ? 'Above the 25.0% programme floor by ' + gap + ' points. Margin is calculated on NSR, so pass-through and out-of-pocket never flatter it.' : 'Below the 25.0% programme floor by ' + gap + ' points. Margin is calculated on NSR, so pass-through and out-of-pocket never flatter it. A deal below the floor needs partner sign-off before issue.')
+        : 'Margin depends on delivery cost, which is masked at level ' + L + '. It is masked rather than approximated: a rounded band would let the exact figure be recovered from NSR by subtraction.',
+      announce: S.announce,
+      levelCells: [1, 2, 3].map(n => ({
+        label: 'Level ' + n,
+        bg: L === n ? '#FFFFFF' : 'transparent',
+        fg: L === n ? '#101720' : '#4B5563',
+        bd: L === n ? '#7D8799' : 'transparent',
+        sh: L === n ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => {
+          this.setState({ level: n });
+          const msg = n === 1
+            ? 'Cost visibility level 1 of 3. All 17 cost lines, the total, the delivery cost and the margin are masked. Effort and headcount remain visible.'
+            : n === 2
+              ? 'Cost visibility level 2 of 3. Internal cost lines are visible; 1 subcontractor line, the intercompany markup, the delivery cost and the margin are masked. The footer figure is a visible subtotal across 16 of 17 lines, not a total.'
+              : 'Cost visibility level 3 of 3. All figures visible, including the intercompany markup and the 27 point margin.';
+          this.say(msg);
+        }
+      })),
+      levelNote: L === 1
+        ? 'Level 1 — effort only. No rate, cost, markup or margin figure is rendered anywhere on the screen.'
+        : L === 2
+          ? 'Level 2 — internal cost visible. Subcontractor cost, intercompany markup and margin stay masked, and every sum that touches them is masked with them.'
+          : 'Level 3 — full visibility. Every figure on this screen is real, including margin.',
+      curCells: ['native', 'project'].map(c => ({
+        label: c === 'native' ? 'Native + converted' : 'Project currency (MYR)',
+        bg: S.currency === c ? '#FFFFFF' : 'transparent',
+        fg: S.currency === c ? '#101720' : '#4B5563',
+        bd: S.currency === c ? '#7D8799' : 'transparent',
+        sh: S.currency === c ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => { this.setState({ currency: c }); this.say(c === 'native' ? 'Showing native rate, FX factor and converted MYR rate side by side. Nine columns.' : 'Native rate and FX columns hidden. Seven columns, all figures in MYR. Native rates remain in each row’s accessible name and in the Excel export.'); }
+      })),
+
+      oop: [
+        { label: 'International travel', note: 'SG and IN mobilisation, 34 trips', amt: 'MYR 480,000', pol: 'At cost, economy class, booked through the client travel desk' },
+        { label: 'Accommodation', note: 'Kuching, 620 room-nights', amt: 'MYR 320,000', pol: 'At cost, capped at MYR 520 per night' },
+        { label: 'Per diem', note: '4 regions, 1,120 days', amt: 'MYR 210,000', pol: 'Fixed regional rate, no receipts required' },
+        { label: 'Visas and permits', note: 'VN and IN, 6 people', amt: 'MYR 46,000', pol: 'At cost, non-refundable if a resource rolls off' }
+      ],
+
+      redaction: [
+        { k: 'What is masked', v: 'The figure only. The row, its label, its unit and its position in the table all stay — a reader must be able to see that a number exists and that they cannot have it.' },
+        { k: 'How it looks', v: 'A fixed-width monospace mask matching the digit grouping of the hidden figure, on a hatched surface/sunken fill with a 1px border/strong edge and a lock glyph. It reads as deliberate, never as a rendering failure.' },
+        { k: 'Propagation', v: 'Upward and total: any subtotal or total containing a masked line is itself masked. Arithmetic is deliberately broken rather than left recoverable by subtraction.' },
+        { k: 'Partial sums', v: 'Where a partial sum is genuinely useful it is labelled “Visible subtotal: X across N of M lines” and carries the reason and the route to access. The word “total” is reserved for a figure that includes everything.' },
+        { k: 'No approximation', v: 'No rounded bands, no “about MYR 1–1.5M”, no percentages of a masked base. An approximation of a restricted figure is a disclosure of it.' },
+        { k: 'Export parity', v: 'PDF, PPTX and Excel exports carry the same masks and the same subtotal labelling, stamped with the exporter’s level. A masked cell in Excel contains the literal text “RESTRICTED”, never an empty cell or a zero.' },
+        { k: 'Escalation', v: 'Every mask names its route: “Restricted — needs cost visibility level 3”, with Request access opening a pre-filled approval to the delivery manager who owns the level.' }
+      ],
+
+      a11y: [
+        { k: 'Masked cell', v: 'Each mask is role="img" whose aria-label is the reason — “Subcontractor line cost restricted — needs cost visibility level 3. Request access.” The lock glyph and the ▪ run sit inside one aria-hidden span, so no screen reader ever reads “black small square”.' },
+        { k: 'Subtotal', v: 'The footer cell carries the full sentence as its accessible name — “Visible subtotal, 24,230,545 Malaysian ringgit, across 16 of 17 lines; 1 line restricted. Not the programme total.” — so the caveat cannot be separated from the number.' },
+        { k: 'Level change', v: 'Changing cost visibility writes to #cost-status politely and states exactly what became visible or hidden, including how many lines and whether the total is now partial.' },
+        { k: 'Currency', v: 'Native and converted values are separate cells with their own column headers; the FX factor column is announced with the rate and its lock date, so a converted figure is never read without its basis.' },
+        { k: 'Waterfall', v: 'Rendered as a table, not a chart: role="table" with a role="row" per step, role="rowheader" on the label and role="cell" on the figure, and the bar column marked aria-hidden. The bar is a redundant encoding of a number already in the cell.' },
+        { k: 'Negative figures', v: 'Announced as “minus 1,290,000 Malaysian ringgit”, never by colour or a bare minus glyph; deductions also carry the word “less” in their label.' }
+      ],
+
+      formats: [
+        { k: 'Currency', v: 'ISO code then value, space-separated: MYR 2,400 — never RM or $, which are ambiguous across MY, SG and US. Two decimals only where cents are material (invoices, FX factors); rates and totals are whole units.' },
+        { k: 'Conversion', v: 'Native figure, FX factor to four decimals, and converted figure are always shown together or the converted figure is omitted. A converted number without its rate and date is not a fact.' },
+        { k: 'Percentages', v: 'One decimal for margin and markup, integer for allocation. A percentage always names its base in the label (“Margin on NSR”), because margin on RR and margin on NSR differ by four points here.' },
+        { k: 'Dates', v: 'DD MMM YYYY (07 Aug 2026) in the interface, ISO 8601 in exports and in every accessible name that a date-format setting could otherwise change under the user.' },
+        { k: 'Durations', v: 'Working days by default, with calendar days in parentheses where the two differ. The region calendar that produced the number is always named.' },
+        { k: 'Large numbers', v: 'Thousands separators, tabular numerals, right-aligned. Abbreviation to 1.2M is permitted only in summary tiles, and the full figure is in the accessible name and the tooltip.' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/foundations.html
+++ b/docs/design/foundations.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<![CDATA[<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; }
+  a { color:#0B57D0; text-decoration:underline; text-underline-offset:2px; }
+  a:hover { color:#08429E; }
+  ::selection { background:#D6E4FD; }
+</style>
+</helmet>
+
+<div style="min-height:100vh;background:#F6F7F9;color:#101720;padding:0 0 96px">
+
+  <div style="max-width:1240px;margin:0 auto;padding:0 40px">
+
+    <header style="padding:72px 0 40px;border-bottom:1px solid #CBD2DC">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — SAP delivery planning</div>
+      <h1 style="margin:14px 0 0;font-size:44px;line-height:50px;font-weight:600;letter-spacing:-0.025em;max-width:20ch;text-wrap:pretty">Foundations: principles &amp; design tokens</h1>
+      <p style="margin:20px 0 0;max-width:68ch;font-size:16px;line-height:26px;color:#4B5563;text-wrap:pretty">Layer 1 of the Cockpit design system. Every value below is a named token with a computed contrast ratio for both themes. Nothing in the component or screen layers may introduce a value that is not defined here.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:24px">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:12px;line-height:16px;font-weight:500;border:1px solid #BBD0F6">WCAG 2.2 AA verified</span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#FFFFFF;color:#4B5563;font-size:12px;line-height:16px;font-weight:500;border:1px solid #CBD2DC">Light + dark, both authored</span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#FFFFFF;color:#4B5563;font-size:12px;line-height:16px;font-weight:500;border:1px solid #CBD2DC">IBM Plex Sans / Plex Mono</span>
+      </div>
+    </header>
+
+    <section style="padding:56px 0 0">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">01 — Principles</div>
+      <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Six rules that decide arguments</h2>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px;margin-top:28px">
+        <sc-for list="{{ principles }}" as="p" hint-placeholder-count="6">
+          <article style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px;display:flex;flex-direction:column;gap:10px">
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:16px;color:#7D8799">{{ p.n }}</div>
+            <h3 style="margin:0;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">{{ p.title }}</h3>
+            <p style="margin:0;font-size:14px;line-height:22px;color:#4B5563;text-wrap:pretty">{{ p.body }}</p>
+            <div style="margin-top:6px;padding-top:12px;border-top:1px dashed #CBD2DC;font-size:13px;line-height:20px;color:#101720"><span style="font-weight:600">Implication — </span>{{ p.impl }}</div>
+          </article>
+        </sc-for>
+      </div>
+    </section>
+
+    <section style="padding:64px 0 0">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">02 — Colour</div>
+      <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Semantic roles, light theme</h2>
+      <p style="margin:12px 0 0;max-width:70ch;font-size:14px;line-height:22px;color:#4B5563">Ratio column states the computed contrast of the token against the surface named in “Verified against”. Text roles target 4.5:1; boundary, icon and focus roles target 3:1. Roles marked <em>decorative</em> carry no meaning alone and are always paired with a stronger cue.</p>
+
+      <div style="margin-top:24px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:56px 1.5fr 110px 2fr 1.3fr 92px;gap:16px;padding:12px 20px;background:#F1F3F7;border-bottom:1px solid #CBD2DC;font-size:12px;line-height:16px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">
+          <div>Swatch</div><div>Token</div><div>Value</div><div>Use</div><div>Verified against</div><div style="text-align:right">Ratio</div>
+        </div>
+        <sc-for list="{{ light }}" as="r" hint-placeholder-count="12">
+          <div style="display:grid;grid-template-columns:56px 1.5fr 110px 2fr 1.3fr 92px;gap:16px;padding:12px 20px;border-bottom:1px solid #E4E7EC;align-items:center">
+            <div style="height:28px;border-radius:6px;border:1px solid #CBD2DC;background:{{ r.hex }}"></div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;color:#101720">{{ r.token }}</div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;color:#4B5563;font-variant-numeric:tabular-nums">{{ r.hex }}</div>
+            <div style="font-size:13px;line-height:19px;color:#4B5563">{{ r.use }}</div>
+            <div style="font-size:13px;line-height:19px;color:#667085">{{ r.against }}</div>
+            <div style="text-align:right;font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;font-variant-numeric:tabular-nums;font-weight:500;color:{{ r.color }}">{{ r.ratio }}</div>
+          </div>
+        </sc-for>
+      </div>
+
+      <h2 style="margin:48px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Semantic roles, dark theme</h2>
+      <p style="margin:12px 0 0;max-width:70ch;font-size:14px;line-height:22px;color:#4B5563">Dark is authored, not inverted: surfaces get lighter as they rise, accent is desaturated and lifted so it still reads as blue at 8:1, and status hues are pulled toward their tint rather than their shade. Accent carries dark text, never white.</p>
+
+      <div style="margin-top:24px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:56px 1.5fr 110px 2fr 1.3fr 92px;gap:16px;padding:12px 20px;background:#171C24;border-bottom:1px solid #333C4A;font-size:12px;line-height:16px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA">
+          <div>Swatch</div><div>Token</div><div>Value</div><div>Use</div><div>Verified against</div><div style="text-align:right">Ratio</div>
+        </div>
+        <sc-for list="{{ dark }}" as="r" hint-placeholder-count="12">
+          <div style="display:grid;grid-template-columns:56px 1.5fr 110px 2fr 1.3fr 92px;gap:16px;padding:12px 20px;border-bottom:1px solid #232A35;align-items:center">
+            <div style="height:28px;border-radius:6px;border:1px solid #3D4757;background:{{ r.hex }}"></div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;color:#E9EEF6">{{ r.token }}</div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;color:#AFBACA;font-variant-numeric:tabular-nums">{{ r.hex }}</div>
+            <div style="font-size:13px;line-height:19px;color:#AFBACA">{{ r.use }}</div>
+            <div style="font-size:13px;line-height:19px;color:#8592A6">{{ r.against }}</div>
+            <div style="text-align:right;font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;font-variant-numeric:tabular-nums;font-weight:500;color:{{ r.color }}">{{ r.ratio }}</div>
+          </div>
+        </sc-for>
+      </div>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:24px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+          <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">The accent trap, stated once</h3>
+          <p style="margin:0;font-size:13px;line-height:21px;color:#4B5563">A mid-blue such as <span style="font-family:'IBM Plex Mono',monospace">#007AFF</span> is 4.02:1 on white and fails for body-sized text and for link text in tables. Cockpit's light accent is <span style="font-family:'IBM Plex Mono',monospace">#0B57D0</span> at 6.39:1, which also survives the sunken surface at 5.75:1 and the app canvas at 5.96:1 — so a link is legible in a table row, a sidebar and a modal without a second token.</p>
+        </div>
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+          <h3 style="margin:0 0 10px;font-size:15px;line-height:22px;font-weight:600">Status never travels alone</h3>
+          <div style="display:flex;flex-direction:column;gap:8px">
+            <sc-for list="{{ statusDemo }}" as="s" hint-placeholder-count="4">
+              <div style="display:flex;align-items:center;gap:10px">
+                <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;font-size:12px;line-height:16px;font-weight:500;background:{{ s.bg }};color:{{ s.fg }};border:1px solid {{ s.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px">{{ s.glyph }}</span>{{ s.label }}</span>
+                <span style="font-size:13px;line-height:19px;color:#4B5563">{{ s.note }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section style="padding:64px 0 0">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">03 — Typography</div>
+      <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Eight steps, one of them numeric</h2>
+      <p style="margin:12px 0 0;max-width:70ch;font-size:14px;line-height:22px;color:#4B5563">IBM Plex Sans for interface text; IBM Plex Mono for identifiers, tokens and keyboard hints. Any figure that appears in a column — rate, margin, date, duration, allocation — takes <span style="font-family:'IBM Plex Mono',monospace">font-variant-numeric: tabular-nums</span> and right alignment.</p>
+      <div style="margin-top:24px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+        <sc-for list="{{ type }}" as="t" hint-placeholder-count="8">
+          <div style="display:grid;grid-template-columns:1.1fr 2.3fr 1.4fr;gap:24px;padding:20px;border-bottom:1px solid #E4E7EC;align-items:center">
+            <div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:18px;color:#101720">{{ t.token }}</div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:18px;color:#667085;font-variant-numeric:tabular-nums">{{ t.spec }}</div>
+            </div>
+            <div style="font-size:{{ t.px }};line-height:{{ t.lh }};font-weight:{{ t.w }};letter-spacing:{{ t.ls }};font-family:{{ t.ff }};text-transform:{{ t.tt }};font-variant-numeric:{{ t.vn }};color:#101720;overflow:hidden;text-overflow:ellipsis">{{ t.sample }}</div>
+            <div style="font-size:13px;line-height:20px;color:#4B5563">{{ t.use }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <section style="padding:64px 0 0">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">04 — Space, shape, depth, motion</div>
+      <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Fixed ramps, no arbitrary values</h2>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:28px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+          <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Spacing — 4px base</h3>
+          <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#4B5563">Dense views use 4–12; page chrome uses 16–32; only the dashboard and marketing-grade surfaces reach 48+.</p>
+          <sc-for list="{{ spacing }}" as="s" hint-placeholder-count="10">
+            <div style="display:grid;grid-template-columns:96px 52px 1fr;gap:12px;align-items:center;padding:5px 0">
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:16px;color:#101720">{{ s.token }}</div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:16px;color:#667085;font-variant-numeric:tabular-nums">{{ s.px }}</div>
+              <div style="height:10px;border-radius:2px;background:#BBD0F6;width:{{ s.px }}"></div>
+            </div>
+          </sc-for>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:16px">
+          <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+            <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Radius &amp; border width</h3>
+            <div style="display:flex;flex-wrap:wrap;gap:12px">
+              <sc-for list="{{ radius }}" as="r" hint-placeholder-count="6">
+                <div style="width:104px">
+                  <div style="height:52px;background:#E8F0FE;border:1px solid #7D8799;border-radius:{{ r.px }}"></div>
+                  <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:15px;color:#101720;margin-top:6px">{{ r.token }}</div>
+                  <div style="font-size:11px;line-height:15px;color:#667085">{{ r.use }}</div>
+                </div>
+              </sc-for>
+            </div>
+            <div style="margin-top:18px;padding-top:16px;border-top:1px solid #E4E7EC;font-size:13px;line-height:21px;color:#4B5563"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px">border/width/hairline 1px</span> · <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">…/emphasis 1.5px</span> (selected row, current Gantt bar) · <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">…/focus 2px</span> (focus ring, always with a 2px offset).</div>
+          </div>
+
+          <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+            <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Elevation</h3>
+            <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#4B5563">In dark mode a shadow alone is invisible, so every dark elevation adds a surface step <em>and</em> a <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">border/subtle</span> hairline.</p>
+            <div style="display:flex;flex-direction:column;gap:12px">
+              <sc-for list="{{ elevation }}" as="e" hint-placeholder-count="5">
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;align-items:stretch">
+                  <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:6px;padding:10px 12px;box-shadow:{{ e.light }}">
+                    <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:16px;color:#101720">{{ e.token }}</div>
+                    <div style="font-size:12px;line-height:17px;color:#667085">{{ e.use }}</div>
+                  </div>
+                  <div style="background:{{ e.darkBg }};border:1px solid #232A35;border-radius:6px;padding:10px 12px;box-shadow:{{ e.dark }}">
+                    <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:16px;color:#E9EEF6">{{ e.darkBg }}</div>
+                    <div style="font-size:12px;line-height:17px;color:#8592A6">dark surface step</div>
+                  </div>
+                </div>
+              </sc-for>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+          <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Motion</h3>
+          <sc-for list="{{ motion }}" as="m" hint-placeholder-count="6">
+            <div style="display:grid;grid-template-columns:150px 96px 1fr;gap:12px;padding:8px 0;border-bottom:1px solid #E4E7EC;align-items:baseline">
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:17px;color:#101720">{{ m.token }}</div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:17px;color:#667085;font-variant-numeric:tabular-nums">{{ m.val }}</div>
+              <div style="font-size:12px;line-height:18px;color:#4B5563">{{ m.use }}</div>
+            </div>
+          </sc-for>
+          <div style="margin-top:14px;font-size:13px;line-height:21px;color:#4B5563"><span style="font-weight:600">Reduced motion — </span>every duration collapses to <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">motion/duration/instant</span>, transforms are dropped and only opacity remains. Gantt auto-scroll becomes a jump; the sync spinner becomes a static glyph with a live-region text update.</div>
+        </div>
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+          <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Z-index</h3>
+          <sc-for list="{{ zindex }}" as="z" hint-placeholder-count="8">
+            <div style="display:grid;grid-template-columns:180px 64px 1fr;gap:12px;padding:8px 0;border-bottom:1px solid #E4E7EC;align-items:baseline">
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:17px;color:#101720">{{ z.token }}</div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:17px;color:#667085;font-variant-numeric:tabular-nums">{{ z.val }}</div>
+              <div style="font-size:12px;line-height:18px;color:#4B5563">{{ z.use }}</div>
+            </div>
+          </sc-for>
+          <div style="margin-top:14px;font-size:13px;line-height:21px;color:#4B5563"><span style="font-weight:600">Stacking rule — </span>Cockpit allows at most two stacked modals (e.g. Edit task → Delete confirm). Each additional modal adds 10 to <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">z/modal</span> and its scrim opacity drops to 24% so the parent stays legible. A third request replaces the second rather than stacking.</div>
+        </div>
+      </div>
+    </section>
+
+    <section style="padding:64px 0 0">
+      <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">05 — Implementation</div>
+      <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Paste-ready custom properties</h2>
+      <p style="margin:12px 0 0;max-width:70ch;font-size:14px;line-height:22px;color:#4B5563">Theme is set by <span style="font-family:'IBM Plex Mono',monospace">data-theme</span> on the root element, defaulting to the OS preference. Component CSS references only these names.</p>
+      <pre style="margin:24px 0 0;background:#0E1116;color:#E9EEF6;border:1px solid #333C4A;border-radius:8px;padding:24px;overflow:auto;font-family:'IBM Plex Mono',monospace;font-size:12.5px;line-height:20px">{{ css }}</pre>
+    </section>
+
+    <section style="padding:64px 0 0">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:28px">
+        <h2 style="margin:0;font-size:20px;line-height:28px;font-weight:600;letter-spacing:-0.015em">Next layers</h2>
+        <p style="margin:10px 0 20px;font-size:14px;line-height:22px;color:#4B5563;max-width:70ch">This document is layer 1 of 5. The remaining layers build only from the tokens above.</p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px">
+          <sc-for list="{{ roadmap }}" as="r" hint-placeholder-count="5">
+            <div style="border:1px solid #E4E7EC;border-radius:6px;padding:14px;background:{{ r.bg }}">
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:15px;color:#667085">{{ r.n }}</div>
+              <div style="font-size:14px;line-height:20px;font-weight:600;margin-top:4px">{{ r.title }}</div>
+              <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:4px">{{ r.body }}</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</div>]]>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1360,&quot;height&quot;:900}}">
+class Component extends DCLogic {
+  renderVals() {
+    const ok = '#0A7A47', warn = '#8A5200';
+    const L = (token, hex, use, against, ratio, dec) => ({ token, hex, use, against, ratio, color: dec ? warn : ok });
+
+    const light = [
+      L('surface/base', '#FFFFFF', 'Cards, tables, modals, drawers', 'app canvas #F6F7F9', '1.06 decorative', true),
+      L('surface/app', '#F6F7F9', 'Page canvas behind all panels', 'surface/base', '1.06 decorative', true),
+      L('surface/sunken', '#F1F3F7', 'Table headers, inset wells, disabled fields', 'surface/base', '1.11 decorative', true),
+      L('surface/overlay', 'rgba(16,23,32,0.48)', 'Modal scrim; 24% when a second modal stacks', 'content beneath', 'n/a', true),
+      L('content/primary', '#101720', 'Body text, table cells, headings', 'surface/base', '18.02:1', false),
+      L('content/secondary', '#4B5563', 'Descriptions, column labels, helper text', 'surface/base', '7.56:1', false),
+      L('content/tertiary', '#667085', 'Metadata, timestamps, placeholder', 'surface/base', '4.97:1', false),
+      L('content/disabled', '#98A2B3', 'Disabled label — always paired with aria-disabled', 'surface/base', '2.58 exempt', true),
+      L('content/inverse', '#FFFFFF', 'Text on accent and on dark tooltips', 'accent/default', '6.39:1', false),
+      L('border/subtle', '#E4E7EC', 'Row rules, card edges — decorative only', 'surface/base', '1.24 decorative', true),
+      L('border/default', '#CBD2DC', 'Section dividers, table gridlines', 'surface/base', '1.52 decorative', true),
+      L('border/strong', '#7D8799', 'Input, checkbox, toggle and Gantt bar edges', 'surface/base', '3.62:1', false),
+      L('border/focus', '#0B57D0', '2px ring, 2px offset, on every focusable', 'surface/base', '6.39:1', false),
+      L('accent/default', '#0B57D0', 'Primary action, links, selection, today marker', 'surface/base', '6.39:1', false),
+      L('accent/hover', '#08429E', 'Hover on primary action and links', 'surface/base', '9.20:1', false),
+      L('accent/active', '#06337A', 'Pressed state', 'surface/base', '12.30:1', false),
+      L('accent/subtle', '#E8F0FE', 'Selected row, active nav, filter chip fill', 'accent/default text', '5.57:1', false),
+      L('accent/onAccent', '#FFFFFF', 'Label on a filled accent surface', 'accent/default', '6.39:1', false),
+      L('status/success/default', '#0A7A47', 'On track, synced, approved', 'surface/base', '5.40:1', false),
+      L('status/success/subtle', '#E3F5EB', 'Pill fill behind success text', 'success/default text', '4.77:1', false),
+      L('status/warning/default', '#8A5200', 'At risk, over-allocated, pending approval', 'surface/base', '6.39:1', false),
+      L('status/warning/subtle', '#FBF0DC', 'Pill fill behind warning text', 'warning/default text', '5.66:1', false),
+      L('status/danger/default', '#B3261E', 'Late, conflict, destructive action, blocked', 'surface/base', '6.54:1', false),
+      L('status/danger/subtle', '#FDE9E7', 'Pill fill, invalid field fill, conflict row', 'danger/default text', '5.60:1', false),
+      L('status/info/default', '#0B57D0', 'Informational banners, baseline overlay', 'surface/base', '6.39:1', false),
+      L('status/info/subtle', '#E8F0FE', 'Info banner fill', 'info/default text', '5.57:1', false)
+    ];
+
+    const D = (token, hex, use, against, ratio, dec) => ({ token, hex, use, against, ratio, color: dec ? '#E9B45A' : '#56D69A' });
+    const dark = [
+      D('surface/base', '#0E1116', 'App canvas — the lowest surface', 'surface/raised', '1.11 decorative', true),
+      D('surface/raised', '#171C24', 'Cards, tables, drawers, menus (+ hairline border)', 'surface/base', '1.11 decorative', true),
+      D('surface/sunken', '#0A0D12', 'Table headers, wells, code and Gantt gutter', 'surface/base', '1.03 decorative', true),
+      D('surface/overlay', 'rgba(4,6,10,0.64)', 'Modal scrim; 32% when a second modal stacks', 'content beneath', 'n/a', true),
+      D('content/primary', '#E9EEF6', 'Body text, table cells, headings', 'surface/base / raised', '16.23:1 / 14.68:1', false),
+      D('content/secondary', '#AFBACA', 'Descriptions, column labels, helper text', 'surface/base / raised', '9.64:1 / 8.71:1', false),
+      D('content/tertiary', '#8592A6', 'Metadata, timestamps, placeholder', 'surface/base / raised', '6.00:1 / 5.42:1', false),
+      D('content/disabled', '#5C6779', 'Disabled label — always paired with aria-disabled', 'surface/base', '3.31 exempt', true),
+      D('content/inverse', '#0B1220', 'Text on accent fills and light tooltips', 'accent/default', '8.52:1', false),
+      D('border/subtle', '#232A35', 'Row rules, card edges — decorative only', 'surface/base', '1.31 decorative', true),
+      D('border/default', '#333C4A', 'Section dividers, table gridlines', 'surface/base', '1.70 decorative', true),
+      D('border/strong', '#748196', 'Input, checkbox, toggle and Gantt bar edges', 'surface/base / raised', '4.79:1 / 4.33:1', false),
+      D('border/focus', '#8FC0FF', '2px ring, 2px offset, on every focusable', 'surface/base / raised', '10.04:1 / 9.08:1', false),
+      D('accent/default', '#7FB0FF', 'Primary action, links, selection, today marker', 'surface/base / raised', '8.61:1 / 7.78:1', false),
+      D('accent/hover', '#A6C8FF', 'Hover on primary action and links', 'surface/raised', '10.36:1', false),
+      D('accent/active', '#5C97F5', 'Pressed state', 'surface/raised', '5.94:1', false),
+      D('accent/subtle', '#16294A', 'Selected row, active nav, filter chip fill', 'accent/default text', '6.59:1', false),
+      D('accent/onAccent', '#0B1220', 'Label on a filled accent surface', 'accent/default', '8.52:1', false),
+      D('status/success/default', '#56D69A', 'On track, synced, approved', 'surface/base', '10.34:1', false),
+      D('status/success/subtle', '#0F2E22', 'Pill fill behind success text', 'success/default text', '8.01:1', false),
+      D('status/warning/default', '#E9B45A', 'At risk, over-allocated, pending approval', 'surface/base', '10.03:1', false),
+      D('status/warning/subtle', '#33240B', 'Pill fill behind warning text', 'warning/default text', '7.97:1', false),
+      D('status/danger/default', '#FF8A80', 'Late, conflict, destructive action, blocked', 'surface/base', '8.28:1', false),
+      D('status/danger/subtle', '#3A1512', 'Pill fill, invalid field fill, conflict row', 'danger/default text', '7.10:1', false),
+      D('status/info/default', '#7FB0FF', 'Informational banners, baseline overlay', 'surface/base', '8.61:1', false),
+      D('status/info/subtle', '#16294A', 'Info banner fill', 'info/default text', '6.59:1', false)
+    ];
+
+    const principles = [
+      { n: 'P1', title: 'The figure is the interface', body: 'Consultants read Cockpit for numbers under time pressure, often on a shared screen in front of a client. Rates, margins, dates and allocation percentages must line up vertically and never reflow between rows.', impl: 'Every numeric column uses type/numeric with tabular figures, right alignment and a fixed decimal count. Currency is never abbreviated in an editable cell; abbreviation is allowed only in summary tiles, where the full value is in the accessible name.' },
+      { n: 'P2', title: 'Density without noise', body: 'A programme view carries hundreds of rows. Grids, stripes and boxes at that scale become texture, and texture hides the exception you were looking for.', impl: 'One accent and four status hues in the whole product. No zebra striping, no vertical gridlines in tables. Separation comes from alignment and space/2–space/3; at most two border weights are visible in any one view.' },
+      { n: 'P3', title: 'Nothing important is implied', body: 'Local-first sync, cost-visibility redaction, baseline drift and permission level all change what the user is looking at without changing the layout. Silence about them is a correctness bug, not a polish issue.', impl: 'The sync chip is present in the top bar of every authenticated screen and announces every transition to a polite live region. Redacted figures, viewer-only mode and drift from baseline each have a persistent on-screen marker, not a tooltip.' },
+      { n: 'P4', title: 'Colour is the second channel', body: 'Status and heat carry decisions: an over-allocated resource in week 32 is a staffing escalation. Anyone with a colour-vision deficiency, on a projector, or printing the plan must read it identically.', impl: 'Every status pill carries a glyph and a word. Allocation heat prints its percentage in the cell and adds a diagonal hatch above 100%. Critical path is a 1.5px outline plus a caret, not a red fill.' },
+      { n: 'P5', title: 'The keyboard is the primary input', body: 'Expert users re-plan a phase faster by typing than by dragging, and drag-only interactions are unusable for assistive-technology users.', impl: 'Every pointer gesture has a stated keyboard equivalent — Gantt bars enter a Move mode with arrow-key nudging at the current zoom grain, and every drag-to-reorder tree has Alt+Arrow. Cmd/Ctrl+K reaches every screen and every project.' },
+      { n: 'P6', title: 'Hidden must look deliberate', body: 'When a viewer\u2019s cost-visibility level forbids a figure, an empty cell reads as a data error and prompts a support ticket — or worse, an assumption that the number is zero.', impl: 'Redaction renders a fixed-width mask with a lock glyph and the reason on focus: “Restricted — needs cost visibility level 2.” Totals that include a redacted component are themselves masked, never silently partial.' }
+    ];
+
+    const statusDemo = [
+      { glyph: '\u2713', label: 'On track', note: 'glyph + word + colour', bg: '#E3F5EB', fg: '#0A7A47', bd: '#9AD9BB' },
+      { glyph: '\u26A0', label: 'At risk', note: 'never amber fill alone', bg: '#FBF0DC', fg: '#8A5200', bd: '#E0C089' },
+      { glyph: '\u2715', label: 'Late', note: 'also sorts to the top', bg: '#FDE9E7', fg: '#B3261E', bd: '#F0B5AF' },
+      { glyph: '\u25CF', label: 'Not started', note: 'neutral, not grey-on-grey', bg: '#F1F3F7', fg: '#4B5563', bd: '#CBD2DC' }
+    ];
+
+    const T = (token, spec, px, lh, w, ls, sample, use, ff, tt, vn) => ({ token, spec, px, lh, w, ls, sample, use, ff: ff || "'IBM Plex Sans',sans-serif", tt: tt || 'none', vn: vn || 'normal' });
+    const type = [
+      T('type/display', '28 / 34 · 600 · -0.02em', '28px', '34px', 600, '-0.02em', 'Portfolio overview', 'Dashboard and auth page titles. One per screen, never inside a panel.'),
+      T('type/heading-lg', '20 / 28 · 600 · -0.015em', '20px', '28px', 600, '-0.015em', 'S/4HANA Migration — Phase plan', 'Screen title in the app shell; modal titles.'),
+      T('type/heading-md', '16 / 22 · 600 · -0.01em', '16px', '22px', 600, '-0.01em', 'Resource allocation', 'Panel, card and drawer headers; form section titles.'),
+      T('type/heading-sm', '12 / 16 · 600 · 0.06em · caps', '12px', '16px', 600, '0.06em', 'Rate card — EMEA', 'Table group headers, eyebrows, sidebar section labels.', null, 'uppercase'),
+      T('type/body', '14 / 20 · 400', '14px', '20px', 400, '0', 'Realization begins once the Explore sign-off is recorded.', 'Default interface text, form values, table cells.'),
+      T('type/body-sm', '13 / 18 · 400', '13px', '18px', 400, '0', 'Dependency: finish-to-start, 2-day lag', 'Dense table rows, Gantt tree rows, secondary descriptions.'),
+      T('type/label', '12 / 16 · 500 · 0.005em', '12px', '16px', 500, '0.005em', 'Allocation %', 'Field labels, chips, captions, badge text, axis labels.'),
+      T('type/numeric', '14 / 20 · 500 · tabular', '14px', '20px', 500, '0', 'EUR 1,248,900.00 · 87.5% · 14 Sep 2026', 'Any figure in a column: rates, margin, dates, durations, allocation.', "'IBM Plex Sans',sans-serif", 'none', 'tabular-nums'),
+      T('type/mono', '13 / 18 · 400', '13px', '18px', 400, '0', 'PRJ-2291 · ⌘K · b8f21c', 'IDs, tokens, keyboard hints, audit-log entries.', "'IBM Plex Mono',monospace")
+    ];
+
+    const spacing = ['space/0 0px', 'space/1 4px', 'space/2 8px', 'space/3 12px', 'space/4 16px', 'space/5 20px', 'space/6 24px', 'space/8 32px', 'space/10 40px', 'space/12 48px', 'space/16 64px']
+      .map(s => ({ token: s.split(' ')[0], px: s.split(' ')[1] }));
+
+    const radius = [
+      { token: 'radius/none', px: '0px', use: 'Gantt bars, table cells' },
+      { token: 'radius/xs', px: '2px', use: 'Checkbox, tag' },
+      { token: 'radius/sm', px: '4px', use: 'Status pill, badge' },
+      { token: 'radius/md', px: '6px', use: 'Button, input, menu item' },
+      { token: 'radius/lg', px: '8px', use: 'Card, panel, modal' },
+      { token: 'radius/full', px: '999px', use: 'Avatar, toggle, chip' }
+    ];
+
+    const elevation = [
+      { token: 'elevation/0 — flat', use: 'Tables, inline panels', light: 'none', dark: 'none', darkBg: '#0E1116' },
+      { token: 'elevation/1 — raised', use: 'Cards, sticky headers', light: '0 1px 2px rgba(16,23,32,0.06)', dark: '0 1px 2px rgba(0,0,0,0.5)', darkBg: '#171C24' },
+      { token: 'elevation/2 — menu', use: 'Dropdown, popover, tooltip', light: '0 4px 12px rgba(16,23,32,0.10)', dark: '0 4px 12px rgba(0,0,0,0.6)', darkBg: '#1D242E' },
+      { token: 'elevation/3 — drawer', use: 'Right / bottom drawer, command palette', light: '0 8px 28px rgba(16,23,32,0.14)', dark: '0 8px 28px rgba(0,0,0,0.68)', darkBg: '#222A35' },
+      { token: 'elevation/4 — modal', use: 'Modal, toast stack', light: '0 16px 48px rgba(16,23,32,0.20)', dark: '0 16px 48px rgba(0,0,0,0.76)', darkBg: '#28313D' }
+    ];
+
+    const motion = [
+      { token: 'duration/instant', val: '0ms', use: 'Reduced-motion substitute for everything below' },
+      { token: 'duration/fast', val: '120ms', use: 'Hover, focus ring, checkbox, tooltip open' },
+      { token: 'duration/base', val: '180ms', use: 'Dropdown, popover, toast enter, tab change' },
+      { token: 'duration/slow', val: '240ms', use: 'Drawer, modal, panel expand/collapse' },
+      { token: 'duration/emphasized', val: '300ms', use: 'Gantt zoom re-scale — the ceiling, never exceeded' },
+      { token: 'easing/standard', val: 'cubic-bezier(.2,0,0,1)', use: 'Anything entering or moving on screen' },
+      { token: 'easing/exit', val: 'cubic-bezier(.4,0,1,1)', use: 'Anything leaving; always faster than its entrance' }
+    ];
+
+    const zindex = [
+      { token: 'z/base', val: '0', use: 'Page content, Gantt canvas' },
+      { token: 'z/sticky', val: '100', use: 'Sticky table header, frozen Gantt tree column' },
+      { token: 'z/dropdown', val: '200', use: 'Select, menu, combobox list, context menu' },
+      { token: 'z/overlay', val: '300', use: 'Drawer scrim and drawer' },
+      { token: 'z/modal', val: '400', use: 'Modal (+10 per stacked modal, max 2)' },
+      { token: 'z/toast', val: '500', use: 'Toast stack, bottom-right, max 3 visible' },
+      { token: 'z/tooltip', val: '600', use: 'Tooltip and coach mark — above everything' }
+    ];
+
+    const roadmap = [
+      { n: 'Layer 1', title: 'Foundations', body: 'Principles and tokens. This document.', bg: '#E8F0FE' },
+      { n: 'Layer 2', title: 'Primitives', body: '32 components, every variant and state, both themes.', bg: '#FFFFFF' },
+      { n: 'Layer 3', title: 'Composites', body: 'App shell, data table, modals, command palette, empty states.', bg: '#FFFFFF' },
+      { n: 'Layer 4', title: 'Domain surfaces', body: 'Gantt, allocation matrix, org chart, RACI, cost, sync and conflict.', bg: '#FFFFFF' },
+      { n: 'Layer 5', title: 'Screens + specs', body: 'Every route in three widths, plus keyboard, focus and a11y annotations.', bg: '#FFFFFF' }
+    ];
+
+    const css = `:root, [data-theme="light"] {
+  --surface-base:#FFFFFF;      --surface-app:#F6F7F9;
+  --surface-sunken:#F1F3F7;    --surface-overlay:rgba(16,23,32,.48);
+  --content-primary:#101720;   --content-secondary:#4B5563;
+  --content-tertiary:#667085;  --content-disabled:#98A2B3;
+  --content-inverse:#FFFFFF;
+  --border-subtle:#E4E7EC;     --border-default:#CBD2DC;
+  --border-strong:#7D8799;     --border-focus:#0B57D0;
+  --accent-default:#0B57D0;    --accent-hover:#08429E;
+  --accent-active:#06337A;     --accent-subtle:#E8F0FE;
+  --accent-on:#FFFFFF;         --accent-border:#BBD0F6;
+  --success-default:#0A7A47;   --success-subtle:#E3F5EB;   --success-border:#9AD9BB;  --success-on:#FFFFFF;
+  --warning-default:#8A5200;   --warning-subtle:#FBF0DC;   --warning-border:#E0C089;  --warning-on:#FFFFFF;
+  --danger-default:#B3261E;    --danger-subtle:#FDE9E7;    --danger-border:#F0B5AF;   --danger-on:#FFFFFF;
+  --info-default:#0B57D0;      --info-subtle:#E8F0FE;      --info-border:#BBD0F6;     --info-on:#FFFFFF;
+  --elevation-1:0 1px 2px rgba(16,23,32,.06);
+  --elevation-2:0 4px 12px rgba(16,23,32,.10);
+  --elevation-3:0 8px 28px rgba(16,23,32,.14);
+  --elevation-4:0 16px 48px rgba(16,23,32,.20);
+}
+[data-theme="dark"] {
+  --surface-base:#0E1116;      --surface-app:#0E1116;
+  --surface-raised:#171C24;    --surface-sunken:#0A0D12;   --surface-overlay:rgba(4,6,10,.64);
+  --content-primary:#E9EEF6;   --content-secondary:#AFBACA;
+  --content-tertiary:#8592A6;  --content-disabled:#5C6779;
+  --content-inverse:#0B1220;
+  --border-subtle:#232A35;     --border-default:#333C4A;
+  --border-strong:#748196;     --border-focus:#8FC0FF;
+  --accent-default:#7FB0FF;    --accent-hover:#A6C8FF;
+  --accent-active:#5C97F5;     --accent-subtle:#16294A;
+  --accent-on:#0B1220;         --accent-border:#2F4E82;
+  --success-default:#56D69A;   --success-subtle:#0F2E22;   --success-border:#2C6B4E;  --success-on:#06170F;
+  --warning-default:#E9B45A;   --warning-subtle:#33240B;   --warning-border:#7A5A22;  --warning-on:#1C1305;
+  --danger-default:#FF8A80;    --danger-subtle:#3A1512;    --danger-border:#8A3A33;   --danger-on:#2A0A07;
+  --info-default:#7FB0FF;      --info-subtle:#16294A;      --info-border:#2F4E82;     --info-on:#0B1220;
+  --elevation-1:0 1px 2px rgba(0,0,0,.50);
+  --elevation-2:0 4px 12px rgba(0,0,0,.60);
+  --elevation-3:0 8px 28px rgba(0,0,0,.68);
+  --elevation-4:0 16px 48px rgba(0,0,0,.76);
+}
+:root {
+  /* surface/raised equals surface/base in light; dark overrides it above */
+  --surface-raised:#FFFFFF;
+
+  --space-0:0px;  --space-1:4px;  --space-2:8px;  --space-3:12px; --space-4:16px;
+  --space-5:20px; --space-6:24px; --space-8:32px; --space-10:40px; --space-12:48px; --space-16:64px;
+
+  --radius-none:0px; --radius-xs:2px; --radius-sm:4px;
+  --radius-md:6px;   --radius-lg:8px; --radius-full:999px;
+
+  --border-hairline:1px; --border-emphasis:1.5px; --border-focus-width:2px; --focus-offset:2px;
+
+  --font-sans:'IBM Plex Sans',system-ui,-apple-system,'Segoe UI',sans-serif;
+  --font-mono:'IBM Plex Mono',ui-monospace,'SFMono-Regular',monospace;
+
+  --type-display:600 28px/34px var(--font-sans);      --ls-display:-.02em;
+  --type-heading-lg:600 20px/28px var(--font-sans);   --ls-heading-lg:-.015em;
+  --type-heading-md:600 16px/22px var(--font-sans);   --ls-heading-md:-.01em;
+  --type-heading-sm:600 12px/16px var(--font-sans);   --ls-heading-sm:.06em;
+  --type-body:400 14px/20px var(--font-sans);
+  --type-body-sm:400 13px/18px var(--font-sans);
+  --type-label:500 12px/16px var(--font-sans);        --ls-label:.005em;
+  --type-numeric:500 14px/20px var(--font-sans);      --numeric-feature:tabular-nums;
+  --type-mono:400 13px/18px var(--font-mono);
+
+  --duration-instant:0ms; --duration-fast:120ms; --duration-base:180ms;
+  --duration-slow:240ms;  --duration-emphasized:300ms;
+  --easing-standard:cubic-bezier(.2,0,0,1);
+  --easing-exit:cubic-bezier(.4,0,1,1);
+
+  --z-base:0; --z-sticky:100; --z-dropdown:200; --z-overlay:300;
+  --z-modal:400; --z-toast:500; --z-tooltip:600;
+}
+.numeric { font: var(--type-numeric); font-variant-numeric: var(--numeric-feature); text-align: right; }
+:where(a,button,input,select,textarea,[tabindex]):focus-visible {
+  outline: var(--border-focus-width) solid var(--border-focus);
+  outline-offset: var(--focus-offset);
+}
+@media (prefers-reduced-motion: reduce) {
+  :root { --duration-fast:0ms; --duration-base:0ms; --duration-slow:0ms; --duration-emphasized:0ms; }
+  *,*::before,*::after { animation-duration:1ms !important; animation-iteration-count:1 !important; transition-duration:1ms !important; }
+}`;
+
+    return { principles, light, dark, statusDemo, type, spacing, radius, elevation, motion, zindex, roadmap, css };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/gantt.html
+++ b/docs/design/gantt.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 28px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4a of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Gantt timeline — working prototype</h1>
+  <p style="margin:16px 0 0;max-width:76ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Loaded with the real shape of the problem: <span style="font-weight:600;color:#101720">{{ phaseCount }} phases</span> and <span style="font-weight:600;color:#101720">{{ taskCount }} tasks</span> across SAP Activate stages and ten workstreams. Rows are windowed — only the ~{{ windowSize }} rows in view exist in the DOM. Click a row to select, press <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">M</kbd> for Move mode, then arrow keys to nudge at the current zoom grain.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#FFFFFF">
+
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #CBD2DC;background:#FFFFFF;flex-wrap:wrap">
+      <div role="radiogroup" aria-label="Zoom" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+        <sc-for list="{{ zoomCells }}" as="z" hint-placeholder-count="4">
+          <button onClick="{{ z.on }}" style="height:26px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ z.bg }};color:{{ z.fg }};border:1px solid {{ z.bd }};box-shadow:{{ z.sh }}">{{ z.label }}</button>
+        </sc-for>
+      </div>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <sc-for list="{{ layerToggles }}" as="t" hint-placeholder-count="4">
+        <button onClick="{{ t.on }}" style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;border-radius:6px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ t.bg }};color:{{ t.fg }};border:1px solid {{ t.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:11px">{{ t.mark }}</span>{{ t.label }}</button>
+      </sc-for>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <button onClick="{{ collapseAll }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Collapse all</button>
+      <button onClick="{{ expandStage }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Expand Realize</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span style="font-variant-numeric:tabular-nums">{{ rowTotal }} rows · {{ windowLabel }} rendered</span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 9px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB;color:#0A7A47;font-size:12px;font-weight:500"><span aria-hidden="true">✓</span>Synced</span>
+      </div>
+    </div>
+
+    <div style="display:flex;border-bottom:1px solid #CBD2DC;background:#F1F3F7">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;display:flex;align-items:center;padding:0 12px;height:56px;gap:8px">
+        <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Phase / task</span>
+        <span style="margin-left:auto;font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Dates</span>
+      </div>
+      <div style="flex:1;overflow:hidden;position:relative;height:56px">
+        <div style="position:absolute;top:0;left:0;height:56px;width:{{ canvasWidth }};transform:translateX({{ axisShift }})">
+          <sc-for list="{{ axisMajor }}" as="a" hint-placeholder-count="8">
+            <div style="position:absolute;top:0;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #CBD2DC;display:flex;align-items:center;padding-left:6px;font-size:11.5px;font-weight:600;color:#101720;overflow:hidden;white-space:nowrap">{{ a.label }}</div>
+          </sc-for>
+          <sc-for list="{{ axisMinor }}" as="a" hint-placeholder-count="20">
+            <div style="position:absolute;top:28px;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #E4E7EC;background:{{ a.bg }};display:flex;align-items:center;justify-content:center;font-size:10.5px;color:{{ a.fg }};font-variant-numeric:tabular-nums;overflow:hidden">{{ a.label }}</div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;height:560px">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;overflow:hidden;position:relative;background:#FFFFFF">
+        <div style="position:absolute;top:0;left:0;right:0;transform:translateY({{ treeShift }})">
+          <sc-for list="{{ rows }}" as="r" hint-placeholder-count="18">
+            <div onClick="{{ r.select }}" style="position:absolute;top:{{ r.top }};left:0;right:0;height:32px;display:flex;align-items:center;gap:6px;padding-left:{{ r.indent }};padding-right:10px;background:{{ r.bg }};box-shadow:{{ r.selBar }};border-bottom:1px solid #F1F3F7;cursor:pointer">
+              <span onClick="{{ r.toggle }}" style="width:16px;flex:none;text-align:center;font-size:9px;color:{{ r.chevFg }};cursor:pointer">{{ r.chev }}</span>
+              <span style="font-size:{{ r.fs }};font-weight:{{ r.fw }};color:{{ r.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+              <sc-if value="{{ r.critical }}" hint-placeholder-val="{{ false }}"><span title="On the critical path" style="flex:none;font-size:10px;color:#B3261E;font-weight:600">▲CP</span></sc-if>
+              <span style="margin-left:auto;flex:none;font-size:11.5px;color:#667085;font-variant-numeric:tabular-nums">{{ r.dates }}</span>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div ref="{{ canvasRef }}" onScroll="{{ onScroll }}" style="flex:1;overflow:auto;position:relative;background:#FFFFFF">
+        <div style="position:relative;width:{{ canvasWidth }};height:{{ canvasHeight }}">
+          <sc-for list="{{ shading }}" as="s" hint-placeholder-count="12">
+            <div title="{{ s.title }}" style="position:absolute;top:0;bottom:0;left:{{ s.left }};width:{{ s.width }};background:{{ s.bg }};border-left:{{ s.bd }}"></div>
+          </sc-for>
+          <div style="position:absolute;top:0;bottom:0;left:{{ todayLeft }};width:2px;background:#0B57D0"></div>
+          <div style="position:absolute;top:{{ todayLabelTop }};left:{{ todayLeft }};transform:translateX(-50%);background:#0B57D0;color:#FFFFFF;font-size:10px;font-weight:600;padding:1px 6px;border-radius:3px;white-space:nowrap">Today</div>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div style="position:absolute;top:{{ b.top }};left:0;right:0;height:32px;background:{{ b.rowBg }};border-bottom:1px solid #F1F3F7"></div>
+          </sc-for>
+
+          <sc-for list="{{ arrows }}" as="a" hint-placeholder-count="6">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:{{ a.w }};height:{{ a.h }};border-right:1.5px solid {{ a.color }};border-bottom:1.5px solid {{ a.color }};border-bottom-right-radius:4px"></div>
+          </sc-for>
+          <sc-for list="{{ arrowHeads }}" as="a" hint-placeholder-count="6">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-left:6px solid {{ a.color }}"></div>
+          </sc-for>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div>
+              <sc-if value="{{ b.hasBaseline }}" hint-placeholder-val="{{ false }}">
+                <div title="Baseline v3" style="position:absolute;top:{{ b.baseTop }};left:{{ b.baseLeft }};width:{{ b.baseWidth }};height:4px;border-radius:2px;background:#98A2B3"></div>
+              </sc-if>
+              <sc-if value="{{ b.isMilestone }}" hint-placeholder-val="{{ false }}">
+                <div title="{{ b.label }}" style="position:absolute;top:{{ b.msTop }};left:{{ b.left }};width:12px;height:12px;background:{{ b.msFill }};border:1.5px solid #101720;transform:rotate(45deg)"></div>
+              </sc-if>
+              <sc-if value="{{ b.isBar }}" hint-placeholder-val="{{ true }}">
+                <div title="{{ b.title }}" style="position:absolute;top:{{ b.barTop }};left:{{ b.left }};width:{{ b.width }};height:{{ b.h }};border-radius:{{ b.radius }};background:{{ b.bg }};border:{{ b.border }};overflow:hidden;box-shadow:{{ b.glow }}">
+                  <div style="position:absolute;top:0;bottom:0;left:0;width:{{ b.progress }};background:{{ b.progressBg }}"></div>
+                  <sc-if value="{{ b.hot }}" hint-placeholder-val="{{ false }}">
+                    <div style="position:absolute;inset:0;background:repeating-linear-gradient(135deg,rgba(16,23,32,0) 0 3px,rgba(16,23,32,.45) 3px 6px)"></div>
+                  </sc-if>
+                  <span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;font-weight:500;color:{{ b.labelFg }};white-space:nowrap;overflow:hidden">{{ b.innerLabel }}</span>
+                </div>
+              </sc-if>
+              <sc-if value="{{ b.outsideLabel }}" hint-placeholder-val="{{ false }}">
+                <div style="position:absolute;top:{{ b.barTop }};left:{{ b.labelLeft }};height:{{ b.h }};display:flex;align-items:center;font-size:11px;color:#101720;white-space:nowrap">{{ b.outsideLabel }}</div>
+              </sc-if>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:14px;padding:8px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }};flex-wrap:wrap">
+      <span style="font-size:12.5px;font-weight:600;color:{{ statusFg }}">{{ statusText }}</span>
+      <span style="font-size:12px;color:#4B5563">{{ statusHint }}</span>
+      <div style="margin-left:auto;display:flex;gap:12px;font-size:11.5px;color:#4B5563;flex-wrap:wrap">
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:8px;border-radius:2px;background:#101720"></span>Phase</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#E8F0FE;border:1px solid #0B57D0"></span>Task</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:10px;height:10px;background:#FFFFFF;border:1.5px solid #101720;transform:rotate(45deg);display:inline-block"></span>Milestone</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;border:1.5px solid #B3261E"></span>Critical ▲CP</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:4px;border-radius:2px;background:#98A2B3"></span>Baseline v3</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:repeating-linear-gradient(135deg,#CBD2DC 0 3px,#4B5563 3px 6px)"></span>Over 100%</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#FBF0DC;border:1px solid #E0C089"></span>Public holiday</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:32px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Geometry</h3>
+      <sc-for list="{{ geometry }}" as="g" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:132px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ g.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ g.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Scale — 80 phases, 1,200 tasks</h3>
+      <sc-for list="{{ scaleRules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Keyboard &amp; drag equivalence</h3>
+      <sc-for list="{{ keys }}" as="k" hint-placeholder-count="10">
+        <div style="display:grid;grid-template-columns:104px 1fr;gap:12px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark canvas</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden;background:#0E1116">
+        <div style="display:flex;height:32px;align-items:center;background:#0A0D12;border-bottom:1px solid #232A35;font-size:11px;color:#AFBACA;padding:0 10px;gap:16px"><span>W41</span><span>W42</span><span>W43</span><span>W44</span></div>
+        <sc-for list="{{ darkBars }}" as="d" hint-placeholder-count="4">
+          <div style="position:relative;height:32px;border-bottom:1px solid #232A35;background:{{ d.rowBg }}">
+            <div style="position:absolute;top:9px;left:{{ d.left }};width:{{ d.w }};height:14px;border-radius:3px;background:{{ d.bg }};border:{{ d.border }};overflow:hidden"><div style="position:absolute;inset:0 auto 0 0;width:{{ d.prog }};background:{{ d.progBg }}"></div><span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;color:{{ d.fg }};white-space:nowrap">{{ d.label }}</span></div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Weekend shading in dark is surface/sunken <span style="font-family:'IBM Plex Mono',monospace">#0A0D12</span> — darker than the canvas rather than lighter, because a lighter band reads as a highlight. Task bars invert: accent/subtle fill with an accent border, progress in full accent carrying content/inverse text.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Collapsed summary &amp; mobile read-only</h3>
+      <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+        <sc-for list="{{ summaryRows }}" as="s" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:1fr 84px;gap:8px;align-items:center;padding:8px 10px;border-bottom:1px solid #E4E7EC">
+            <div>
+              <div style="display:flex;align-items:center;gap:8px"><span style="font-size:13px;font-weight:500">{{ s.name }}</span><span style="display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 7px 0 5px;border-radius:4px;background:{{ s.pillBg }};color:{{ s.pillFg }};border:1px solid {{ s.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ s.pillG }}</span>{{ s.pill }}</span></div>
+              <div style="height:8px;border-radius:999px;background:#E4E7EC;margin-top:6px;overflow:hidden"><div style="height:100%;width:{{ s.pct }};background:{{ s.fill }}"></div></div>
+            </div>
+            <div style="text-align:right;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.dates }}</div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:12px;text-wrap:pretty">This is the mobile experience, and it is deliberate rather than a shrunken canvas: a stage-level list with progress, status and window. Tapping a stage opens its phases in the same form; tapping a phase opens a read-only task list. Editing, drag and dependency work do not exist below 768px — the six phone jobs are read timeline, update % complete, see who is on what this week, approve a request, read health, accept an invite. A single “Open on desktop for editing” link states the boundary instead of hiding it.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:118px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+const STAGES = [
+  { name: 'Prepare', s: 0, e: 62 },
+  { name: 'Explore', s: 48, e: 186 },
+  { name: 'Realize', s: 160, e: 452 },
+  { name: 'Deploy', s: 430, e: 568 },
+  { name: 'Run', s: 556, e: 720 }
+];
+const STREAMS = ['Finance (FI/CO)', 'Logistics (MM/SD/PP)', 'Human Capital', 'Technical (Basis/ABAP)', 'Data Migration', 'Integration', 'Change Management', 'Testing', 'Cutover', 'PMO', 'Analytics', 'Security', 'Training', 'Wave 1', 'Wave 2', 'Hypercare'];
+const TASK_VERBS = ['Workshop', 'Design', 'Build', 'Unit test', 'Config', 'Fit-gap', 'Review', 'Sign-off', 'Load', 'Rehearsal', 'Runbook', 'Handover', 'Audit', 'Dry run', 'Playback'];
+const HOLIDAYS = [
+  { d: 25, n: 'Thaipusam (MY)' }, { d: 48, n: 'Chinese New Year (MY, SG)' }, { d: 49, n: 'Chinese New Year day 2 (MY, SG)' },
+  { d: 86, n: 'Nyepi (ID) / Holi (IN)' }, { d: 116, n: 'Labour Day (MY, SG, VN, IN)' }, { d: 121, n: 'Wesak Day (MY, SG)' },
+  { d: 176, n: 'Hari Raya Haji (MY, SG)' }, { d: 238, n: 'Merdeka Day (MY)' }, { d: 253, n: 'Malaysia Day (MY)' },
+  { d: 282, n: 'Deepavali (MY, SG, IN)' }, { d: 313, n: 'National Day (VN)' }, { d: 359, n: 'Christmas Day (MY, SG, VN)' },
+  { d: 390, n: 'New Year (all regions)' }, { d: 433, n: 'Chinese New Year 2027 (MY, SG)' }, { d: 481, n: 'Labour Day 2027' },
+  { d: 603, n: 'Merdeka Day 2027 (MY)' }, { d: 647, n: 'Deepavali 2027 (MY, SG, IN)' }, { d: 724, n: 'Christmas 2027' }
+];
+const PX = { Day: 26, Week: 8.4, Month: 2.9, Quarter: 1.15 };
+const GRAIN = { Day: 1, Week: 7, Month: 30, Quarter: 90 };
+const DAYS = 730;
+const ROW_H = 32;
+const TODAY = 268;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function seed(n) { const x = Math.sin(n * 12.9898) * 43758.5453; return x - Math.floor(x); }
+function dayLabel(d) {
+  const base = new Date(2026, 0, 5).getTime() + d * 86400000;
+  const dt = new Date(base);
+  return dt.getDate() + ' ' + MONTHS[dt.getMonth()] + ' ' + String(dt.getFullYear()).slice(2);
+}
+function dow(d) { return (d + 0) % 7; }
+
+function buildData() {
+  const phases = [];
+  let taskId = 0;
+  for (let i = 0; i < 80; i++) {
+    const st = STAGES[Math.floor(i / 16)];
+    const k = i % 16;
+    const span = st.e - st.s;
+    const start = Math.round(st.s + (k / 16) * span * 0.45);
+    const dur = Math.round(span * (0.4 + seed(i) * 0.35));
+    const tasks = [];
+    for (let j = 0; j < 15; j++) {
+      const r = seed(i * 31 + j * 7);
+      const tStart = Math.round(start + (j / 15) * dur * 0.8 + r * 4);
+      const tDur = Math.max(2, Math.round(3 + seed(i + j * 3) * 17));
+      const done = tStart + tDur < TODAY ? 100 : tStart > TODAY ? 0 : Math.round(seed(i * 5 + j) * 90);
+      tasks.push({
+        id: 't' + (taskId++), name: TASK_VERBS[j % TASK_VERBS.length] + ' — ' + STREAMS[i % STREAMS.length].split(' ')[0] + ' ' + (j + 1),
+        start: tStart, dur: tDur, done,
+        alloc: 60 + Math.round(seed(i * 9 + j * 11) * 80),
+        critical: (i * 7 + j * 3) % 29 === 0,
+        milestone: j === 14 && i % 4 === 0,
+        baseline: (i + j) % 5 === 0 ? Math.round(seed(i + j) * 8) - 4 : 0
+      });
+    }
+    phases.push({
+      id: 'p' + i, stage: st.name, name: st.name + ' · ' + STREAMS[i % STREAMS.length],
+      start, dur, tasks,
+      done: Math.round(tasks.reduce((a, t) => a + t.done, 0) / tasks.length)
+    });
+  }
+  return phases;
+}
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.data = buildData();
+    this.state = {
+      zoom: 'Week', scrollTop: 0, scrollLeft: 0, viewportW: 900,
+      expanded: { p32: true, p33: true },
+      selected: 'p32', moveMode: false, nudge: {}, pending: 0,
+      showCritical: true, showBaseline: true, showHeat: true, showHolidays: true
+    };
+  }
+
+  componentDidMount() {
+    this._key = (e) => {
+      const k = e.key;
+      if (k === 'm' || k === 'M') { this.setState(s => ({ moveMode: !s.moveMode })); return; }
+      if (!this.state.moveMode) return;
+      const g = GRAIN[this.state.zoom];
+      if (k === 'ArrowRight' || k === 'ArrowLeft') {
+        e.preventDefault();
+        const d = (k === 'ArrowRight' ? 1 : -1) * g * (e.shiftKey ? 4 : 1);
+        this.setState(s => {
+          const n = Object.assign({}, s.nudge);
+          n[s.selected] = (n[s.selected] || 0) + d;
+          return { nudge: n, pending: s.pending + 1 };
+        });
+      }
+      if (k === 'Escape') this.setState(s => { const n = Object.assign({}, s.nudge); delete n[s.selected]; return { nudge: n, moveMode: false }; });
+      if (k === 'Enter') this.setState({ moveMode: false });
+    };
+    window.addEventListener('keydown', this._key);
+  }
+  componentWillUnmount() { window.removeEventListener('keydown', this._key); }
+
+  flat() {
+    const out = [];
+    this.data.forEach(p => {
+      out.push({ kind: 'phase', o: p });
+      if (this.state.expanded[p.id]) p.tasks.forEach(t => out.push({ kind: 'task', o: t, parent: p }));
+    });
+    return out;
+  }
+
+  renderVals() {
+    const S = this.state;
+    const px = PX[S.zoom];
+    const canvasW = DAYS * px;
+    const flat = this.flat();
+    const first = Math.max(0, Math.floor(S.scrollTop / ROW_H) - 4);
+    const count = Math.ceil(560 / ROW_H) + 8;
+    const win = flat.slice(first, first + count);
+    const nudgeOf = (id) => S.nudge[id] || 0;
+
+    const rows = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      return {
+        top: (i * ROW_H) + 'px', indent: isPhase ? '8px' : '32px',
+        name: o.name, fs: isPhase ? '13px' : '12.5px', fw: isPhase ? 600 : 400,
+        fg: isPhase ? '#101720' : '#4B5563',
+        chev: isPhase ? (S.expanded[o.id] ? '▼' : '▶') : '',
+        chevFg: '#4B5563',
+        bg: sel ? '#E8F0FE' : (isPhase ? '#F6F7F9' : '#FFFFFF'),
+        selBar: sel ? 'inset 2px 0 0 #0B57D0' : 'none',
+        critical: !isPhase && o.critical && S.showCritical,
+        dates: dayLabel(st) + ' → ' + dayLabel(st + o.dur),
+        select: () => this.setState({ selected: o.id }),
+        toggle: isPhase ? (e) => { e.stopPropagation(); this.setState(s => { const x = Object.assign({}, s.expanded); x[o.id] = !x[o.id]; return { expanded: x, selected: o.id }; }); } : () => {}
+      };
+    });
+
+    const minBar = 4;
+    const bars = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      const left = st * px;
+      const w = Math.max(minBar, o.dur * px);
+      const label = o.name;
+      const fits = w > label.length * 6.2 + 14;
+      const crit = !isPhase && o.critical && S.showCritical;
+      const hot = !isPhase && S.showHeat && o.alloc > 100;
+      return {
+        top: (i * ROW_H) + 'px',
+        rowBg: sel ? 'rgba(11,87,208,.06)' : (isPhase ? 'rgba(241,243,247,.75)' : 'transparent'),
+        isMilestone: !isPhase && o.milestone,
+        msTop: (i * ROW_H + 10) + 'px', msFill: o.done === 100 ? '#101720' : '#FFFFFF',
+        isBar: !(!isPhase && o.milestone),
+        barTop: (i * ROW_H + (isPhase ? 11 : 9)) + 'px',
+        h: isPhase ? '10px' : '14px',
+        radius: isPhase ? '2px' : '3px',
+        left: left + 'px', width: w + 'px',
+        bg: isPhase ? '#4B5563' : '#E8F0FE',
+        border: isPhase ? '1px solid #101720' : (crit ? '1.5px solid #B3261E' : '1px solid #0B57D0'),
+        glow: sel && !isPhase ? '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' : 'none',
+        progress: (isPhase ? o.done : o.done) + '%',
+        progressBg: isPhase ? '#101720' : '#0B57D0',
+        hot,
+        innerLabel: fits ? (crit ? '▲ ' + label : label) : '',
+        labelFg: isPhase ? '#FFFFFF' : (o.done > 55 ? '#FFFFFF' : '#101720'),
+        outsideLabel: fits ? '' : (crit ? '▲ ' + label : label),
+        labelLeft: (left + w + 6) + 'px',
+        hasBaseline: !isPhase && S.showBaseline && o.baseline !== 0,
+        baseTop: (i * ROW_H + 25) + 'px',
+        baseLeft: ((st + o.baseline) * px) + 'px',
+        baseWidth: Math.max(minBar, o.dur * px) + 'px',
+        title: label + ' · ' + dayLabel(st) + ' → ' + dayLabel(st + o.dur) + (isPhase ? '' : ' · ' + o.done + '% complete · ' + o.alloc + '% allocated' + (o.critical ? ' · critical path' : '')),
+        label
+      };
+    });
+
+    const arrows = [];
+    const arrowHeads = [];
+    win.forEach((n, idx) => {
+      if (n.kind !== 'task' || idx === 0) return;
+      const prev = win[idx - 1];
+      if (prev.kind !== 'task') return;
+      const i = first + idx;
+      const a = prev.o, b = n.o;
+      const ax = (a.start + nudgeOf(a.id) + a.dur) * px;
+      const bx = (b.start + nudgeOf(b.id)) * px;
+      if (bx - ax < 6 || bx - ax > 400) return;
+      const color = (a.critical && b.critical && S.showCritical) ? '#B3261E' : '#7D8799';
+      arrows.push({ left: ax + 'px', top: ((i - 1) * ROW_H + 16) + 'px', w: (bx - ax - 8) + 'px', h: ROW_H + 'px', color });
+      arrowHeads.push({ left: (bx - 8) + 'px', top: (i * ROW_H + 12) + 'px', color });
+    });
+
+    const visFrom = Math.floor(S.scrollLeft / px) - 2;
+    const visTo = visFrom + Math.ceil(S.viewportW / px) + 4;
+    const shading = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let d = Math.max(0, visFrom); d < Math.min(DAYS, visTo); d++) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d === d);
+        if (hol && S.showHolidays) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#FBF0DC', bd: '1px solid #E0C089', title: hol.n });
+        else if (wd === 5 || wd === 6) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#F1F3F7', bd: 'none', title: 'Weekend — non-working' });
+      }
+    }
+
+    const axisMajor = [];
+    const axisMinor = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[(m) % 12] + ' ' + (2026 + Math.floor(m / 12)) });
+      }
+      const step = S.zoom === 'Day' ? 1 : 7;
+      for (let d = Math.max(0, Math.floor(visFrom / step) * step); d < Math.min(DAYS, visTo); d += step) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d >= d && h.d < d + step);
+        axisMinor.push({
+          left: (d * px) + 'px', width: (step * px) + 'px',
+          label: S.zoom === 'Day' ? String(new Date(new Date(2026, 0, 5).getTime() + d * 86400000).getDate()) : 'W' + (Math.floor(d / 7) % 53 + 1),
+          bg: hol && S.showHolidays ? '#FBF0DC' : (S.zoom === 'Day' && (wd === 5 || wd === 6) ? '#F1F3F7' : 'transparent'),
+          fg: hol && S.showHolidays ? '#8A5200' : '#4B5563'
+        });
+      }
+    } else {
+      for (let q = 0; q < 9; q++) {
+        const d0 = Math.round(q * 91.3);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (91.3 * px) + 'px', label: 'Q' + (q % 4 + 1) + ' ' + (2026 + Math.floor(q / 4)) });
+      }
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMinor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[m % 12], bg: 'transparent', fg: '#4B5563' });
+      }
+    }
+
+    const selObj = flat.find(f => f.o.id === S.selected);
+    const nudged = nudgeOf(S.selected);
+    const statusText = S.moveMode
+      ? 'Move mode — ' + (selObj ? selObj.o.name : 'nothing selected')
+      : (selObj ? 'Selected: ' + selObj.o.name : 'Nothing selected');
+    const statusHint = S.moveMode
+      ? '← → nudge by 1 ' + S.zoom.toLowerCase() + (nudged ? ' · moved ' + (nudged > 0 ? '+' : '') + nudged + ' days' : '') + ' · Shift+arrow ×4 · Enter commits · Esc reverts'
+      : 'Press M to move · ' + S.pending + ' change' + (S.pending === 1 ? '' : 's') + ' pending sync';
+
+    return {
+      phaseCount: '80', taskCount: '1,200', windowSize: String(count),
+      rowTotal: flat.length.toLocaleString(),
+      windowLabel: win.length + ' rows',
+      canvasWidth: canvasW + 'px',
+      canvasHeight: (flat.length * ROW_H) + 'px',
+      treeShift: (-S.scrollTop) + 'px',
+      axisShift: (-S.scrollLeft) + 'px',
+      todayLeft: (TODAY * px) + 'px',
+      todayLabelTop: (S.scrollTop + 4) + 'px',
+      rows, bars, arrows, arrowHeads, shading, axisMajor, axisMinor,
+      statusText, statusHint,
+      statusBg: S.moveMode ? '#E8F0FE' : '#F6F7F9',
+      statusFg: S.moveMode ? '#0B57D0' : '#101720',
+      onScroll: (e) => { this._el = e.target; this.setState({ scrollTop: e.target.scrollTop, scrollLeft: e.target.scrollLeft, viewportW: e.target.clientWidth }); },
+      canvasRef: (el) => { if (el) this._el = el; },
+      collapseAll: () => {
+        this.setState({ expanded: {} });
+        if (this._el) { this._el.scrollTop = 0; this.setState({ scrollTop: 0 }); }
+      },
+      expandStage: () => {
+        const x = {};
+        this.data.forEach(p => { if (p.stage === 'Realize') x[p.id] = true; });
+        this.setState({ expanded: x }, () => {
+          const flat2 = this.flat();
+          const idx = flat2.findIndex(f => f.kind === 'phase' && f.o.stage === 'Realize');
+          const startDay = idx >= 0 ? flat2[idx].o.start : 160;
+          const el = this._el;
+          if (el) {
+            el.scrollTop = Math.max(0, idx * ROW_H);
+            el.scrollLeft = Math.max(0, startDay * PX[this.state.zoom] - 80);
+            this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, viewportW: el.clientWidth, selected: flat2[idx].o.id });
+          }
+        });
+      },
+      zoomCells: ['Day', 'Week', 'Month', 'Quarter'].map(z => ({
+        label: z,
+        bg: S.zoom === z ? '#FFFFFF' : 'transparent',
+        fg: S.zoom === z ? '#101720' : '#4B5563',
+        bd: S.zoom === z ? '#7D8799' : 'transparent',
+        sh: S.zoom === z ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => this.setState({ zoom: z })
+      })),
+      layerToggles: [
+        { key: 'showCritical', label: 'Critical path' },
+        { key: 'showBaseline', label: 'Baseline v3' },
+        { key: 'showHeat', label: 'Allocation heat' },
+        { key: 'showHolidays', label: 'Holidays' }
+      ].map(t => ({
+        label: t.label,
+        mark: S[t.key] ? '✓' : '○',
+        bg: S[t.key] ? '#E8F0FE' : '#FFFFFF',
+        fg: S[t.key] ? '#0B57D0' : '#4B5563',
+        bd: S[t.key] ? '#BBD0F6' : '#CBD2DC',
+        on: () => this.setState(s => { const o = {}; o[t.key] = !s[t.key]; return o; })
+      })),
+
+      geometry: [
+        { k: 'Row height', v: '32px standard, 28px compact. Both keep 13px/12.5px text — density never comes from shrinking type.' },
+        { k: 'Bar heights', v: 'Phase 10px with square caps, task 14px, milestone a 12px diamond centred on the row, baseline a 4px bar 2px below the current bar.' },
+        { k: 'Minimum bar', v: '4px. Below that a bar is unclickable, so a sub-grain task renders at 4px with a 24px invisible hit area and its label always outside.' },
+        { k: 'Label overflow', v: 'A label needs width ≥ 6.2 × characters + 14px padding. Below that it moves outside the bar’s right edge in content/primary; below 60px of free canvas it becomes a tooltip only, and the tree column remains the reliable place to read the name.' },
+        { k: 'Zoom grain', v: 'Day 26px, Week 8.4px, Month 2.9px, Quarter 1.15px per day. Weekend and holiday shading render at Day and Week only — at Month a single day is 2.9px and shading becomes noise.' },
+        { k: 'Sticky left', v: 'The 392px tree pane is a separate scroll-locked pane translated by the canvas scrollTop, so it never repaints on horizontal scroll and never detaches vertically.' },
+        { k: 'Today marker', v: '2px accent line spanning the full canvas height with a pinned label that follows the vertical scroll, so it is legible at row 800 as well as row 1.' },
+        { k: 'Dependency arrows', v: 'Orthogonal, 1.5px, border/strong; critical-path links inherit status/danger. Drawn only between rows currently in the window — off-window predecessors show a ◀ stub on the successor bar.' }
+      ],
+      scaleRules: [
+        'All 80 phases collapse by default. Nothing above 40 rows auto-expands, because a plan that opens 1,280 rows deep cannot be read and costs a second of layout.',
+        'Vertical windowing renders ~' + count + ' rows regardless of dataset size; the scroll container is sized by row count so the scrollbar stays honest.',
+        'Horizontal windowing: shading and axis ticks are generated only for the visible day range plus 2 days of bleed. At Quarter zoom the whole 730-day range is 840px, so nothing is windowed horizontally.',
+        'Bars are plain absolutely-positioned divs, not SVG — 30 divs beat one 1,200-node SVG for scroll performance, and each bar keeps a real DOM node for focus and ARIA.',
+        'Expand-all is deliberately absent. “Expand stage” is offered instead, because a stage is the largest unit a person can scan.',
+        'Filtering (workstream, region, status, resource) reduces the flat list before windowing, so a filtered plan of 40 rows scrolls like a 40-row plan.',
+        'The tree pane truncates names with an ellipsis and never wraps: a wrapped name would desynchronise the two panes’ row heights, which is the one failure a split Gantt cannot recover from.'
+      ],
+      keys: [
+        { k: '↑ ↓', v: 'Move the row cursor. Selection follows focus; the canvas scrolls to keep the row visible.' },
+        { k: '← →', v: 'Collapse / expand the focused phase. On a task, jump to its predecessor / successor.' },
+        { k: 'M', v: 'Toggle Move mode on the selected bar. The status bar turns accent and states the grain.' },
+        { k: '← → (move)', v: 'Nudge by one zoom grain — 1 day, 1 week, 1 month, 1 quarter. Shift multiplies by 4.' },
+        { k: '⌥ ← →', v: 'Resize: move the finish date only, leaving the start fixed.' },
+        { k: 'Enter', v: 'Commit the move. Escape reverts to the position before Move mode was entered.' },
+        { k: '⌥ ↑ ↓', v: 'Reorder the focused task within its phase — the keyboard equivalent of drag-reorder.' },
+        { k: 'Space', v: 'Add to multi-selection. Shift+↑↓ extends a contiguous selection.' },
+        { k: '+ / −', v: 'Zoom in / out one step, anchored on the selected bar rather than the viewport centre.' },
+        { k: 'T', v: 'Scroll to today. G then C opens the critical-path drawer.' }
+      ],
+      a11y: [
+        { k: 'Structure', v: 'The tree is role="treegrid" with aria-level, aria-expanded, aria-posinset and aria-setsize; the canvas row is the same row element extended, so the two panes are one grid to assistive tech, not two.' },
+        { k: 'Bar name', v: '“Unit test — Finance 4, task, Realize · Finance, 12 to 26 October 2026, 15 working days, 60% complete, 120% allocated, on critical path.” Everything the colour and hatch encode is in the name.' },
+        { k: 'Move mode', v: 'Entering announces “Move mode. Left and right arrows move by one week.” Each nudge announces the new start date only — not the whole name — so repeated nudging stays usable.' },
+        { k: 'Windowing', v: 'aria-rowcount is the full flat count (1,280 when everything is expanded), aria-rowindex is absolute, so a screen reader reports “row 812 of 1,280” correctly.' },
+        { k: 'Dependencies', v: 'aria-describedby on the successor references a hidden node listing its predecessors; ← and → navigate the dependency graph directly rather than requiring the user to find an arrow.' },
+        { k: 'Non-working days', v: 'Weekend and holiday shading is decorative in the canvas; the same information is in each bar’s accessible name as working-day counts and in the date-picker cell names.' },
+        { k: 'Reduced motion', v: 'Scroll-to-row becomes an instant jump, zoom re-scale drops its 300ms transition, and the today marker never pulses.' }
+      ],
+      darkBars: [
+        { rowBg: '#171C24', left: '12px', w: '150px', bg: '#3D4757', border: '1px solid #E9EEF6', prog: '62%', progBg: '#8592A6', fg: '#E9EEF6', label: 'Realize · Finance' },
+        { rowBg: '#171C24', left: '40px', w: '96px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '80%', progBg: '#7FB0FF', fg: '#0B1220', label: 'Fit-gap 3' },
+        { rowBg: '#16294A', left: '96px', w: '120px', bg: '#16294A', border: '1.5px solid #FF8A80', prog: '35%', progBg: '#7FB0FF', fg: '#E9EEF6', label: '▲ Mock conversion 3' },
+        { rowBg: '#171C24', left: '150px', w: '64px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '0%', progBg: '#7FB0FF', fg: '#E9EEF6', label: 'Sign-off' }
+      ],
+      summaryRows: [
+        { name: 'Prepare', pct: '100%', fill: '#0A7A47', dates: '05 Jan – 09 Mar', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Explore', pct: '100%', fill: '#0A7A47', dates: '23 Feb – 13 Jul', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Realize', pct: '62%', fill: '#0B57D0', dates: '14 Jun – 03 Apr 27', pill: 'At risk', pillG: '⚠', pillBg: '#FBF0DC', pillFg: '#8A5200', pillBd: '#E0C089' },
+        { name: 'Deploy', pct: '8%', fill: '#0B57D0', dates: '12 Mar – 27 Jul 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Run', pct: '0%', fill: '#0B57D0', dates: '15 Jul – 26 Dec 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/gantt2.html
+++ b/docs/design/gantt2.html
@@ -1,0 +1,702 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 28px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4a of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Gantt timeline — working prototype</h1>
+  <p style="margin:16px 0 0;max-width:76ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Loaded with the real shape of the problem: <span style="font-weight:600;color:#101720">{{ phaseCount }} phases</span> and <span style="font-weight:600;color:#101720">{{ taskCount }} tasks</span> across SAP Activate stages and ten workstreams. Rows are windowed — only the ~{{ windowSize }} rows in view exist in the DOM. Click a row to select, press <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">M</kbd> for Move mode, then arrow keys to nudge at the current zoom grain.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#FFFFFF">
+
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #CBD2DC;background:#FFFFFF;flex-wrap:wrap">
+      <div role="radiogroup" aria-label="Zoom" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+        <sc-for list="{{ zoomCells }}" as="z" hint-placeholder-count="4">
+          <button onClick="{{ z.on }}" style="height:26px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ z.bg }};color:{{ z.fg }};border:1px solid {{ z.bd }};box-shadow:{{ z.sh }}">{{ z.label }}</button>
+        </sc-for>
+      </div>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <sc-for list="{{ layerToggles }}" as="t" hint-placeholder-count="4">
+        <button onClick="{{ t.on }}" style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;border-radius:6px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ t.bg }};color:{{ t.fg }};border:1px solid {{ t.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:11px">{{ t.mark }}</span>{{ t.label }}</button>
+      </sc-for>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <button onClick="{{ collapseAll }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Collapse all</button>
+      <button onClick="{{ expandStage }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Expand Realize</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span style="font-variant-numeric:tabular-nums">{{ rowTotal }} rows · {{ windowLabel }} rendered</span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 9px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB;color:#0A7A47;font-size:12px;font-weight:500"><span aria-hidden="true">✓</span>Synced</span>
+      </div>
+    </div>
+
+    <div style="display:flex;border-bottom:1px solid #CBD2DC;background:#F1F3F7">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;display:flex;align-items:center;padding:0 12px;height:56px;gap:8px">
+        <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Phase / task</span>
+        <span style="margin-left:auto;font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Dates</span>
+      </div>
+      <div style="flex:1;overflow:hidden;position:relative;height:56px">
+        <div style="position:absolute;top:0;left:0;height:56px;width:{{ canvasWidth }};transform:translateX({{ axisShift }})">
+          <sc-for list="{{ axisMajor }}" as="a" hint-placeholder-count="8">
+            <div style="position:absolute;top:0;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #CBD2DC;display:flex;align-items:center;padding-left:6px;font-size:11.5px;font-weight:600;color:#101720;overflow:hidden;white-space:nowrap">{{ a.label }}</div>
+          </sc-for>
+          <sc-for list="{{ axisMinor }}" as="a" hint-placeholder-count="20">
+            <div style="position:absolute;top:28px;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #E4E7EC;background:{{ a.bg }};display:flex;align-items:center;justify-content:center;font-size:10.5px;color:{{ a.fg }};font-variant-numeric:tabular-nums;overflow:hidden">{{ a.label }}</div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div role="treegrid" aria-label="Programme timeline" tabindex="0" onKeyDown="{{ onKey }}" style="display:flex;height:560px;outline:none">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;overflow:hidden;position:relative;background:#FFFFFF">
+        <div style="position:absolute;top:0;left:0;right:0;transform:translateY({{ treeShift }})">
+          <sc-for list="{{ rows }}" as="r" hint-placeholder-count="18">
+            <div role="row" aria-level="{{ r.level }}" aria-selected="{{ r.sel }}" aria-rowindex="{{ r.rowIndex }}" tabindex="{{ r.tab }}" onClick="{{ r.select }}" style="position:absolute;top:{{ r.top }};left:0;right:0;height:32px;display:flex;align-items:center;gap:6px;padding-left:{{ r.indent }};padding-right:10px;background:{{ r.bg }};box-shadow:{{ r.selBar }};border-bottom:1px solid #F1F3F7;cursor:pointer">
+              <span onClick="{{ r.toggle }}" style="width:16px;flex:none;text-align:center;font-size:9px;color:{{ r.chevFg }};cursor:pointer">{{ r.chev }}</span>
+              <span style="font-size:{{ r.fs }};font-weight:{{ r.fw }};color:{{ r.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+              <sc-if value="{{ r.critical }}" hint-placeholder-val="{{ false }}"><span title="On the critical path" style="flex:none;font-size:10px;color:#B3261E;font-weight:600">▲CP</span></sc-if>
+              <span style="margin-left:auto;flex:none;font-size:11.5px;color:#667085;font-variant-numeric:tabular-nums">{{ r.dates }}</span>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div ref="{{ canvasRef }}" onScroll="{{ onScroll }}" style="flex:1;overflow:auto;position:relative;background:#FFFFFF">
+        <div style="position:relative;width:{{ canvasWidth }};height:{{ canvasHeight }}">
+          <sc-for list="{{ shading }}" as="s" hint-placeholder-count="12">
+            <div title="{{ s.title }}" style="position:absolute;top:0;bottom:0;left:{{ s.left }};width:{{ s.width }};background:{{ s.bg }};border-left:{{ s.bd }}"></div>
+          </sc-for>
+          <div style="position:absolute;top:0;bottom:0;left:{{ todayLeft }};width:2px;background:#0B57D0"></div>
+          <div style="position:absolute;top:{{ todayLabelTop }};left:{{ todayLeft }};transform:translateX(-50%);background:#0B57D0;color:#FFFFFF;font-size:10px;font-weight:600;padding:1px 6px;border-radius:3px;white-space:nowrap">Today</div>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div style="position:absolute;top:{{ b.top }};left:0;right:0;height:32px;background:{{ b.rowBg }};border-bottom:1px solid #F1F3F7"></div>
+          </sc-for>
+
+          <sc-for list="{{ segs }}" as="a" hint-placeholder-count="12">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:{{ a.w }};height:{{ a.h }};background:{{ a.color }}"></div>
+          </sc-for>
+          <sc-for list="{{ arrowHeads }}" as="a" hint-placeholder-count="6">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-left:6px solid {{ a.color }}"></div>
+          </sc-for>
+          <sc-for list="{{ stubs }}" as="a" hint-placeholder-count="4">
+            <div title="{{ a.title }}" tabindex="-1" style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-right:6px solid {{ a.color }}"></div>
+          </sc-for>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div>
+              <sc-if value="{{ b.hasBaseline }}" hint-placeholder-val="{{ false }}">
+                <div title="Baseline v3" style="position:absolute;top:{{ b.baseTop }};left:{{ b.baseLeft }};width:{{ b.baseWidth }};height:4px;border-radius:2px;background:#98A2B3"></div>
+              </sc-if>
+              <sc-if value="{{ b.isMilestone }}" hint-placeholder-val="{{ false }}">
+                <div title="{{ b.label }}" style="position:absolute;top:{{ b.msTop }};left:{{ b.left }};width:12px;height:12px;background:{{ b.msFill }};border:1.5px solid #101720;transform:rotate(45deg)"></div>
+              </sc-if>
+              <sc-if value="{{ b.isBar }}" hint-placeholder-val="{{ true }}">
+                <div title="{{ b.title }}" style="position:absolute;top:{{ b.barTop }};left:{{ b.left }};width:{{ b.width }};height:{{ b.h }};border-radius:{{ b.radius }};background:{{ b.bg }};border:{{ b.border }};overflow:hidden;box-shadow:{{ b.glow }}">
+                  <div style="position:absolute;top:0;bottom:0;left:0;width:{{ b.progress }};background:{{ b.progressBg }}"></div>
+                  <sc-if value="{{ b.hot }}" hint-placeholder-val="{{ false }}">
+                    <div style="position:absolute;inset:0;background:repeating-linear-gradient(135deg,rgba(16,23,32,0) 0 3px,rgba(16,23,32,.45) 3px 6px)"></div>
+                  </sc-if>
+                  <span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;font-weight:500;color:{{ b.labelFg }};white-space:nowrap;overflow:hidden">{{ b.innerLabel }}</span>
+                  <span aria-hidden="true" style="position:absolute;top:0;left:0;bottom:0;width:{{ b.progress }};overflow:hidden"><span style="position:absolute;top:0;left:0;height:100%;width:{{ b.width }};display:flex;align-items:center;padding:0 6px;font-size:11px;font-weight:500;color:{{ b.labelFgFilled }};white-space:nowrap;box-sizing:border-box">{{ b.innerLabel }}</span></span>
+                </div>
+              </sc-if>
+              <sc-if value="{{ b.outsideLabel }}" hint-placeholder-val="{{ false }}">
+                <div style="position:absolute;top:{{ b.barTop }};left:{{ b.labelLeft }};height:{{ b.h }};display:flex;align-items:center;font-size:11px;color:#101720;white-space:nowrap">{{ b.outsideLabel }}</div>
+              </sc-if>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div id="gantt-status" role="status" aria-live="polite" aria-atomic="true" style="display:flex;align-items:flex-start;gap:10px;padding:8px 14px;border-top:1px solid #CBD2DC;background:#FFFFFF">
+      <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">Announced</span>
+      <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:14px;padding:8px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }};flex-wrap:wrap">
+      <span style="font-size:12.5px;font-weight:600;color:{{ statusFg }}">{{ statusText }}</span>
+      <span style="font-size:12px;color:#4B5563">{{ statusHint }}</span>
+      <div style="margin-left:auto;display:flex;gap:12px;font-size:11.5px;color:#4B5563;flex-wrap:wrap">
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:8px;border-radius:2px;background:#101720"></span>Phase</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#E8F0FE;border:1px solid #0B57D0"></span>Task</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:10px;height:10px;background:#FFFFFF;border:1.5px solid #101720;transform:rotate(45deg);display:inline-block"></span>Milestone</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;border:1.5px solid #B3261E"></span>Critical ▲CP</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:4px;border-radius:2px;background:#98A2B3"></span>Baseline v3</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:repeating-linear-gradient(135deg,#CBD2DC 0 3px,#4B5563 3px 6px)"></span>Over 100%</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#FBF0DC;border:1px solid #E0C089"></span>Public holiday</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:32px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Geometry</h3>
+      <sc-for list="{{ geometry }}" as="g" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:132px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ g.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ g.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Scale — 80 phases, 1,200 tasks</h3>
+      <sc-for list="{{ scaleRules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Dependencies</h3>
+      <sc-for list="{{ depLegend }}" as="d" hint-placeholder-count="4">
+        <div style="display:grid;grid-template-columns:74px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ d.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ d.v }}</div></div>
+      </sc-for>
+      <h3 style="margin:20px 0 10px;font-size:16px;line-height:22px;font-weight:600">Announcements</h3>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">The strip above the legend is the Gantt’s <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">#gantt-status</span> region — <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">role="status" aria-live="polite" aria-atomic="true"</span> — shown visibly here so the announcement can be reviewed. In the product it is visually hidden and the sync chip owns everything about sync, exactly as Layer 3 specifies. It is written on cursor movement, expand/collapse, Move-mode entry and exit, each nudge, commit and revert.</div>
+      <div style="margin-top:10px;display:flex;flex-direction:column;gap:6px">
+        <sc-for list="{{ sayExamples }}" as="s" hint-placeholder-count="5">
+          <div style="font-size:12px;line-height:18px;color:#101720;background:#F1F3F7;border:1px solid #E4E7EC;border-radius:4px;padding:6px 8px"><span style="font-family:'IBM Plex Mono',monospace;color:#0B57D0">{{ s.k }}</span> — “{{ s.v }}”</div>
+        </sc-for>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Keyboard &amp; drag equivalence</h3>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-bottom:10px">Keys are bound to the <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">role="treegrid"</span> element, not the window, so M types an M inside a text field and the timeline only responds when it holds focus. One tab stop enters the grid; the row cursor is a roving tabindex.</div>
+      <sc-for list="{{ keys }}" as="k" hint-placeholder-count="10">
+        <div style="display:grid;grid-template-columns:104px 1fr;gap:12px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark canvas</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden;background:#0E1116">
+        <div style="display:flex;height:32px;align-items:center;background:#0A0D12;border-bottom:1px solid #232A35;font-size:11px;color:#AFBACA;padding:0 10px;gap:16px"><span>W41</span><span>W42</span><span>W43</span><span>W44</span></div>
+        <sc-for list="{{ darkBars }}" as="d" hint-placeholder-count="4">
+          <div style="position:relative;height:32px;border-bottom:1px solid #232A35;background:{{ d.rowBg }}">
+            <div style="position:absolute;top:9px;left:{{ d.left }};width:{{ d.w }};height:14px;border-radius:3px;background:{{ d.bg }};border:{{ d.border }};overflow:hidden"><div style="position:absolute;inset:0 auto 0 0;width:{{ d.prog }};background:{{ d.progBg }}"></div><span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;color:{{ d.fg }};white-space:nowrap">{{ d.label }}</span></div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Weekend shading in dark is surface/sunken <span style="font-family:'IBM Plex Mono',monospace">#0A0D12</span> — darker than the canvas rather than lighter, because a lighter band reads as a highlight. Task bars invert: accent/subtle fill with an accent border, progress in full accent carrying content/inverse text.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Collapsed summary &amp; mobile read-only</h3>
+      <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+        <sc-for list="{{ summaryRows }}" as="s" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:1fr 84px;gap:8px;align-items:center;padding:8px 10px;border-bottom:1px solid #E4E7EC">
+            <div>
+              <div style="display:flex;align-items:center;gap:8px"><span style="font-size:13px;font-weight:500">{{ s.name }}</span><span style="display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 7px 0 5px;border-radius:4px;background:{{ s.pillBg }};color:{{ s.pillFg }};border:1px solid {{ s.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ s.pillG }}</span>{{ s.pill }}</span></div>
+              <div style="height:8px;border-radius:999px;background:#E4E7EC;margin-top:6px;overflow:hidden"><div style="height:100%;width:{{ s.pct }};background:{{ s.fill }}"></div></div>
+            </div>
+            <div style="text-align:right;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.dates }}</div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:12px;text-wrap:pretty">This is the mobile experience, and it is deliberate rather than a shrunken canvas: a stage-level list with progress, status and window. Tapping a stage opens its phases in the same form; tapping a phase opens a read-only task list. Editing, drag and dependency work do not exist below 768px — the six phone jobs are read timeline, update % complete, see who is on what this week, approve a request, read health, accept an invite. A single “Open on desktop for editing” link states the boundary instead of hiding it.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:118px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+const STAGES = [
+  { name: 'Prepare', s: 0, e: 62 },
+  { name: 'Explore', s: 48, e: 186 },
+  { name: 'Realize', s: 160, e: 452 },
+  { name: 'Deploy', s: 430, e: 568 },
+  { name: 'Run', s: 556, e: 720 }
+];
+const STREAMS = ['Finance (FI/CO)', 'Logistics (MM/SD/PP)', 'Human Capital', 'Technical (Basis/ABAP)', 'Data Migration', 'Integration', 'Change Management', 'Testing', 'Cutover', 'PMO', 'Analytics', 'Security', 'Training', 'Wave 1', 'Wave 2', 'Hypercare'];
+const TASK_VERBS = ['Workshop', 'Design', 'Build', 'Unit test', 'Config', 'Fit-gap', 'Review', 'Sign-off', 'Load', 'Rehearsal', 'Runbook', 'Handover', 'Audit', 'Dry run', 'Playback'];
+const HOLIDAYS = [
+  { d: 25, n: 'Thaipusam (MY)' }, { d: 48, n: 'Chinese New Year (MY, SG)' }, { d: 49, n: 'Chinese New Year day 2 (MY, SG)' },
+  { d: 86, n: 'Nyepi (ID) / Holi (IN)' }, { d: 116, n: 'Labour Day (MY, SG, VN, IN)' }, { d: 121, n: 'Wesak Day (MY, SG)' },
+  { d: 176, n: 'Hari Raya Haji (MY, SG)' }, { d: 238, n: 'Merdeka Day (MY)' }, { d: 253, n: 'Malaysia Day (MY)' },
+  { d: 282, n: 'Deepavali (MY, SG, IN)' }, { d: 313, n: 'National Day (VN)' }, { d: 359, n: 'Christmas Day (MY, SG, VN)' },
+  { d: 390, n: 'New Year (all regions)' }, { d: 433, n: 'Chinese New Year 2027 (MY, SG)' }, { d: 481, n: 'Labour Day 2027' },
+  { d: 603, n: 'Merdeka Day 2027 (MY)' }, { d: 647, n: 'Deepavali 2027 (MY, SG, IN)' }, { d: 724, n: 'Christmas 2027' }
+];
+const PX = { Day: 26, Week: 8.4, Month: 2.9, Quarter: 1.15 };
+const GRAIN = { Day: 1, Week: 7, Month: 30, Quarter: 90 };
+const DAYS = 730;
+const ROW_H = 32;
+const TODAY = 268;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function seed(n) { const x = Math.sin(n * 12.9898) * 43758.5453; return x - Math.floor(x); }
+function dayLabel(d) {
+  const base = new Date(2026, 0, 5).getTime() + d * 86400000;
+  const dt = new Date(base);
+  return dt.getDate() + ' ' + MONTHS[dt.getMonth()] + ' ' + String(dt.getFullYear()).slice(2);
+}
+function dow(d) { return (d + 0) % 7; }
+
+function buildData() {
+  const phases = [];
+  let taskId = 0;
+  for (let i = 0; i < 80; i++) {
+    const st = STAGES[Math.floor(i / 16)];
+    const k = i % 16;
+    const span = st.e - st.s;
+    const start = Math.round(st.s + (k / 16) * span * 0.45);
+    const dur = Math.round(span * (0.4 + seed(i) * 0.35));
+    const tasks = [];
+    for (let j = 0; j < 15; j++) {
+      const r = seed(i * 31 + j * 7);
+      const tStart = Math.round(start + (j / 15) * dur * 0.8 + r * 4);
+      const tDur = Math.max(2, Math.round(3 + seed(i + j * 3) * 17));
+      const done = tStart + tDur < TODAY ? 100 : tStart > TODAY ? 0 : Math.round(seed(i * 5 + j) * 90);
+      taskId++;
+      const deps = [];
+      if (j > 0) deps.push({ id: 'p' + i + '_t' + (j - 1), type: 'FS', lag: (i + j) % 7 === 0 ? 2 : 0 });
+      if (j === 0 && i > 0) deps.push({ id: 'p' + (i - 1) + '_t14', type: 'FS', lag: 0, cross: true });
+      if (j === 7 && i % 3 === 0 && i > 2) deps.push({ id: 'p' + (i - 3) + '_t9', type: 'SS', lag: 0, cross: true });
+      tasks.push({
+        id: 'p' + i + '_t' + j, deps,
+        name: TASK_VERBS[j % TASK_VERBS.length] + ' — ' + STREAMS[i % STREAMS.length].split(' ')[0] + ' ' + (j + 1),
+        start: tStart, dur: tDur, done,
+        alloc: 60 + Math.round(seed(i * 9 + j * 11) * 80),
+        critical: (i * 7 + j * 3) % 29 === 0,
+        milestone: j === 14 && i % 4 === 0,
+        baseline: (i + j) % 5 === 0 ? Math.round(seed(i + j) * 8) - 4 : 0
+      });
+    }
+    phases.push({
+      id: 'p' + i, stage: st.name, name: st.name + ' · ' + STREAMS[i % STREAMS.length],
+      start, dur, tasks,
+      done: Math.round(tasks.reduce((a, t) => a + t.done, 0) / tasks.length)
+    });
+  }
+  return phases;
+}
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.data = buildData();
+    this.state = {
+      zoom: 'Week', scrollTop: 0, scrollLeft: 0, viewportW: 900,
+      expanded: { p32: true, p33: true },
+      selected: 'p32', cursor: 32, moveMode: false, nudge: {}, pending: 0,
+      announce: 'Timeline ready. 80 phases, 1,200 tasks. Use up and down arrows to move the row cursor, M to move the selected bar.', preMove: null,
+      showCritical: true, showBaseline: true, showHeat: true, showHolidays: true
+    };
+  }
+
+  say(msg) { this.setState({ announce: msg }); }
+
+  scrollRowIntoView(idx) {
+    const el = this._el;
+    if (!el) return;
+    const top = idx * ROW_H;
+    if (top < el.scrollTop) el.scrollTop = top;
+    else if (top + ROW_H > el.scrollTop + el.clientHeight) el.scrollTop = top + ROW_H - el.clientHeight;
+    this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, viewportW: el.clientWidth });
+  }
+
+  moveCursor(delta) {
+    const flat = this.flat();
+    const next = Math.max(0, Math.min(flat.length - 1, this.state.cursor + delta));
+    const n = flat[next];
+    this.setState({ cursor: next, selected: n.o.id }, () => this.scrollRowIntoView(next));
+    const st = n.o.start + (this.state.nudge[n.o.id] || 0);
+    this.say(n.o.name + ', ' + (n.kind === 'phase' ? 'phase, ' + (this.state.expanded[n.o.id] ? 'expanded' : 'collapsed') : 'task, level 2') +
+      ', ' + dayLabel(st) + ' to ' + dayLabel(st + n.o.dur) + ', row ' + (next + 1) + ' of ' + flat.length + '.');
+  }
+
+  onKey(e) {
+    const k = e.key;
+    const flat = this.flat();
+    const cur = flat[Math.min(this.state.cursor, flat.length - 1)];
+    if (!cur) return;
+    const S = this.state;
+    if (k === 'ArrowDown') { e.preventDefault(); this.moveCursor(1); return; }
+    if (k === 'ArrowUp') { e.preventDefault(); this.moveCursor(-1); return; }
+    if (k === 'm' || k === 'M') {
+      e.preventDefault();
+      if (!S.moveMode) {
+        this.setState({ moveMode: true, preMove: S.nudge[cur.o.id] || 0 });
+        this.say('Move mode on. ' + cur.o.name + '. Left and right arrows move by one ' + S.zoom.toLowerCase() + '. Enter commits, Escape reverts.');
+      } else {
+        this.setState({ moveMode: false });
+        this.say('Move mode off.');
+      }
+      return;
+    }
+    if (S.moveMode) {
+      if (k === 'ArrowRight' || k === 'ArrowLeft') {
+        e.preventDefault();
+        const g = GRAIN[S.zoom] * (e.shiftKey ? 4 : 1);
+        const d = (k === 'ArrowRight' ? 1 : -1) * g;
+        const n = Object.assign({}, S.nudge);
+        n[cur.o.id] = (n[cur.o.id] || 0) + d;
+        const st = cur.o.start + n[cur.o.id];
+        this.setState({ nudge: n, pending: S.pending + 1 });
+        this.say('Start ' + dayLabel(st) + ', finish ' + dayLabel(st + cur.o.dur) + '.');
+        return;
+      }
+      if (k === 'Enter') {
+        e.preventDefault();
+        const moved = (S.nudge[cur.o.id] || 0) - (S.preMove || 0);
+        this.setState({ moveMode: false, preMove: null });
+        this.say('Moved ' + cur.o.name + ' by ' + Math.abs(moved) + ' days ' + (moved >= 0 ? 'later' : 'earlier') + '. Saved locally, ' + (S.pending + 1) + ' changes pending sync.');
+        return;
+      }
+      if (k === 'Escape') {
+        e.preventDefault();
+        const n = Object.assign({}, S.nudge);
+        if (S.preMove) n[cur.o.id] = S.preMove; else delete n[cur.o.id];
+        this.setState({ nudge: n, moveMode: false, preMove: null });
+        this.say('Move cancelled. ' + cur.o.name + ' returned to ' + dayLabel(cur.o.start + (S.preMove || 0)) + '.');
+        return;
+      }
+      return;
+    }
+    if (k === 'ArrowRight' || k === 'ArrowLeft') {
+      e.preventDefault();
+      if (cur.kind === 'phase') {
+        const open = k === 'ArrowRight';
+        const x = Object.assign({}, S.expanded);
+        if (open) x[cur.o.id] = true; else delete x[cur.o.id];
+        this.setState({ expanded: x });
+        this.say(cur.o.name + ' ' + (open ? 'expanded, 15 tasks' : 'collapsed') + '.');
+      } else if (k === 'ArrowLeft' && cur.o.deps && cur.o.deps.length) {
+        const pid = cur.o.deps[0].id;
+        const idx = flat.findIndex(f => f.o.id === pid);
+        if (idx >= 0) { this.setState({ cursor: idx, selected: pid }, () => this.scrollRowIntoView(idx)); this.say('Predecessor: ' + flat[idx].o.name + '.'); }
+        else this.say('Predecessor is inside a collapsed phase. Press Left again on the phase row to reveal it.');
+      }
+      return;
+    }
+    if (k === 't' || k === 'T') {
+      e.preventDefault();
+      if (this._el) { this._el.scrollLeft = Math.max(0, TODAY * PX[S.zoom] - 200); this.setState({ scrollLeft: this._el.scrollLeft }); }
+      this.say('Scrolled to today, ' + dayLabel(TODAY) + '.');
+    }
+  }
+
+  flat() {
+    const out = [];
+    this.data.forEach(p => {
+      out.push({ kind: 'phase', o: p });
+      if (this.state.expanded[p.id]) p.tasks.forEach(t => out.push({ kind: 'task', o: t, parent: p }));
+    });
+    return out;
+  }
+
+  renderVals() {
+    const S = this.state;
+    const px = PX[S.zoom];
+    const canvasW = DAYS * px;
+    const flat = this.flat();
+    const first = Math.max(0, Math.floor(S.scrollTop / ROW_H) - 4);
+    const count = Math.ceil(560 / ROW_H) + 8;
+    const win = flat.slice(first, first + count);
+    const nudgeOf = (id) => S.nudge[id] || 0;
+
+    const rows = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      return {
+        top: (i * ROW_H) + 'px', indent: isPhase ? '8px' : '32px',
+        level: isPhase ? 1 : 2, sel: sel ? 'true' : 'false', rowIndex: i + 1, tab: sel ? 0 : -1,
+        name: o.name, fs: isPhase ? '13px' : '12.5px', fw: isPhase ? 600 : 400,
+        fg: isPhase ? '#101720' : '#4B5563',
+        chev: isPhase ? (S.expanded[o.id] ? '▼' : '▶') : '',
+        chevFg: '#4B5563',
+        bg: sel ? '#E8F0FE' : (isPhase ? '#F6F7F9' : '#FFFFFF'),
+        selBar: sel ? 'inset 2px 0 0 #0B57D0' : 'none',
+        critical: !isPhase && o.critical && S.showCritical,
+        dates: dayLabel(st) + ' → ' + dayLabel(st + o.dur),
+        select: () => this.setState({ selected: o.id }),
+        toggle: isPhase ? (e) => { e.stopPropagation(); this.setState(s => { const x = Object.assign({}, s.expanded); x[o.id] = !x[o.id]; return { expanded: x, selected: o.id }; }); } : () => {}
+      };
+    });
+
+    const minBar = 4;
+    const bars = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      const left = st * px;
+      const w = Math.max(minBar, o.dur * px);
+      const label = o.name;
+      const fits = w > label.length * 6.2 + 14;
+      const crit = !isPhase && o.critical && S.showCritical;
+      const hot = !isPhase && S.showHeat && o.alloc > 100;
+      return {
+        top: (i * ROW_H) + 'px',
+        rowBg: sel ? 'rgba(11,87,208,.06)' : (isPhase ? 'rgba(241,243,247,.75)' : 'transparent'),
+        isMilestone: !isPhase && o.milestone,
+        msTop: (i * ROW_H + 10) + 'px', msFill: o.done === 100 ? '#101720' : '#FFFFFF',
+        isBar: !(!isPhase && o.milestone),
+        barTop: (i * ROW_H + (isPhase ? 11 : 9)) + 'px',
+        h: isPhase ? '10px' : '14px',
+        radius: isPhase ? '2px' : '3px',
+        left: left + 'px', width: w + 'px',
+        bg: isPhase ? '#4B5563' : '#E8F0FE',
+        border: isPhase ? '1px solid #101720' : (crit ? '1.5px solid #B3261E' : '1px solid #0B57D0'),
+        glow: sel && !isPhase ? '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' : 'none',
+        progress: o.done + '%',
+        progressBg: isPhase ? '#101720' : '#0B57D0',
+        hot,
+        innerLabel: fits ? (crit ? '▲ ' + label : label) : '',
+        labelFg: isPhase ? '#FFFFFF' : '#101720',
+        labelFgFilled: '#FFFFFF',
+        outsideLabel: fits ? '' : (crit ? '▲ ' + label : label),
+        labelLeft: (left + w + 6) + 'px',
+        hasBaseline: !isPhase && S.showBaseline && o.baseline !== 0,
+        baseTop: (i * ROW_H + 25) + 'px',
+        baseLeft: ((st + o.baseline) * px) + 'px',
+        baseWidth: Math.max(minBar, o.dur * px) + 'px',
+        title: label + ' · ' + dayLabel(st) + ' → ' + dayLabel(st + o.dur) + (isPhase ? '' : ' · ' + o.done + '% complete · ' + o.alloc + '% allocated' + (o.critical ? ' · critical path' : '')),
+        label
+      };
+    });
+
+    const indexOf = {};
+    flat.forEach((f, i) => { indexOf[f.o.id] = i; });
+    const segs = [];
+    const arrowHeads = [];
+    const stubs = [];
+    const lastWin = first + win.length - 1;
+    win.forEach((n, idx) => {
+      if (n.kind !== 'task' || !n.o.deps) return;
+      const i = first + idx;
+      const b = n.o;
+      const bx = (b.start + nudgeOf(b.id)) * px;
+      const by = i * ROW_H + 16;
+      b.deps.forEach(dep => {
+        const pi = indexOf[dep.id];
+        const pf = pi === undefined ? null : flat[pi];
+        const color = (b.critical && pf && pf.o.critical && S.showCritical) ? '#B3261E' : '#7D8799';
+        if (pf === null || pi < first || pi > lastWin) {
+          stubs.push({ left: (bx - 14) + 'px', top: (i * ROW_H + 12) + 'px', color, title: 'Predecessor off screen — ' + dep.type + (dep.lag ? ', ' + dep.lag + '-day lag' : '') });
+          return;
+        }
+        const a = pf.o;
+        const ast = a.start + nudgeOf(a.id);
+        const ax = dep.type === 'SS' ? ast * px : (ast + a.dur) * px;
+        const ay = pi * ROW_H + 16;
+        const elbow = Math.max(ax + 10, bx - 12);
+        segs.push({ left: Math.min(ax, elbow) + 'px', top: ay + 'px', w: Math.abs(elbow - ax) + 'px', h: '1.5px', color });
+        segs.push({ left: elbow + 'px', top: Math.min(ay, by) + 'px', w: '1.5px', h: Math.abs(by - ay) + 'px', color });
+        segs.push({ left: Math.min(elbow, bx - 6) + 'px', top: by + 'px', w: Math.abs(bx - 6 - elbow) + 'px', h: '1.5px', color });
+        arrowHeads.push({ left: (bx - 6) + 'px', top: (by - 4) + 'px', color });
+      });
+    });
+
+    const visFrom = Math.floor(S.scrollLeft / px) - 2;
+    const visTo = visFrom + Math.ceil(S.viewportW / px) + 4;
+    const shading = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let d = Math.max(0, visFrom); d < Math.min(DAYS, visTo); d++) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d === d);
+        if (hol && S.showHolidays) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#FBF0DC', bd: '1px solid #E0C089', title: hol.n });
+        else if (wd === 5 || wd === 6) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#F1F3F7', bd: 'none', title: 'Weekend — non-working' });
+      }
+    }
+
+    const axisMajor = [];
+    const axisMinor = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[(m) % 12] + ' ' + (2026 + Math.floor(m / 12)) });
+      }
+      const step = S.zoom === 'Day' ? 1 : 7;
+      for (let d = Math.max(0, Math.floor(visFrom / step) * step); d < Math.min(DAYS, visTo); d += step) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d >= d && h.d < d + step);
+        axisMinor.push({
+          left: (d * px) + 'px', width: (step * px) + 'px',
+          label: S.zoom === 'Day' ? String(new Date(new Date(2026, 0, 5).getTime() + d * 86400000).getDate()) : 'W' + (Math.floor(d / 7) % 53 + 1),
+          bg: hol && S.showHolidays ? '#FBF0DC' : (S.zoom === 'Day' && (wd === 5 || wd === 6) ? '#F1F3F7' : 'transparent'),
+          fg: hol && S.showHolidays ? '#8A5200' : '#4B5563'
+        });
+      }
+    } else {
+      for (let q = 0; q < 9; q++) {
+        const d0 = Math.round(q * 91.3);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (91.3 * px) + 'px', label: 'Q' + (q % 4 + 1) + ' ' + (2026 + Math.floor(q / 4)) });
+      }
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMinor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[m % 12], bg: 'transparent', fg: '#4B5563' });
+      }
+    }
+
+    const selObj = flat.find(f => f.o.id === S.selected);
+    const nudged = nudgeOf(S.selected);
+    const statusText = S.moveMode
+      ? 'Move mode — ' + (selObj ? selObj.o.name : 'nothing selected')
+      : (selObj ? 'Selected: ' + selObj.o.name : 'Nothing selected');
+    const statusHint = S.moveMode
+      ? '← → nudge by 1 ' + S.zoom.toLowerCase() + (nudged ? ' · moved ' + (nudged > 0 ? '+' : '') + nudged + ' days' : '') + ' · Shift+arrow ×4 · Enter commits · Esc reverts'
+      : 'Press M to move · ' + S.pending + ' change' + (S.pending === 1 ? '' : 's') + ' pending sync';
+
+    return {
+      phaseCount: '80', taskCount: '1,200', windowSize: String(count),
+      rowTotal: flat.length.toLocaleString(),
+      windowLabel: win.length + ' rows',
+      canvasWidth: canvasW + 'px',
+      canvasHeight: (flat.length * ROW_H) + 'px',
+      treeShift: (-S.scrollTop) + 'px',
+      axisShift: (-S.scrollLeft) + 'px',
+      todayLeft: (TODAY * px) + 'px',
+      todayLabelTop: (S.scrollTop + 4) + 'px',
+      rows, bars, segs, arrowHeads, stubs, shading, axisMajor, axisMinor,
+      announce: S.announce,
+      onKey: (e) => this.onKey(e),
+      sayExamples: [
+        { k: '↓', v: 'Fit-gap — Finance 6, task, level 2, 14 Jul 26 to 27 Jul 26, row 39 of 95.' },
+        { k: 'M', v: 'Move mode on. Fit-gap — Finance 6. Left and right arrows move by one week. Enter commits, Escape reverts.' },
+        { k: '→ (move)', v: 'Start 21 Jul 26, finish 03 Aug 26.' },
+        { k: 'Enter', v: 'Moved Fit-gap — Finance 6 by 7 days later. Saved locally, 3 changes pending sync.' },
+        { k: 'Esc', v: 'Move cancelled. Fit-gap — Finance 6 returned to 14 Jul 26.' },
+        { k: '→ on phase', v: 'Realize · Data Migration expanded, 15 tasks.' }
+      ],
+      depLegend: [
+        { k: 'FS', v: 'Finish-to-start, the default: the arrow leaves the predecessor’s right edge and enters the successor’s left edge.' },
+        { k: 'FS + lag', v: 'Same geometry; the lag is written on the successor’s tooltip and in its accessible name (“2-day lag”).' },
+        { k: 'SS', v: 'Start-to-start: the arrow leaves the predecessor’s left edge. Used for the cross-phase links every third phase carries here.' },
+        { k: '◀ stub', v: 'The predecessor is outside the rendered window or inside a collapsed phase. The stub is focusable and ← navigates to it, expanding the phase if needed.' }
+      ],
+      statusText, statusHint,
+      statusBg: S.moveMode ? '#E8F0FE' : '#F6F7F9',
+      statusFg: S.moveMode ? '#0B57D0' : '#101720',
+      onScroll: (e) => { this._el = e.target; this.setState({ scrollTop: e.target.scrollTop, scrollLeft: e.target.scrollLeft, viewportW: e.target.clientWidth }); },
+      canvasRef: (el) => { if (el) this._el = el; },
+      collapseAll: () => {
+        this.setState({ expanded: {} });
+        if (this._el) { this._el.scrollTop = 0; this.setState({ scrollTop: 0 }); }
+      },
+      expandStage: () => {
+        const x = {};
+        this.data.forEach(p => { if (p.stage === 'Realize') x[p.id] = true; });
+        this.setState({ expanded: x }, () => {
+          const flat2 = this.flat();
+          const idx = flat2.findIndex(f => f.kind === 'phase' && f.o.stage === 'Realize');
+          const startDay = idx >= 0 ? flat2[idx].o.start : 160;
+          const el = this._el;
+          if (el) {
+            el.scrollTop = Math.max(0, idx * ROW_H);
+            el.scrollLeft = Math.max(0, startDay * PX[this.state.zoom] - 80);
+            this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, viewportW: el.clientWidth, selected: flat2[idx].o.id });
+          }
+        });
+      },
+      zoomCells: ['Day', 'Week', 'Month', 'Quarter'].map(z => ({
+        label: z,
+        bg: S.zoom === z ? '#FFFFFF' : 'transparent',
+        fg: S.zoom === z ? '#101720' : '#4B5563',
+        bd: S.zoom === z ? '#7D8799' : 'transparent',
+        sh: S.zoom === z ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => this.setState({ zoom: z })
+      })),
+      layerToggles: [
+        { key: 'showCritical', label: 'Critical path' },
+        { key: 'showBaseline', label: 'Baseline v3' },
+        { key: 'showHeat', label: 'Allocation heat' },
+        { key: 'showHolidays', label: 'Holidays' }
+      ].map(t => ({
+        label: t.label,
+        mark: S[t.key] ? '✓' : '○',
+        bg: S[t.key] ? '#E8F0FE' : '#FFFFFF',
+        fg: S[t.key] ? '#0B57D0' : '#4B5563',
+        bd: S[t.key] ? '#BBD0F6' : '#CBD2DC',
+        on: () => this.setState(s => { const o = {}; o[t.key] = !s[t.key]; return o; })
+      })),
+
+      geometry: [
+        { k: 'Row height', v: '32px standard, 28px compact. Both keep 13px/12.5px text — density never comes from shrinking type.' },
+        { k: 'Bar heights', v: 'Phase 10px with square caps, task 14px, milestone a 12px diamond centred on the row, baseline a 4px bar 2px below the current bar.' },
+        { k: 'Minimum bar', v: '4px. Below that a bar is unclickable, so a sub-grain task renders at 4px with a 24px invisible hit area and its label always outside.' },
+        { k: 'Label overflow', v: 'A label needs width ≥ 6.2 × characters + 14px padding. Below that it moves outside the bar’s right edge in content/primary; below 60px of free canvas it becomes a tooltip only, and the tree column remains the reliable place to read the name.' },
+        { k: 'Label contrast', v: 'The label is drawn twice and clipped at the progress boundary: content/primary #101720 over the unfilled accent/subtle remainder at 15.72:1, and content/inverse #FFFFFF over the filled accent at 6.39:1. Phase bars keep white throughout — 7.56:1 on the unfilled #4B5563 body and 18.02:1 on the filled #101720. No label ever crosses a boundary at low contrast.' },
+        { k: 'Zoom grain', v: 'Day 26px, Week 8.4px, Month 2.9px, Quarter 1.15px per day. Weekend and holiday shading render at Day and Week only — at Month a single day is 2.9px and shading becomes noise.' },
+        { k: 'Sticky left', v: 'The 392px tree pane is a separate scroll-locked pane translated by the canvas scrollTop, so it never repaints on horizontal scroll and never detaches vertically.' },
+        { k: 'Today marker', v: '2px accent line spanning the full canvas height with a pinned label that follows the vertical scroll, so it is legible at row 800 as well as row 1.' },
+        { k: 'Dependency arrows', v: 'Orthogonal, 1.5px, border/strong; critical-path links inherit status/danger. Drawn only between rows currently in the window — off-window predecessors show a ◀ stub on the successor bar.' }
+      ],
+      scaleRules: [
+        'All 80 phases collapse by default. Nothing above 40 rows auto-expands, because a plan that opens 1,280 rows deep cannot be read and costs a second of layout.',
+        'Vertical windowing renders ~' + count + ' rows regardless of dataset size; the scroll container is sized by row count so the scrollbar stays honest.',
+        'Horizontal windowing: shading and axis ticks are generated only for the visible day range plus 2 days of bleed. At Quarter zoom the whole 730-day range is 840px, so nothing is windowed horizontally.',
+        'Bars are plain absolutely-positioned divs, not SVG — 30 divs beat one 1,200-node SVG for scroll performance, and each bar keeps a real DOM node for focus and ARIA.',
+        'Expand-all is deliberately absent. “Expand stage” is offered instead, because a stage is the largest unit a person can scan.',
+        'Filtering (workstream, region, status, resource) reduces the flat list before windowing, so a filtered plan of 40 rows scrolls like a 40-row plan.',
+        'The tree pane truncates names with an ellipsis and never wraps: a wrapped name would desynchronise the two panes’ row heights, which is the one failure a split Gantt cannot recover from.'
+      ],
+      keys: [
+        { k: '↑ ↓', v: 'Move the row cursor. Selection follows focus; the canvas scrolls to keep the row visible.' },
+        { k: '← →', v: 'Collapse / expand the focused phase. On a task, jump to its predecessor / successor.' },
+        { k: 'M', v: 'Toggle Move mode on the selected bar. The status bar turns accent and states the grain.' },
+        { k: '← → (move)', v: 'Nudge by one zoom grain — 1 day, 1 week, 1 month, 1 quarter. Shift multiplies by 4.' },
+        { k: '⌥ ← →', v: 'Resize: move the finish date only, leaving the start fixed.' },
+        { k: 'Enter', v: 'Commit the move. Escape reverts to the position before Move mode was entered.' },
+        { k: '⌥ ↑ ↓', v: 'Reorder the focused task within its phase — the keyboard equivalent of drag-reorder.' },
+        { k: 'Space', v: 'Add to multi-selection. Shift+↑↓ extends a contiguous selection.' },
+        { k: '+ / −', v: 'Zoom in / out one step, anchored on the selected bar rather than the viewport centre.' },
+        { k: 'T', v: 'Scroll to today. G then C opens the critical-path drawer.' }
+      ],
+      a11y: [
+        { k: 'Structure', v: 'The tree is role="treegrid" with aria-level, aria-expanded, aria-posinset and aria-setsize; the canvas row is the same row element extended, so the two panes are one grid to assistive tech, not two.' },
+        { k: 'Bar name', v: '“Unit test — Finance 4, task, Realize · Finance, 12 to 26 October 2026, 15 working days, 60% complete, 120% allocated, on critical path.” Everything the colour and hatch encode is in the name.' },
+        { k: 'Move mode', v: 'Entering announces “Move mode. Left and right arrows move by one week.” Each nudge announces the new start date only — not the whole name — so repeated nudging stays usable.' },
+        { k: 'Windowing', v: 'aria-rowcount is the full flat count (1,280 when everything is expanded), aria-rowindex is absolute, so a screen reader reports “row 812 of 1,280” correctly.' },
+        { k: 'Dependencies', v: 'aria-describedby on the successor references a hidden node listing its predecessors; ← and → navigate the dependency graph directly rather than requiring the user to find an arrow.' },
+        { k: 'Non-working days', v: 'Weekend and holiday shading is decorative in the canvas; the same information is in each bar’s accessible name as working-day counts and in the date-picker cell names.' },
+        { k: 'Reduced motion', v: 'Scroll-to-row becomes an instant jump, zoom re-scale drops its 300ms transition, and the today marker never pulses.' }
+      ],
+      darkBars: [
+        { rowBg: '#171C24', left: '12px', w: '150px', bg: '#3D4757', border: '1px solid #E9EEF6', prog: '62%', progBg: '#8592A6', fg: '#E9EEF6', label: 'Realize · Finance' },
+        { rowBg: '#171C24', left: '40px', w: '96px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '80%', progBg: '#7FB0FF', fg: '#0B1220', label: 'Fit-gap 3' },
+        { rowBg: '#16294A', left: '96px', w: '120px', bg: '#16294A', border: '1.5px solid #FF8A80', prog: '35%', progBg: '#7FB0FF', fg: '#E9EEF6', label: '▲ Mock conversion 3' },
+        { rowBg: '#171C24', left: '150px', w: '64px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '0%', progBg: '#7FB0FF', fg: '#E9EEF6', label: 'Sign-off' }
+      ],
+      summaryRows: [
+        { name: 'Prepare', pct: '100%', fill: '#0A7A47', dates: '05 Jan – 09 Mar', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Explore', pct: '100%', fill: '#0A7A47', dates: '23 Feb – 13 Jul', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Realize', pct: '62%', fill: '#0B57D0', dates: '14 Jun – 03 Apr 27', pill: 'At risk', pillG: '⚠', pillBg: '#FBF0DC', pillFg: '#8A5200', pillBd: '#E0C089' },
+        { name: 'Deploy', pct: '8%', fill: '#0B57D0', dates: '12 Mar – 27 Jul 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Run', pct: '0%', fill: '#0B57D0', dates: '15 Jul – 26 Dec 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/gantt3.html
+++ b/docs/design/gantt3.html
@@ -1,0 +1,779 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 28px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4a of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Gantt timeline — working prototype</h1>
+  <p style="margin:16px 0 0;max-width:76ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Loaded with the real shape of the problem: <span style="font-weight:600;color:#101720">{{ phaseCount }} phases</span> and <span style="font-weight:600;color:#101720">{{ taskCount }} tasks</span> across SAP Activate stages and ten workstreams. Rows are windowed — only the ~{{ windowSize }} rows in view exist in the DOM. Click a row to select, press <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">M</kbd> for Move mode, then arrow keys to nudge at the current zoom grain.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;background:#FFFFFF">
+
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #CBD2DC;background:#FFFFFF;flex-wrap:wrap">
+      <div role="radiogroup" aria-label="Zoom" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+        <sc-for list="{{ zoomCells }}" as="z" hint-placeholder-count="4">
+          <button onClick="{{ z.on }}" style="height:26px;padding:0 12px;border-radius:4px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ z.bg }};color:{{ z.fg }};border:1px solid {{ z.bd }};box-shadow:{{ z.sh }}">{{ z.label }}</button>
+        </sc-for>
+      </div>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <sc-for list="{{ layerToggles }}" as="t" hint-placeholder-count="4">
+        <button onClick="{{ t.on }}" style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;border-radius:6px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ t.bg }};color:{{ t.fg }};border:1px solid {{ t.bd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:11px">{{ t.mark }}</span>{{ t.label }}</button>
+      </sc-for>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <button onClick="{{ collapseAll }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Collapse all</button>
+      <button onClick="{{ expandStage }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Expand Realize</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span style="font-variant-numeric:tabular-nums">{{ rowTotal }} rows · {{ windowLabel }} rendered</span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 9px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB;color:#0A7A47;font-size:12px;font-weight:500"><span aria-hidden="true">✓</span>Synced</span>
+      </div>
+    </div>
+
+    <div style="display:flex;border-bottom:1px solid #CBD2DC;background:#F1F3F7">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;display:flex;align-items:center;padding:0 12px;height:56px;gap:8px">
+        <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Phase / task</span>
+        <span style="margin-left:auto;font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Dates</span>
+      </div>
+      <div style="flex:1;overflow:hidden;position:relative;height:56px">
+        <div style="position:absolute;top:0;left:0;height:56px;width:{{ canvasWidth }};transform:translateX({{ axisShift }})">
+          <sc-for list="{{ axisMajor }}" as="a" hint-placeholder-count="8">
+            <div style="position:absolute;top:0;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #CBD2DC;display:flex;align-items:center;padding-left:6px;font-size:11.5px;font-weight:600;color:#101720;overflow:hidden;white-space:nowrap">{{ a.label }}</div>
+          </sc-for>
+          <sc-for list="{{ axisMinor }}" as="a" hint-placeholder-count="20">
+            <div style="position:absolute;top:28px;left:{{ a.left }};width:{{ a.width }};height:28px;border-left:1px solid #E4E7EC;background:{{ a.bg }};display:flex;align-items:center;justify-content:center;font-size:10.5px;color:{{ a.fg }};font-variant-numeric:tabular-nums;overflow:hidden">{{ a.label }}</div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div role="treegrid" aria-label="Programme timeline" aria-rowcount="{{ rowCount }}" aria-colcount="3" aria-multiselectable="true" aria-describedby="gantt-status" tabindex="0" onKeyDown="{{ onKey }}" style="display:flex;height:560px;outline:none">
+      <div style="width:392px;flex:none;border-right:1px solid #CBD2DC;overflow:hidden;position:relative;background:#FFFFFF">
+        <div style="position:absolute;top:0;left:0;right:0;transform:translateY({{ treeShift }})">
+          <sc-for list="{{ rows }}" as="r" hint-placeholder-count="18">
+            <div role="row" aria-level="{{ r.level }}" aria-selected="{{ r.sel }}" aria-rowindex="{{ r.rowIndex }}" aria-expanded="{{ r.expandedAttr }}" aria-posinset="{{ r.posinset }}" aria-setsize="{{ r.setsize }}" aria-describedby="{{ r.depId }}" tabindex="{{ r.tab }}" onClick="{{ r.select }}" style="position:absolute;top:{{ r.top }};left:0;right:0;height:32px;display:flex;align-items:center;gap:6px;padding-left:{{ r.indent }};padding-right:10px;background:{{ r.bg }};box-shadow:{{ r.selBar }};border-bottom:1px solid #F1F3F7;cursor:pointer">
+              <span onClick="{{ r.toggle }}" style="width:16px;flex:none;text-align:center;font-size:9px;color:{{ r.chevFg }};cursor:pointer">{{ r.chev }}</span>
+              <span style="font-size:{{ r.fs }};font-weight:{{ r.fw }};color:{{ r.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ r.name }}</span>
+              <sc-if value="{{ r.critical }}" hint-placeholder-val="{{ false }}"><span title="On the critical path" style="flex:none;font-size:10px;color:#B3261E;font-weight:600">▲CP</span></sc-if>
+              <span style="margin-left:auto;flex:none;font-size:11.5px;color:#667085;font-variant-numeric:tabular-nums">{{ r.dates }}</span>
+              <sc-if value="{{ r.depText }}" hint-placeholder-val="{{ false }}"><span id="{{ r.depId }}" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap">{{ r.depText }}</span></sc-if>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div ref="{{ canvasRef }}" onScroll="{{ onScroll }}" style="flex:1;overflow:auto;position:relative;background:#FFFFFF">
+        <div style="position:relative;width:{{ canvasWidth }};height:{{ canvasHeight }}">
+          <sc-for list="{{ shading }}" as="s" hint-placeholder-count="12">
+            <div title="{{ s.title }}" style="position:absolute;top:0;bottom:0;left:{{ s.left }};width:{{ s.width }};background:{{ s.bg }};border-left:{{ s.bd }}"></div>
+          </sc-for>
+          <div style="position:absolute;top:0;bottom:0;left:{{ todayLeft }};width:2px;background:#0B57D0"></div>
+          <div style="position:absolute;top:{{ todayLabelTop }};left:{{ todayLeft }};transform:translateX(-50%);background:#0B57D0;color:#FFFFFF;font-size:10px;font-weight:600;padding:1px 6px;border-radius:3px;white-space:nowrap">Today</div>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div style="position:absolute;top:{{ b.top }};left:0;right:0;height:32px;background:{{ b.rowBg }};border-bottom:1px solid #F1F3F7"></div>
+          </sc-for>
+
+          <sc-for list="{{ segs }}" as="a" hint-placeholder-count="12">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:{{ a.w }};height:{{ a.h }};background:{{ a.color }}"></div>
+          </sc-for>
+          <sc-for list="{{ arrowHeads }}" as="a" hint-placeholder-count="6">
+            <div style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-left:6px solid {{ a.color }}"></div>
+          </sc-for>
+          <sc-for list="{{ stubs }}" as="a" hint-placeholder-count="4">
+            <div title="{{ a.title }}" tabindex="-1" style="position:absolute;left:{{ a.left }};top:{{ a.top }};width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-right:6px solid {{ a.color }}"></div>
+          </sc-for>
+
+          <sc-for list="{{ bars }}" as="b" hint-placeholder-count="18">
+            <div>
+              <sc-if value="{{ b.hasBaseline }}" hint-placeholder-val="{{ false }}">
+                <div title="Baseline v3" style="position:absolute;top:{{ b.baseTop }};left:{{ b.baseLeft }};width:{{ b.baseWidth }};height:4px;border-radius:2px;background:#98A2B3"></div>
+              </sc-if>
+              <sc-if value="{{ b.isMilestone }}" hint-placeholder-val="{{ false }}">
+                <div title="{{ b.label }}" style="position:absolute;top:{{ b.msTop }};left:{{ b.left }};width:12px;height:12px;background:{{ b.msFill }};border:1.5px solid #101720;transform:rotate(45deg)"></div>
+              </sc-if>
+              <sc-if value="{{ b.isBar }}" hint-placeholder-val="{{ true }}">
+                <div title="{{ b.title }}" style="position:absolute;top:{{ b.barTop }};left:{{ b.left }};width:{{ b.width }};height:{{ b.h }};border-radius:{{ b.radius }};background:{{ b.bg }};border:{{ b.border }};overflow:hidden;box-shadow:{{ b.glow }}">
+                  <div style="position:absolute;top:0;bottom:0;left:0;width:{{ b.progress }};background:{{ b.progressBg }}"></div>
+                  <sc-if value="{{ b.hot }}" hint-placeholder-val="{{ false }}">
+                    <div style="position:absolute;inset:0;background:repeating-linear-gradient(135deg,rgba(16,23,32,0) 0 3px,rgba(16,23,32,.45) 3px 6px)"></div>
+                  </sc-if>
+                  <span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;font-weight:500;color:{{ b.labelFg }};white-space:nowrap;overflow:hidden">{{ b.innerLabel }}</span>
+                  <span aria-hidden="true" style="position:absolute;top:0;left:0;bottom:0;width:{{ b.progress }};overflow:hidden"><span style="position:absolute;top:0;left:0;height:100%;width:{{ b.width }};display:flex;align-items:center;padding:0 6px;font-size:11px;font-weight:500;color:{{ b.labelFgFilled }};white-space:nowrap;box-sizing:border-box">{{ b.innerLabel }}</span></span>
+                </div>
+              </sc-if>
+              <sc-if value="{{ b.outsideLabel }}" hint-placeholder-val="{{ false }}">
+                <div style="position:absolute;top:{{ b.barTop }};left:{{ b.labelLeft }};height:{{ b.h }};display:flex;align-items:center;font-size:11px;color:#101720;white-space:nowrap">{{ b.outsideLabel }}</div>
+              </sc-if>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+
+    <div id="gantt-status" role="status" aria-live="polite" aria-atomic="true" style="display:flex;align-items:flex-start;gap:10px;padding:8px 14px;border-top:1px solid #CBD2DC;background:#FFFFFF">
+      <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">Announced</span>
+      <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:14px;padding:8px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }};flex-wrap:wrap">
+      <span style="font-size:12.5px;font-weight:600;color:{{ statusFg }}">{{ statusText }}</span>
+      <span style="font-size:12px;color:#4B5563">{{ statusHint }}</span>
+      <div style="margin-left:auto;display:flex;gap:12px;font-size:11.5px;color:#4B5563;flex-wrap:wrap">
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:8px;border-radius:2px;background:#101720"></span>Phase</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#E8F0FE;border:1px solid #0B57D0"></span>Task</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:10px;height:10px;background:#FFFFFF;border:1.5px solid #101720;transform:rotate(45deg);display:inline-block"></span>Milestone</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;border:1.5px solid #B3261E"></span>Critical ▲CP</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:4px;border-radius:2px;background:#98A2B3"></span>Baseline v3</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:repeating-linear-gradient(135deg,#CBD2DC 0 3px,#4B5563 3px 6px)"></span>Over 100%</span>
+        <span style="display:inline-flex;align-items:center;gap:5px"><span style="width:14px;height:10px;border-radius:2px;background:#FBF0DC;border:1px solid #E0C089"></span>Public holiday</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:32px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Geometry</h3>
+      <sc-for list="{{ geometry }}" as="g" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:132px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ g.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ g.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Scale — 80 phases, 1,200 tasks</h3>
+      <sc-for list="{{ scaleRules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Dependencies</h3>
+      <sc-for list="{{ depLegend }}" as="d" hint-placeholder-count="4">
+        <div style="display:grid;grid-template-columns:74px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ d.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ d.v }}</div></div>
+      </sc-for>
+      <h3 style="margin:20px 0 10px;font-size:16px;line-height:22px;font-weight:600">Announcements</h3>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">The strip above the legend is the Gantt’s <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">#gantt-status</span> region — <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">role="status" aria-live="polite" aria-atomic="true"</span> — shown visibly here so the announcement can be reviewed. In the product it is visually hidden and the sync chip owns everything about sync, exactly as Layer 3 specifies. It is written on cursor movement, expand/collapse, Move-mode entry and exit, each nudge, commit and revert.</div>
+      <div style="margin-top:10px;display:flex;flex-direction:column;gap:6px">
+        <sc-for list="{{ sayExamples }}" as="s" hint-placeholder-count="5">
+          <div style="font-size:12px;line-height:18px;color:#101720;background:#F1F3F7;border:1px solid #E4E7EC;border-radius:4px;padding:6px 8px"><span style="font-family:'IBM Plex Mono',monospace;color:#0B57D0">{{ s.k }}</span> — “{{ s.v }}”</div>
+        </sc-for>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Keyboard &amp; drag equivalence</h3>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-bottom:10px">Keys are bound to the <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">role="treegrid"</span> element, not the window, so M types an M inside a text field and the timeline only responds when it holds focus. One tab stop enters the grid; the row cursor is a roving tabindex.</div>
+      <sc-for list="{{ keys }}" as="k" hint-placeholder-count="10">
+        <div style="display:grid;grid-template-columns:104px 1fr;gap:12px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+      </sc-for>
+      <div style="margin-top:18px;padding:12px 14px;background:#F1F3F7;border:1px dashed #7D8799;border-radius:6px">
+        <div style="font-size:12px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Specified, not prototyped</div>
+        <sc-for list="{{ notProto }}" as="k" hint-placeholder-count="4">
+          <div style="display:grid;grid-template-columns:104px 1fr;gap:12px;padding:6px 0;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#FFFFFF;border:1px solid #CBD2DC;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark canvas</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden;background:#0E1116">
+        <div style="display:flex;height:32px;align-items:center;background:#0A0D12;border-bottom:1px solid #232A35;font-size:11px;color:#AFBACA;padding:0 10px;gap:16px"><span>W41</span><span>W42</span><span>W43</span><span>W44</span></div>
+        <sc-for list="{{ darkBars }}" as="d" hint-placeholder-count="4">
+          <div style="position:relative;height:32px;border-bottom:1px solid #232A35;background:{{ d.rowBg }}">
+            <div style="position:absolute;top:9px;left:{{ d.left }};width:{{ d.w }};height:14px;border-radius:3px;background:{{ d.bg }};border:{{ d.border }};overflow:hidden"><div style="position:absolute;inset:0 auto 0 0;width:{{ d.prog }};background:{{ d.progBg }}"></div><span style="position:absolute;inset:0;display:flex;align-items:center;padding:0 6px;font-size:11px;color:{{ d.fg }};white-space:nowrap">{{ d.label }}</span></div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">Weekend shading in dark is surface/sunken <span style="font-family:'IBM Plex Mono',monospace">#0A0D12</span> — darker than the canvas rather than lighter, because a lighter band reads as a highlight. Task bars invert: accent/subtle fill with an accent border, progress in full accent carrying content/inverse text.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Collapsed summary &amp; mobile read-only</h3>
+      <div style="border:1px solid #E4E7EC;border-radius:6px;overflow:hidden">
+        <sc-for list="{{ summaryRows }}" as="s" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:1fr 84px;gap:8px;align-items:center;padding:8px 10px;border-bottom:1px solid #E4E7EC">
+            <div>
+              <div style="display:flex;align-items:center;gap:8px"><span style="font-size:13px;font-weight:500">{{ s.name }}</span><span style="display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 7px 0 5px;border-radius:4px;background:{{ s.pillBg }};color:{{ s.pillFg }};border:1px solid {{ s.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ s.pillG }}</span>{{ s.pill }}</span></div>
+              <div style="height:8px;border-radius:999px;background:#E4E7EC;margin-top:6px;overflow:hidden"><div style="height:100%;width:{{ s.pct }};background:{{ s.fill }}"></div></div>
+            </div>
+            <div style="text-align:right;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.dates }}</div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:12px;text-wrap:pretty">This is the mobile experience, and it is deliberate rather than a shrunken canvas: a stage-level list with progress, status and window. Tapping a stage opens its phases in the same form; tapping a phase opens a read-only task list. Editing, drag and dependency work do not exist below 768px — the six phone jobs are read timeline, update % complete, see who is on what this week, approve a request, read health, accept an invite. A single “Open on desktop for editing” link states the boundary instead of hiding it.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:118px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+const STAGES = [
+  { name: 'Prepare', s: 0, e: 62 },
+  { name: 'Explore', s: 48, e: 186 },
+  { name: 'Realize', s: 160, e: 452 },
+  { name: 'Deploy', s: 430, e: 568 },
+  { name: 'Run', s: 556, e: 720 }
+];
+const STREAMS = ['Finance (FI/CO)', 'Logistics (MM/SD/PP)', 'Human Capital', 'Technical (Basis/ABAP)', 'Data Migration', 'Integration', 'Change Management', 'Testing', 'Cutover', 'PMO', 'Analytics', 'Security', 'Training', 'Wave 1', 'Wave 2', 'Hypercare'];
+const TASK_VERBS = ['Workshop', 'Design', 'Build', 'Unit test', 'Config', 'Fit-gap', 'Review', 'Sign-off', 'Load', 'Rehearsal', 'Runbook', 'Handover', 'Audit', 'Dry run', 'Playback'];
+const HOLIDAYS = [
+  { d: 25, n: 'Thaipusam (MY)' }, { d: 48, n: 'Chinese New Year (MY, SG)' }, { d: 49, n: 'Chinese New Year day 2 (MY, SG)' },
+  { d: 86, n: 'Nyepi (ID) / Holi (IN)' }, { d: 116, n: 'Labour Day (MY, SG, VN, IN)' }, { d: 121, n: 'Wesak Day (MY, SG)' },
+  { d: 176, n: 'Hari Raya Haji (MY, SG)' }, { d: 238, n: 'Merdeka Day (MY)' }, { d: 253, n: 'Malaysia Day (MY)' },
+  { d: 282, n: 'Deepavali (MY, SG, IN)' }, { d: 313, n: 'National Day (VN)' }, { d: 359, n: 'Christmas Day (MY, SG, VN)' },
+  { d: 390, n: 'New Year (all regions)' }, { d: 433, n: 'Chinese New Year 2027 (MY, SG)' }, { d: 481, n: 'Labour Day 2027' },
+  { d: 603, n: 'Merdeka Day 2027 (MY)' }, { d: 647, n: 'Deepavali 2027 (MY, SG, IN)' }, { d: 724, n: 'Christmas 2027' }
+];
+const PX = { Day: 26, Week: 8.4, Month: 2.9, Quarter: 1.15 };
+const GRAIN = { Day: 1, Week: 7, Month: 30, Quarter: 90 };
+const DAYS = 730;
+const ROW_H = 32;
+const TODAY = 268;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function seed(n) { const x = Math.sin(n * 12.9898) * 43758.5453; return x - Math.floor(x); }
+function dayLabel(d) {
+  const base = new Date(2026, 0, 5).getTime() + d * 86400000;
+  const dt = new Date(base);
+  return dt.getDate() + ' ' + MONTHS[dt.getMonth()] + ' ' + String(dt.getFullYear()).slice(2);
+}
+function dow(d) { return (d + 0) % 7; }
+
+function buildData() {
+  const phases = [];
+  let taskId = 0;
+  for (let i = 0; i < 80; i++) {
+    const st = STAGES[Math.floor(i / 16)];
+    const k = i % 16;
+    const span = st.e - st.s;
+    const start = Math.round(st.s + (k / 16) * span * 0.45);
+    const dur = Math.round(span * (0.4 + seed(i) * 0.35));
+    const tasks = [];
+    for (let j = 0; j < 15; j++) {
+      const r = seed(i * 31 + j * 7);
+      const tStart = Math.round(start + (j / 15) * dur * 0.8 + r * 4);
+      const tDur = Math.max(2, Math.round(3 + seed(i + j * 3) * 17));
+      const done = tStart + tDur < TODAY ? 100 : tStart > TODAY ? 0 : Math.round(seed(i * 5 + j) * 90);
+      taskId++;
+      const deps = [];
+      if (j > 0) deps.push({ id: 'p' + i + '_t' + (j - 1), type: 'FS', lag: (i + j) % 7 === 0 ? 2 : 0 });
+      if (j === 0 && i > 0) deps.push({ id: 'p' + (i - 1) + '_t14', type: 'FS', lag: 0, cross: true });
+      if (j === 7 && i % 3 === 0 && i > 2) deps.push({ id: 'p' + (i - 3) + '_t9', type: 'SS', lag: 0, cross: true });
+      tasks.push({
+        id: 'p' + i + '_t' + j, deps,
+        name: TASK_VERBS[j % TASK_VERBS.length] + ' — ' + STREAMS[i % STREAMS.length].split(' ')[0] + ' ' + (j + 1),
+        start: tStart, dur: tDur, done,
+        alloc: 60 + Math.round(seed(i * 9 + j * 11) * 80),
+        critical: (i * 7 + j * 3) % 29 === 0,
+        milestone: j === 14 && i % 4 === 0,
+        baseline: (i + j) % 5 === 0 ? Math.round(seed(i + j) * 8) - 4 : 0
+      });
+    }
+    phases.push({
+      id: 'p' + i, stage: st.name, name: st.name + ' · ' + STREAMS[i % STREAMS.length],
+      start, dur, tasks,
+      done: Math.round(tasks.reduce((a, t) => a + t.done, 0) / tasks.length)
+    });
+  }
+  return phases;
+}
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.data = buildData();
+    this.state = {
+      zoom: 'Week', scrollTop: 0, scrollLeft: 0, viewportW: 900,
+      expanded: { p32: true, p33: true },
+      selected: 'p32', cursor: 32, moveMode: false, nudge: {}, pending: 0,
+      announce: 'Timeline ready. 80 phases, 1,200 tasks. Use up and down arrows to move the row cursor, M to move the selected bar.', preMove: null,
+      multi: {}, resize: {},
+      showCritical: true, showBaseline: true, showHeat: true, showHolidays: true
+    };
+  }
+
+  say(msg) { this.setState({ announce: msg }); }
+
+  scrollRowIntoView(idx) {
+    const el = this._el;
+    if (!el) return;
+    const top = idx * ROW_H;
+    if (top < el.scrollTop) el.scrollTop = top;
+    else if (top + ROW_H > el.scrollTop + el.clientHeight) el.scrollTop = top + ROW_H - el.clientHeight;
+    this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, viewportW: el.clientWidth });
+  }
+
+  moveCursor(delta) {
+    const flat = this.flat();
+    const next = Math.max(0, Math.min(flat.length - 1, this.state.cursor + delta));
+    const n = flat[next];
+    this.setState({ cursor: next, selected: n.o.id }, () => this.scrollRowIntoView(next));
+    const st = n.o.start + (this.state.nudge[n.o.id] || 0);
+    this.say(n.o.name + ', ' + (n.kind === 'phase' ? 'phase, ' + (this.state.expanded[n.o.id] ? 'expanded' : 'collapsed') : 'task, level 2') +
+      ', ' + dayLabel(st) + ' to ' + dayLabel(st + n.o.dur) + ', row ' + (next + 1) + ' of ' + flat.length + '.');
+  }
+
+  onKey(e) {
+    const k = e.key;
+    const flat = this.flat();
+    const cur = flat[Math.min(this.state.cursor, flat.length - 1)];
+    if (!cur) return;
+    const S = this.state;
+    if (k === 'ArrowDown' && !e.altKey) { e.preventDefault(); this.moveCursor(1); return; }
+    if (k === 'ArrowUp' && !e.altKey) { e.preventDefault(); this.moveCursor(-1); return; }
+    if (k === 'm' || k === 'M') {
+      e.preventDefault();
+      if (!S.moveMode) {
+        this.setState({ moveMode: true, preMove: S.nudge[cur.o.id] || 0 });
+        this.say('Move mode on. ' + cur.o.name + '. Left and right arrows move by one ' + S.zoom.toLowerCase() + '. Enter commits, Escape reverts.');
+      } else {
+        this.setState({ moveMode: false });
+        this.say('Move mode off.');
+      }
+      return;
+    }
+    if (S.moveMode) {
+      if ((k === 'ArrowRight' || k === 'ArrowLeft') && !e.altKey) {
+        e.preventDefault();
+        const g = GRAIN[S.zoom] * (e.shiftKey ? 4 : 1);
+        const d = (k === 'ArrowRight' ? 1 : -1) * g;
+        const n = Object.assign({}, S.nudge);
+        n[cur.o.id] = (n[cur.o.id] || 0) + d;
+        const st = cur.o.start + n[cur.o.id];
+        this.setState({ nudge: n, pending: S.pending + 1 });
+        this.say('Start ' + dayLabel(st) + ', finish ' + dayLabel(st + cur.o.dur) + '.');
+        return;
+      }
+      if (k === 'Enter') {
+        e.preventDefault();
+        const moved = (S.nudge[cur.o.id] || 0) - (S.preMove || 0);
+        this.setState({ moveMode: false, preMove: null });
+        this.say('Moved ' + cur.o.name + ' by ' + Math.abs(moved) + ' days ' + (moved >= 0 ? 'later' : 'earlier') + '. Saved locally, ' + (S.pending + 1) + ' changes pending sync.');
+        return;
+      }
+      if (k === 'Escape') {
+        e.preventDefault();
+        const n = Object.assign({}, S.nudge);
+        if (S.preMove) n[cur.o.id] = S.preMove; else delete n[cur.o.id];
+        this.setState({ nudge: n, moveMode: false, preMove: null });
+        this.say('Move cancelled. ' + cur.o.name + ' returned to ' + dayLabel(cur.o.start + (S.preMove || 0)) + '.');
+        return;
+      }
+      return;
+    }
+    if ((k === 'ArrowRight' || k === 'ArrowLeft') && !e.altKey) {
+      e.preventDefault();
+      if (cur.kind === 'phase') {
+        const open = k === 'ArrowRight';
+        const x = Object.assign({}, S.expanded);
+        if (open) x[cur.o.id] = true; else delete x[cur.o.id];
+        this.setState({ expanded: x });
+        this.say(cur.o.name + ' ' + (open ? 'expanded, 15 tasks' : 'collapsed') + '.');
+      } else if (k === 'ArrowLeft' && cur.o.deps && cur.o.deps.length) {
+        const pid = cur.o.deps[0].id;
+        const idx = flat.findIndex(f => f.o.id === pid);
+        if (idx >= 0) { this.setState({ cursor: idx, selected: pid }, () => this.scrollRowIntoView(idx)); this.say('Predecessor: ' + flat[idx].o.name + '.'); }
+        else this.say('Predecessor is inside a collapsed phase. Press Left again on the phase row to reveal it.');
+      }
+      return;
+    }
+    if (k === ' ' || k === 'Spacebar') {
+      e.preventDefault();
+      const m = Object.assign({}, S.multi);
+      if (m[cur.o.id]) delete m[cur.o.id]; else m[cur.o.id] = true;
+      const n = Object.keys(m).length;
+      this.setState({ multi: m });
+      this.say((m[cur.o.id] ? 'Added ' : 'Removed ') + cur.o.name + '. ' + n + ' row' + (n === 1 ? '' : 's') + ' selected.');
+      return;
+    }
+    if (e.altKey && (k === 'ArrowUp' || k === 'ArrowDown')) {
+      e.preventDefault();
+      if (cur.kind !== 'task') { this.say('Reorder applies to tasks. Phases are ordered by their stage.'); return; }
+      const phase = cur.parent;
+      const pos = phase.tasks.indexOf(cur.o);
+      const to = pos + (k === 'ArrowDown' ? 1 : -1);
+      if (to < 0 || to >= phase.tasks.length) { this.say('Already ' + (to < 0 ? 'first' : 'last') + ' in ' + phase.name + '.'); return; }
+      phase.tasks.splice(pos, 1);
+      phase.tasks.splice(to, 0, cur.o);
+      const flat2 = this.flat();
+      const newIdx = flat2.findIndex(f => f.o.id === cur.o.id);
+      this.setState({ cursor: newIdx, pending: S.pending + 1 }, () => this.scrollRowIntoView(newIdx));
+      this.say('Moved ' + cur.o.name + ' to position ' + (to + 1) + ' of ' + phase.tasks.length + ' in ' + phase.name + '. Saved locally.');
+      return;
+    }
+    if (e.altKey && (k === 'ArrowLeft' || k === 'ArrowRight')) {
+      e.preventDefault();
+      const g = GRAIN[S.zoom];
+      const d = (k === 'ArrowRight' ? 1 : -1) * g;
+      const r = Object.assign({}, S.resize);
+      const cd = (r[cur.o.id] || 0) + d;
+      if (cur.o.dur + cd < 1) { this.say('Minimum duration is 1 day.'); return; }
+      r[cur.o.id] = cd;
+      const st = cur.o.start + (S.nudge[cur.o.id] || 0);
+      this.setState({ resize: r, pending: S.pending + 1 });
+      this.say('Finish ' + dayLabel(st + cur.o.dur + cd) + '. Duration ' + (cur.o.dur + cd) + ' days. Start unchanged.');
+      return;
+    }
+    if (k === '+' || k === '=' || k === '-' || k === '_') {
+      e.preventDefault();
+      const order = ['Quarter', 'Month', 'Week', 'Day'];
+      const i2 = order.indexOf(S.zoom);
+      const next = order[Math.max(0, Math.min(order.length - 1, i2 + ((k === '+' || k === '=') ? 1 : -1)))];
+      const anchor = cur.o.start + (S.nudge[cur.o.id] || 0);
+      this.setState({ zoom: next }, () => {
+        if (this._el) { this._el.scrollLeft = Math.max(0, anchor * PX[next] - 120); this.setState({ scrollLeft: this._el.scrollLeft }); }
+      });
+      this.say('Zoom ' + next + '. Anchored on ' + cur.o.name + '.');
+      return;
+    }
+    if (k === 't' || k === 'T') {
+      e.preventDefault();
+      if (this._el) { this._el.scrollLeft = Math.max(0, TODAY * PX[S.zoom] - 200); this.setState({ scrollLeft: this._el.scrollLeft }); }
+      this.say('Scrolled to today, ' + dayLabel(TODAY) + '.');
+    }
+  }
+
+  flat() {
+    const out = [];
+    this.data.forEach(p => {
+      out.push({ kind: 'phase', o: p });
+      if (this.state.expanded[p.id]) p.tasks.forEach(t => out.push({ kind: 'task', o: t, parent: p }));
+    });
+    return out;
+  }
+
+  renderVals() {
+    const S = this.state;
+    const px = PX[S.zoom];
+    const canvasW = DAYS * px;
+    const flat = this.flat();
+    const first = Math.max(0, Math.floor(S.scrollTop / ROW_H) - 4);
+    const count = Math.ceil(560 / ROW_H) + 8;
+    const win = flat.slice(first, first + count);
+    const nudgeOf = (id) => S.nudge[id] || 0;
+    const durOf = (o) => Math.max(1, o.dur + (S.resize[o.id] || 0));
+
+    const rows = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      return {
+        top: (i * ROW_H) + 'px', indent: isPhase ? '8px' : '32px',
+        level: isPhase ? 1 : 2,
+        sel: S.multi[o.id] ? 'true' : (sel ? 'true' : 'false'),
+        rowIndex: i + 1, tab: sel ? 0 : -1,
+        expandedAttr: isPhase ? (S.expanded[o.id] ? 'true' : 'false') : undefined,
+        posinset: isPhase ? (this.data.indexOf(o) + 1) : (n.parent.tasks.indexOf(o) + 1),
+        setsize: isPhase ? 80 : n.parent.tasks.length,
+        depId: (!isPhase && o.deps && o.deps.length) ? ('dep-' + o.id) : undefined,
+        depText: (!isPhase && o.deps && o.deps.length)
+          ? 'Predecessors: ' + o.deps.map(d => {
+              const p = flat.find(f => f.o.id === d.id);
+              return (p ? p.o.name : 'a task in a collapsed phase') + ' (' + (d.type === 'SS' ? 'start-to-start' : 'finish-to-start') + (d.lag ? ', ' + d.lag + '-day lag' : '') + ')';
+            }).join('; ') + '.'
+          : '',
+        name: o.name, fs: isPhase ? '13px' : '12.5px', fw: isPhase ? 600 : 400,
+        fg: isPhase ? '#101720' : '#4B5563',
+        chev: isPhase ? (S.expanded[o.id] ? '▼' : '▶') : '',
+        chevFg: '#4B5563',
+        bg: sel ? '#E8F0FE' : (isPhase ? '#F6F7F9' : '#FFFFFF'),
+        selBar: sel ? 'inset 2px 0 0 #0B57D0' : 'none',
+        critical: !isPhase && o.critical && S.showCritical,
+        dates: dayLabel(st) + ' → ' + dayLabel(st + durOf(o)),
+        select: () => this.setState({ selected: o.id }),
+        toggle: isPhase ? (e) => { e.stopPropagation(); this.setState(s => { const x = Object.assign({}, s.expanded); x[o.id] = !x[o.id]; return { expanded: x, selected: o.id }; }); } : () => {}
+      };
+    });
+
+    const minBar = 4;
+    const bars = win.map((n, idx) => {
+      const i = first + idx;
+      const isPhase = n.kind === 'phase';
+      const o = n.o;
+      const sel = S.selected === o.id;
+      const st = o.start + nudgeOf(o.id);
+      const left = st * px;
+      const w = Math.max(minBar, durOf(o) * px);
+      const label = o.name;
+      const fits = w > label.length * 6.2 + 14;
+      const crit = !isPhase && o.critical && S.showCritical;
+      const hot = !isPhase && S.showHeat && o.alloc > 100;
+      return {
+        top: (i * ROW_H) + 'px',
+        rowBg: sel ? 'rgba(11,87,208,.06)' : (isPhase ? 'rgba(241,243,247,.75)' : 'transparent'),
+        isMilestone: !isPhase && o.milestone,
+        msTop: (i * ROW_H + 10) + 'px', msFill: o.done === 100 ? '#101720' : '#FFFFFF',
+        isBar: !(!isPhase && o.milestone),
+        barTop: (i * ROW_H + (isPhase ? 11 : 9)) + 'px',
+        h: isPhase ? '10px' : '14px',
+        radius: isPhase ? '2px' : '3px',
+        left: left + 'px', width: w + 'px',
+        bg: isPhase ? '#4B5563' : '#E8F0FE',
+        border: isPhase ? '1px solid #101720' : (crit ? '1.5px solid #B3261E' : '1px solid #0B57D0'),
+        glow: sel && !isPhase ? '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' : 'none',
+        progress: o.done + '%',
+        progressBg: isPhase ? '#101720' : '#0B57D0',
+        hot,
+        innerLabel: fits ? (crit ? '▲ ' + label : label) : '',
+        labelFg: isPhase ? '#FFFFFF' : '#101720',
+        labelFgFilled: '#FFFFFF',
+        outsideLabel: fits ? '' : (crit ? '▲ ' + label : label),
+        labelLeft: (left + w + 6) + 'px',
+        hasBaseline: !isPhase && S.showBaseline && o.baseline !== 0,
+        baseTop: (i * ROW_H + 25) + 'px',
+        baseLeft: ((st + o.baseline) * px) + 'px',
+        baseWidth: Math.max(minBar, o.dur * px) + 'px',
+        title: label + ' · ' + dayLabel(st) + ' → ' + dayLabel(st + durOf(o)) + (isPhase ? '' : ' · ' + o.done + '% complete · ' + o.alloc + '% allocated' + (o.critical ? ' · critical path' : '')),
+        label
+      };
+    });
+
+    const indexOf = {};
+    flat.forEach((f, i) => { indexOf[f.o.id] = i; });
+    const segs = [];
+    const arrowHeads = [];
+    const stubs = [];
+    const lastWin = first + win.length - 1;
+    win.forEach((n, idx) => {
+      if (n.kind !== 'task' || !n.o.deps) return;
+      const i = first + idx;
+      const b = n.o;
+      const bx = (b.start + nudgeOf(b.id)) * px;
+      const by = i * ROW_H + 16;
+      b.deps.forEach(dep => {
+        const pi = indexOf[dep.id];
+        const pf = pi === undefined ? null : flat[pi];
+        const color = (b.critical && pf && pf.o.critical && S.showCritical) ? '#B3261E' : '#7D8799';
+        if (pf === null || pi < first || pi > lastWin) {
+          stubs.push({ left: (bx - 14) + 'px', top: (i * ROW_H + 12) + 'px', color, title: 'Predecessor off screen — ' + dep.type + (dep.lag ? ', ' + dep.lag + '-day lag' : '') });
+          return;
+        }
+        const a = pf.o;
+        const ast = a.start + nudgeOf(a.id);
+        const ax = dep.type === 'SS' ? ast * px : (ast + durOf(a)) * px;
+        const ay = pi * ROW_H + 16;
+        const elbow = Math.max(ax + 10, bx - 12);
+        segs.push({ left: Math.min(ax, elbow) + 'px', top: ay + 'px', w: Math.abs(elbow - ax) + 'px', h: '1.5px', color });
+        segs.push({ left: elbow + 'px', top: Math.min(ay, by) + 'px', w: '1.5px', h: Math.abs(by - ay) + 'px', color });
+        segs.push({ left: Math.min(elbow, bx - 6) + 'px', top: by + 'px', w: Math.abs(bx - 6 - elbow) + 'px', h: '1.5px', color });
+        arrowHeads.push({ left: (bx - 6) + 'px', top: (by - 4) + 'px', color });
+      });
+    });
+
+    const visFrom = Math.floor(S.scrollLeft / px) - 2;
+    const visTo = visFrom + Math.ceil(S.viewportW / px) + 4;
+    const shading = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let d = Math.max(0, visFrom); d < Math.min(DAYS, visTo); d++) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d === d);
+        if (hol && S.showHolidays) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#FBF0DC', bd: '1px solid #E0C089', title: hol.n });
+        else if (wd === 5 || wd === 6) shading.push({ left: (d * px) + 'px', width: px + 'px', bg: '#F1F3F7', bd: 'none', title: 'Weekend — non-working' });
+      }
+    }
+
+    const axisMajor = [];
+    const axisMinor = [];
+    if (S.zoom === 'Day' || S.zoom === 'Week') {
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[(m) % 12] + ' ' + (2026 + Math.floor(m / 12)) });
+      }
+      const step = S.zoom === 'Day' ? 1 : 7;
+      for (let d = Math.max(0, Math.floor(visFrom / step) * step); d < Math.min(DAYS, visTo); d += step) {
+        const wd = dow(d);
+        const hol = HOLIDAYS.find(h => h.d >= d && h.d < d + step);
+        axisMinor.push({
+          left: (d * px) + 'px', width: (step * px) + 'px',
+          label: S.zoom === 'Day' ? String(new Date(new Date(2026, 0, 5).getTime() + d * 86400000).getDate()) : 'W' + (Math.floor(d / 7) % 53 + 1),
+          bg: hol && S.showHolidays ? '#FBF0DC' : (S.zoom === 'Day' && (wd === 5 || wd === 6) ? '#F1F3F7' : 'transparent'),
+          fg: hol && S.showHolidays ? '#8A5200' : '#4B5563'
+        });
+      }
+    } else {
+      for (let q = 0; q < 9; q++) {
+        const d0 = Math.round(q * 91.3);
+        axisMajor.push({ left: (d0 * px) + 'px', width: (91.3 * px) + 'px', label: 'Q' + (q % 4 + 1) + ' ' + (2026 + Math.floor(q / 4)) });
+      }
+      for (let m = 0; m < 25; m++) {
+        const d0 = Math.round(m * 30.44);
+        axisMinor.push({ left: (d0 * px) + 'px', width: (30.44 * px) + 'px', label: MONTHS[m % 12], bg: 'transparent', fg: '#4B5563' });
+      }
+    }
+
+    const selObj = flat.find(f => f.o.id === S.selected);
+    const nudged = nudgeOf(S.selected);
+    const statusText = S.moveMode
+      ? 'Move mode — ' + (selObj ? selObj.o.name : 'nothing selected')
+      : (selObj ? 'Selected: ' + selObj.o.name : 'Nothing selected');
+    const statusHint = S.moveMode
+      ? '← → nudge by 1 ' + S.zoom.toLowerCase() + (nudged ? ' · moved ' + (nudged > 0 ? '+' : '') + nudged + ' days' : '') + ' · Shift+arrow ×4 · Enter commits · Esc reverts'
+      : 'Press M to move · ' + S.pending + ' change' + (S.pending === 1 ? '' : 's') + ' pending sync';
+
+    return {
+      phaseCount: '80', taskCount: '1,200', windowSize: String(count),
+      rowTotal: flat.length.toLocaleString(), rowCount: flat.length,
+      windowLabel: win.length + ' rows',
+      canvasWidth: canvasW + 'px',
+      canvasHeight: (flat.length * ROW_H) + 'px',
+      treeShift: (-S.scrollTop) + 'px',
+      axisShift: (-S.scrollLeft) + 'px',
+      todayLeft: (TODAY * px) + 'px',
+      todayLabelTop: (S.scrollTop + 4) + 'px',
+      rows, bars, segs, arrowHeads, stubs, shading, axisMajor, axisMinor,
+      announce: S.announce,
+      onKey: (e) => this.onKey(e),
+      sayExamples: [
+        { k: '↓', v: 'Fit-gap — Finance 6, task, level 2, 14 Jul 26 to 27 Jul 26, row 39 of 95.' },
+        { k: 'M', v: 'Move mode on. Fit-gap — Finance 6. Left and right arrows move by one week. Enter commits, Escape reverts.' },
+        { k: '→ (move)', v: 'Start 21 Jul 26, finish 03 Aug 26.' },
+        { k: 'Enter', v: 'Moved Fit-gap — Finance 6 by 7 days later. Saved locally, 3 changes pending sync.' },
+        { k: 'Esc', v: 'Move cancelled. Fit-gap — Finance 6 returned to 14 Jul 26.' },
+        { k: '→ on phase', v: 'Realize · Data Migration expanded, 15 tasks.' }
+      ],
+      depLegend: [
+        { k: 'FS', v: 'Finish-to-start, the default: the arrow leaves the predecessor’s right edge and enters the successor’s left edge.' },
+        { k: 'FS + lag', v: 'Same geometry; the lag is written on the successor’s tooltip and in its accessible name (“2-day lag”).' },
+        { k: 'SS', v: 'Start-to-start: the arrow leaves the predecessor’s left edge. Used for the cross-phase links every third phase carries here.' },
+        { k: '◀ stub', v: 'The predecessor is outside the rendered window or inside a collapsed phase. The stub is focusable and ← navigates to it, expanding the phase if needed.' }
+      ],
+      statusText, statusHint,
+      statusBg: S.moveMode ? '#E8F0FE' : '#F6F7F9',
+      statusFg: S.moveMode ? '#0B57D0' : '#101720',
+      onScroll: (e) => { this._el = e.target; this.setState({ scrollTop: e.target.scrollTop, scrollLeft: e.target.scrollLeft, viewportW: e.target.clientWidth }); },
+      canvasRef: (el) => { if (el) this._el = el; },
+      collapseAll: () => {
+        this.setState({ expanded: {} });
+        if (this._el) { this._el.scrollTop = 0; this.setState({ scrollTop: 0 }); }
+      },
+      expandStage: () => {
+        const x = {};
+        this.data.forEach(p => { if (p.stage === 'Realize') x[p.id] = true; });
+        this.setState({ expanded: x }, () => {
+          const flat2 = this.flat();
+          const idx = flat2.findIndex(f => f.kind === 'phase' && f.o.stage === 'Realize');
+          const startDay = idx >= 0 ? flat2[idx].o.start : 160;
+          const el = this._el;
+          if (el) {
+            el.scrollTop = Math.max(0, idx * ROW_H);
+            el.scrollLeft = Math.max(0, startDay * PX[this.state.zoom] - 80);
+            this.setState({ scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, viewportW: el.clientWidth, selected: flat2[idx].o.id });
+          }
+        });
+      },
+      zoomCells: ['Day', 'Week', 'Month', 'Quarter'].map(z => ({
+        label: z,
+        bg: S.zoom === z ? '#FFFFFF' : 'transparent',
+        fg: S.zoom === z ? '#101720' : '#4B5563',
+        bd: S.zoom === z ? '#7D8799' : 'transparent',
+        sh: S.zoom === z ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => this.setState({ zoom: z })
+      })),
+      layerToggles: [
+        { key: 'showCritical', label: 'Critical path' },
+        { key: 'showBaseline', label: 'Baseline v3' },
+        { key: 'showHeat', label: 'Allocation heat' },
+        { key: 'showHolidays', label: 'Holidays' }
+      ].map(t => ({
+        label: t.label,
+        mark: S[t.key] ? '✓' : '○',
+        bg: S[t.key] ? '#E8F0FE' : '#FFFFFF',
+        fg: S[t.key] ? '#0B57D0' : '#4B5563',
+        bd: S[t.key] ? '#BBD0F6' : '#CBD2DC',
+        on: () => this.setState(s => { const o = {}; o[t.key] = !s[t.key]; return o; })
+      })),
+
+      geometry: [
+        { k: 'Row height', v: '32px standard, 28px compact. Both keep 13px/12.5px text — density never comes from shrinking type.' },
+        { k: 'Bar heights', v: 'Phase 10px with square caps, task 14px, milestone a 12px diamond centred on the row, baseline a 4px bar 2px below the current bar.' },
+        { k: 'Minimum bar', v: '4px. Below that a bar is unclickable, so a sub-grain task renders at 4px with a 24px invisible hit area and its label always outside.' },
+        { k: 'Label overflow', v: 'A label needs width ≥ 6.2 × characters + 14px padding. Below that it moves outside the bar’s right edge in content/primary; below 60px of free canvas it becomes a tooltip only, and the tree column remains the reliable place to read the name.' },
+        { k: 'Label contrast', v: 'The label is drawn twice and clipped at the progress boundary: content/primary #101720 over the unfilled accent/subtle remainder at 15.72:1, and content/inverse #FFFFFF over the filled accent at 6.39:1. Phase bars keep white throughout — 7.56:1 on the unfilled #4B5563 body and 18.02:1 on the filled #101720. No label ever crosses a boundary at low contrast.' },
+        { k: 'Zoom grain', v: 'Day 26px, Week 8.4px, Month 2.9px, Quarter 1.15px per day. Weekend and holiday shading render at Day and Week only — at Month a single day is 2.9px and shading becomes noise.' },
+        { k: 'Sticky left', v: 'The 392px tree pane is a separate scroll-locked pane translated by the canvas scrollTop, so it never repaints on horizontal scroll and never detaches vertically.' },
+        { k: 'Today marker', v: '2px accent line spanning the full canvas height with a pinned label that follows the vertical scroll, so it is legible at row 800 as well as row 1.' },
+        { k: 'Dependency arrows', v: 'Orthogonal, 1.5px, border/strong; critical-path links inherit status/danger. Drawn only between rows currently in the window — off-window predecessors show a ◀ stub on the successor bar.' }
+      ],
+      scaleRules: [
+        'All 80 phases collapse by default. Nothing above 40 rows auto-expands, because a plan that opens 1,280 rows deep cannot be read and costs a second of layout.',
+        'Vertical windowing renders ~' + count + ' rows regardless of dataset size; the scroll container is sized by row count so the scrollbar stays honest.',
+        'Horizontal windowing: shading and axis ticks are generated only for the visible day range plus 2 days of bleed. At Quarter zoom the whole 730-day range is 840px, so nothing is windowed horizontally.',
+        'Bars are plain absolutely-positioned divs, not SVG — 30 divs beat one 1,200-node SVG for scroll performance, and each bar keeps a real DOM node for focus and ARIA.',
+        'Expand-all is deliberately absent. “Expand stage” is offered instead, because a stage is the largest unit a person can scan.',
+        'Filtering (workstream, region, status, resource) reduces the flat list before windowing, so a filtered plan of 40 rows scrolls like a 40-row plan.',
+        'The tree pane truncates names with an ellipsis and never wraps: a wrapped name would desynchronise the two panes’ row heights, which is the one failure a split Gantt cannot recover from.'
+      ],
+      keys: [
+        { k: '↑ ↓', v: 'Move the row cursor. Selection follows focus; the canvas scrolls to keep the row visible.' },
+        { k: '← →', v: 'Collapse / expand the focused phase. On a task, ← jumps to its predecessor.' },
+        { k: 'M', v: 'Toggle Move mode on the selected bar. The status strip turns accent and states the grain.' },
+        { k: '← → (move)', v: 'Nudge by one zoom grain — 1 day, 1 week, 1 month, 1 quarter. Shift multiplies by 4.' },
+        { k: 'Enter / Esc', v: 'Commit the move, or revert to the position held before Move mode was entered.' },
+        { k: '⌥ ← →', v: 'Resize: move the finish date only, leaving the start fixed. Minimum duration 1 day.' },
+        { k: '⌥ ↑ ↓', v: 'Reorder the focused task within its phase — the keyboard equivalent of drag-reorder.' },
+        { k: 'Space', v: 'Add or remove the focused row from the multi-selection; the count is announced.' },
+        { k: '+ / −', v: 'Zoom in / out one step, anchored on the selected bar rather than the viewport centre.' },
+        { k: 'T', v: 'Scroll to today.' }
+      ],
+      notProto: [
+        { k: 'Shift + ↑ ↓', v: 'Extend a contiguous multi-selection. Specified; the prototype implements only Space-toggled selection.' },
+        { k: 'G then C', v: 'Open the critical-path drawer. Specified in Layer 3’s drawer pattern; not wired here.' },
+        { k: 'Pointer drag', v: 'Drag-to-move, drag-to-resize and drag-to-reorder are specified with the same grain and snapping as their keyboard equivalents above, which are the prototyped path.' },
+        { k: '⌘ Z / ⇧⌘ Z', v: 'Undo and redo across move, resize, reorder and delete, announced per Layer 3’s undo strings.' }
+      ],
+      a11y: [
+        { k: 'Structure', v: 'role="treegrid" aria-rowcount aria-multiselectable on the container; every row carries aria-level, aria-selected, aria-rowindex, aria-posinset and aria-setsize, and phase rows carry aria-expanded. All of these are in the rendered markup — inspect any row to confirm.' },
+        { k: 'Predecessors', v: 'Each task row has aria-describedby pointing at a visually hidden node listing every predecessor by name, link type and lag: “Predecessors: Sign-off — Finance 8 (finish-to-start, 2-day lag).”' },
+        { k: 'Bar name', v: '“Unit test — Finance 4, task, Realize · Finance, 12 to 26 October 2026, 15 working days, 60% complete, 120% allocated, on critical path.” Everything the colour and hatch encode is in the name.' },
+        { k: 'Move mode', v: 'Entering announces “Move mode. Left and right arrows move by one week.” Each nudge announces the new start date only — not the whole name — so repeated nudging stays usable.' },
+        { k: 'Windowing', v: 'aria-rowcount is the full flat count (1,280 when everything is expanded), aria-rowindex is absolute, so a screen reader reports “row 812 of 1,280” correctly.' },
+        { k: 'Dependencies', v: 'aria-describedby on the successor references a hidden node listing its predecessors; ← and → navigate the dependency graph directly rather than requiring the user to find an arrow.' },
+        { k: 'Non-working days', v: 'Weekend and holiday shading is decorative in the canvas; the same information is in each bar’s accessible name as working-day counts and in the date-picker cell names.' },
+        { k: 'Reduced motion', v: 'Scroll-to-row becomes an instant jump, zoom re-scale drops its 300ms transition, and the today marker never pulses.' }
+      ],
+      darkBars: [
+        { rowBg: '#171C24', left: '12px', w: '150px', bg: '#3D4757', border: '1px solid #E9EEF6', prog: '62%', progBg: '#8592A6', fg: '#E9EEF6', label: 'Realize · Finance' },
+        { rowBg: '#171C24', left: '40px', w: '96px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '80%', progBg: '#7FB0FF', fg: '#0B1220', label: 'Fit-gap 3' },
+        { rowBg: '#16294A', left: '96px', w: '120px', bg: '#16294A', border: '1.5px solid #FF8A80', prog: '35%', progBg: '#7FB0FF', fg: '#E9EEF6', label: '▲ Mock conversion 3' },
+        { rowBg: '#171C24', left: '150px', w: '64px', bg: '#16294A', border: '1px solid #7FB0FF', prog: '0%', progBg: '#7FB0FF', fg: '#E9EEF6', label: 'Sign-off' }
+      ],
+      summaryRows: [
+        { name: 'Prepare', pct: '100%', fill: '#0A7A47', dates: '05 Jan – 09 Mar', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Explore', pct: '100%', fill: '#0A7A47', dates: '23 Feb – 13 Jul', pill: 'Complete', pillG: '✓', pillBg: '#FFFFFF', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Realize', pct: '62%', fill: '#0B57D0', dates: '14 Jun – 03 Apr 27', pill: 'At risk', pillG: '⚠', pillBg: '#FBF0DC', pillFg: '#8A5200', pillBd: '#E0C089' },
+        { name: 'Deploy', pct: '8%', fill: '#0B57D0', dates: '12 Mar – 27 Jul 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' },
+        { name: 'Run', pct: '0%', fill: '#0B57D0', dates: '15 Jul – 26 Dec 27', pill: 'Not started', pillG: '●', pillBg: '#F1F3F7', pillFg: '#4B5563', pillBd: '#CBD2DC' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/org-chart.html
+++ b/docs/design/org-chart.html
@@ -1,0 +1,610 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 26px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4c of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Delivery org chart</h1>
+  <p style="margin:16px 0 0;max-width:78ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">{{ nodeCount }} people in the delivery structure. Drag the canvas to pan, use the zoom control or <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">+ −</kbd>, click a card to select, <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">C</kbd> collapses a subtree and <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:12px">R</kbd> starts a keyboard reparent — the equivalent of drag-to-reparent.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #CBD2DC;flex-wrap:wrap">
+      <div style="display:inline-flex;align-items:center;gap:6px">
+        <button onClick="{{ zoomOut }}" aria-label="Zoom out" style="width:28px;height:28px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:14px;cursor:pointer">−</button>
+        <span style="min-width:52px;text-align:center;font-size:12.5px;font-weight:500;font-variant-numeric:tabular-nums">{{ zoomPct }}</span>
+        <button onClick="{{ zoomIn }}" aria-label="Zoom in" style="width:28px;height:28px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:14px;cursor:pointer">+</button>
+        <button onClick="{{ fit }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Fit</button>
+      </div>
+      <div style="width:1px;height:20px;background:#CBD2DC"></div>
+      <sc-if value="{{ showRate }}" hint-placeholder-val="{{ true }}"><span style="font-size:0"></span></sc-if>
+      <button onClick="{{ toggleRate }}" style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;border-radius:6px;font-size:12.5px;font-weight:500;cursor:pointer;background:{{ rateBg }};color:{{ rateFg }};border:1px solid {{ rateBd }}"><span style="font-family:'IBM Plex Mono',monospace;font-size:11px">{{ rateMark }}</span>Show day rates</button>
+      <button onClick="{{ collapseL3 }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Collapse level 3</button>
+      <button onClick="{{ expandAll }}" style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Expand all</button>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px;font-size:12px;color:#4B5563">
+        <span style="font-variant-numeric:tabular-nums">{{ visibleCount }} of {{ nodeCount }} shown</span>
+        <span style="width:1px;height:16px;background:#CBD2DC"></span>
+        <span style="font-variant-numeric:tabular-nums">Blended rate MYR {{ blended }}/day</span>
+      </div>
+    </div>
+
+    <div ref="{{ canvasRef }}" role="tree" aria-label="Delivery organisation" aria-activedescendant="{{ activeId }}" tabindex="0" onKeyDown="{{ onKey }}" onMouseDown="{{ onDown }}" onMouseMove="{{ onMove }}" onMouseUp="{{ onUp }}" onMouseLeave="{{ onUp }}" style="position:relative;height:560px;overflow:hidden;background:#F6F7F9;cursor:{{ cursor }};outline:none">
+      <div style="position:absolute;inset:0;background-image:radial-gradient(#E4E7EC 1px,transparent 1px);background-size:24px 24px;opacity:.7"></div>
+      <div style="position:absolute;top:0;left:0;transform:translate({{ panX }},{{ panY }}) scale({{ scale }});transform-origin:0 0">
+        <sc-for list="{{ links }}" as="l" hint-placeholder-count="20">
+          <div style="position:absolute;left:{{ l.left }};top:{{ l.top }};width:{{ l.w }};height:{{ l.h }};border-left:{{ l.bl }};border-top:{{ l.bt }};border-color:{{ l.color }}"></div>
+        </sc-for>
+        <sc-for list="{{ nodes }}" as="n" hint-placeholder-count="24">
+          <div id="{{ n.domId }}" role="treeitem" aria-level="{{ n.level }}" aria-selected="{{ n.selAttr }}" aria-expanded="{{ n.expAttr }}" aria-label="{{ n.aria }}" onClick="{{ n.on }}" style="position:absolute;left:{{ n.x }};top:{{ n.y }};width:196px;background:{{ n.bg }};border:{{ n.border }};border-radius:8px;box-shadow:{{ n.shadow }};padding:10px 12px;min-height:{{ n.minH }};box-sizing:border-box;position:relative;cursor:pointer">
+            <div style="display:flex;align-items:center;gap:9px">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;flex:none;border-radius:999px;background:{{ n.avBg }};color:{{ n.avFg }};font-size:11px;font-weight:600">{{ n.initials }}</span>
+              <span style="min-width:0;flex:1">
+                <span style="display:block;font-size:12.5px;line-height:17px;font-weight:600;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ n.name }}</span>
+                <span style="display:block;font-size:11px;line-height:15px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ n.role }}</span>
+              </span>
+            </div>
+            <sc-if value="{{ n.full }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex;align-items:center;gap:6px;margin-top:8px">
+                <span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:10px;font-weight:500;color:#4B5563">{{ n.region }}</span>
+                <span style="font-size:11px;color:#4B5563;font-variant-numeric:tabular-nums">{{ n.rateText }}</span>
+                <sc-if value="{{ n.kids }}" hint-placeholder-val="{{ false }}">
+                  <button onClick="{{ n.toggle }}" aria-label="{{ n.toggleLabel }}" style="margin-left:auto;display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 6px;border-radius:999px;border:1px solid #7D8799;background:#FFFFFF;font-size:10px;font-weight:600;color:#101720;cursor:pointer;font-variant-numeric:tabular-nums">{{ n.chev }}{{ n.kids }}</button>
+                </sc-if>
+              </div>
+            </sc-if>
+            <sc-if value="{{ n.compact }}" hint-placeholder-val="{{ false }}">
+              <sc-if value="{{ n.kids }}" hint-placeholder-val="{{ false }}">
+                <button onClick="{{ n.toggle }}" aria-label="{{ n.toggleLabel }}" style="position:absolute;right:8px;bottom:8px;display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 6px;border-radius:999px;border:1px solid #7D8799;background:#FFFFFF;font-size:10px;font-weight:600;color:#101720;cursor:pointer;font-variant-numeric:tabular-nums">{{ n.chev }}{{ n.kids }}</button>
+              </sc-if>
+            </sc-if>
+            <sc-if value="{{ n.isTarget }}" hint-placeholder-val="{{ false }}">
+              <span style="position:absolute;inset:-4px;border:2px dashed #0B57D0;border-radius:10px"></span>
+            </sc-if>
+          </div>
+        </sc-for>
+      </div>
+      <sc-if value="{{ reparenting }}" hint-placeholder-val="{{ false }}">
+        <div style="position:absolute;left:14px;bottom:14px;right:14px;display:flex;align-items:center;gap:12px;background:#E8F0FE;border:1px solid #0B57D0;border-radius:8px;padding:10px 14px;box-shadow:0 8px 28px rgba(16,23,32,.14)">
+          <span style="font-size:12.5px;font-weight:600;color:#0B57D0">Reparent: {{ movingName }}</span>
+          <span style="font-size:12.5px;color:#4B5563">New manager → <span style="font-weight:600;color:#101720">{{ targetName }}</span></span>
+          <span style="margin-left:auto;font-size:12px;color:#4B5563">↑↓ choose · Enter commit · Esc cancel</span>
+        </div>
+      </sc-if>
+    </div>
+
+    <div id="org-status" role="status" aria-live="polite" aria-atomic="true" style="display:flex;align-items:flex-start;gap:10px;padding:8px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }}">
+      <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">Announced</span>
+      <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:28px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Node card anatomy</h3>
+      <sc-for list="{{ anatomy }}" as="a" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:118px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Rules</h3>
+      <sc-for list="{{ rules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Keyboard &amp; announcements</h3>
+      <sc-for list="{{ keys }}" as="k" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:96px 1fr;gap:12px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline"><kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div></div>
+      </sc-for>
+      <div style="margin-top:14px;display:flex;flex-direction:column;gap:6px">
+        <sc-for list="{{ sayExamples }}" as="s" hint-placeholder-count="4">
+          <div style="font-size:12px;line-height:18px;color:#101720;background:#F1F3F7;border:1px solid #E4E7EC;border-radius:4px;padding:6px 8px"><span style="font-family:'IBM Plex Mono',monospace;color:#0B57D0">{{ s.k }}</span> — “{{ s.v }}”</div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 0">
+  <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+    <div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap">
+      <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Print layout — A4 landscape</h3>
+      <span style="font-size:12.5px;color:#4B5563">297 × 210 mm · shown at 38% · the same artefact the proposal pack embeds</span>
+    </div>
+    <div style="margin-top:16px;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:6px;padding:20px;height:342px;overflow:hidden;display:flex;justify-content:center">
+      <div style="width:1122px;height:794px;flex:none;transform:scale(.38);transform-origin:top center;background:#FFFFFF;border:1px solid #CBD2DC;box-shadow:0 8px 28px rgba(16,23,32,.14);padding:40px 44px;box-sizing:border-box;display:flex;flex-direction:column">
+        <div style="display:flex;align-items:flex-start;border-bottom:2px solid #101720;padding-bottom:12px">
+          <div>
+            <div style="font-size:22px;font-weight:600;letter-spacing:-0.015em">Delivery organisation — S/4HANA Migration</div>
+            <div style="font-size:13px;color:#4B5563;margin-top:4px">Sarawak Energy · Programme PRJ-2291 · Structure as at 07 Aug 2026</div>
+          </div>
+          <div style="margin-left:auto;text-align:right;font-size:12px;color:#4B5563;line-height:18px">
+            <div style="font-weight:600;color:#101720">ABeam Consulting</div>
+            <div>42 people · 4 regions</div>
+            <div>Blended rate MYR 2,312 / day</div>
+          </div>
+        </div>
+        <div style="flex:1;position:relative;margin-top:24px;transform:scale({{ printScale }});transform-origin:top left">
+          <sc-for list="{{ printLinks }}" as="l" hint-placeholder-count="16">
+            <div style="position:absolute;left:{{ l.left }};top:{{ l.top }};width:{{ l.w }};height:{{ l.h }};border-left:{{ l.bl }};border-top:{{ l.bt }};border-color:#7D8799"></div>
+          </sc-for>
+          <sc-for list="{{ printNodes }}" as="n" hint-placeholder-count="20">
+            <div style="position:absolute;left:{{ n.x }};top:{{ n.y }};width:168px;border:1px solid #101720;border-top:3px solid {{ n.accent }};border-radius:4px;padding:7px 9px;background:#FFFFFF">
+              <div style="font-size:12px;font-weight:600;line-height:16px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ n.name }}</div>
+              <div style="font-size:11px;color:#4B5563;line-height:15px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ n.role }}</div>
+              <div style="display:flex;justify-content:space-between;font-size:10.5px;color:#101720;margin-top:4px;font-variant-numeric:tabular-nums"><span>{{ n.region }}</span><span>{{ n.rate }}</span></div>
+            </div>
+          </sc-for>
+        </div>
+        <div style="display:flex;align-items:center;gap:20px;border-top:1px solid #CBD2DC;padding-top:10px;font-size:11px;color:#4B5563">
+          <span style="display:inline-flex;align-items:center;gap:6px"><span style="width:22px;height:3px;background:#0B57D0"></span>Programme leadership</span>
+          <span style="display:inline-flex;align-items:center;gap:6px"><span style="width:22px;height:3px;background:#0A7A47"></span>Workstream lead</span>
+          <span style="display:inline-flex;align-items:center;gap:6px"><span style="width:22px;height:3px;background:#8A5200"></span>Subcontracted</span>
+          <span style="margin-left:auto">Page 1 of 2 · Levels 1–3. Level 4 continues on page 2, grouped by workstream.</span>
+        </div>
+      </div>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;margin-top:20px">
+      <sc-for list="{{ printRules }}" as="p" hint-placeholder-count="4">
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty"><span style="font-weight:600;color:#101720">{{ p.k }} — </span>{{ p.v }}</div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:16px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark</h3>
+      <div style="display:flex;gap:12px;flex-wrap:wrap">
+        <sc-for list="{{ darkNodes }}" as="n" hint-placeholder-count="3">
+          <div style="width:196px;background:{{ n.bg }};border:{{ n.border }};border-radius:8px;padding:10px 12px">
+            <div style="display:flex;align-items:center;gap:9px">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:{{ n.avBg }};color:{{ n.avFg }};font-size:11px;font-weight:600">{{ n.initials }}</span>
+              <span style="min-width:0"><span style="display:block;font-size:12.5px;font-weight:600;color:#E9EEF6">{{ n.name }}</span><span style="display:block;font-size:11px;color:#AFBACA">{{ n.role }}</span></span>
+            </div>
+            <div style="display:flex;align-items:center;gap:6px;margin-top:8px"><span style="height:18px;padding:0 6px;display:inline-flex;align-items:center;border-radius:3px;background:#0A0D12;border:1px solid #333C4A;font-size:10px;color:#AFBACA">{{ n.region }}</span><span style="font-size:11px;color:#AFBACA;font-variant-numeric:tabular-nums">{{ n.rate }}</span></div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:12px">Cards are surface/raised on a surface/base canvas; the dot grid drops to <span style="font-family:'IBM Plex Mono',monospace">#232A35</span> at 1.31:1, deliberately below the boundary threshold because it is texture, not structure. Connector lines use border/strong at 4.79:1 — they <em>are</em> structure.</div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Reparent — pointer and keyboard</h3>
+      <div style="font-size:12.5px;line-height:20px;color:#4B5563;text-wrap:pretty">Dragging a card lifts it to elevation/3, dims its former connector to 40%, and outlines every legal drop target with a 2px dashed accent ring. Illegal targets — the node itself, its own descendants, and anyone outside the programme — get no ring and reject the drop with a shake of 4px over 120ms (suppressed under reduced motion, replaced by a status/danger border flash).</div>
+      <div style="font-size:12.5px;line-height:20px;color:#4B5563;margin-top:10px;text-wrap:pretty">The keyboard path is identical in outcome and announced at each step: <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">R</span> enters reparent mode with the current manager preselected, ↑↓ walks the legal-target list in tree order, Enter commits, Escape restores. No pointer-only capability exists in this surface.</div>
+      <h3 style="margin:18px 0 10px;font-size:16px;line-height:22px;font-weight:600">Accessibility contract</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Responsive</h3>
+      <sc-for list="{{ responsive }}" as="r" hint-placeholder-count="5">
+        <div style="display:grid;grid-template-columns:78px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+const PEOPLE = [
+  { id: 'n1', p: null, name: 'Nurul Iman', role: 'Programme Director', region: 'MY', rate: 4000, kind: 'lead' },
+  { id: 'n2', p: 'n1', name: 'Chan Wei Ling', role: 'Delivery Manager', region: 'MY', rate: 2900, kind: 'lead' },
+  { id: 'n3', p: 'n1', name: 'Rajesh Menon', role: 'Solution Architect', region: 'MY', rate: 3200, kind: 'lead' },
+  { id: 'n4', p: 'n1', name: 'Wong Jia Hui', role: 'PMO Lead', region: 'MY', rate: 1400, kind: 'stream' },
+  { id: 'n5', p: 'n2', name: 'Aisyah Rahman', role: 'Finance Lead (FI/CO)', region: 'MY', rate: 2400, kind: 'stream' },
+  { id: 'n6', p: 'n2', name: 'Lim Siew Fong', role: 'Logistics Lead (MM/SD)', region: 'MY', rate: 2400, kind: 'stream' },
+  { id: 'n7', p: 'n2', name: 'Sharifah Aziz', role: 'Human Capital Lead', region: 'MY', rate: 2300, kind: 'stream' },
+  { id: 'n8', p: 'n3', name: 'Zulkifli Hassan', role: 'Basis Lead', region: 'MY', rate: 2600, kind: 'stream' },
+  { id: 'n9', p: 'n3', name: 'Goh Mei Yee', role: 'Integration Architect', region: 'SG', rate: 3800, kind: 'stream' },
+  { id: 'n10', p: 'n3', name: 'Daniel Okafor', role: 'Data Migration Lead', region: 'MY', rate: 2700, kind: 'stream' },
+  { id: 'n11', p: 'n2', name: 'Siti Nurhaliza', role: 'Test Lead', region: 'MY', rate: 2200, kind: 'stream' },
+  { id: 'n12', p: 'n2', name: 'Farah Nasution', role: 'Change Manager', region: 'MY', rate: 2100, kind: 'stream' },
+  { id: 'n13', p: 'n5', name: 'Tan Boon Hock', role: 'FI/CO Consultant', region: 'MY', rate: 2400, kind: 'member' },
+  { id: 'n14', p: 'n5', name: 'Cheryl Tan', role: 'FI/CO Consultant', region: 'SG', rate: 3200, kind: 'member' },
+  { id: 'n15', p: 'n5', name: 'Iskandar Zulkarnain', role: 'Business Analyst', region: 'MY', rate: 1800, kind: 'member' },
+  { id: 'n16', p: 'n6', name: 'Hafiz Kamarudin', role: 'MM/SD Consultant', region: 'MY', rate: 2400, kind: 'member' },
+  { id: 'n17', p: 'n6', name: 'Yeo Chin Wei', role: 'PP/QM Consultant', region: 'MY', rate: 2500, kind: 'member' },
+  { id: 'n18', p: 'n7', name: 'Devi Krishnan', role: 'HCM Consultant', region: 'MY', rate: 2300, kind: 'member' },
+  { id: 'n19', p: 'n8', name: 'Mohd Faizal', role: 'Basis Consultant', region: 'MY', rate: 2600, kind: 'member' },
+  { id: 'n20', p: 'n8', name: 'Arun Prakash', role: 'ABAP Developer', region: 'IN', rate: 1100, kind: 'member' },
+  { id: 'n21', p: 'n8', name: 'Priya Raghavan', role: 'ABAP Developer', region: 'IN', rate: 1100, kind: 'member' },
+  { id: 'n22', p: 'n9', name: 'Kavitha Nair', role: 'Integration Consultant', region: 'SG', rate: 3800, kind: 'member' },
+  { id: 'n23', p: 'n9', name: 'Nguyen Thi Lan', role: 'Security Consultant', region: 'VN', rate: 1300, kind: 'sub' },
+  { id: 'n24', p: 'n10', name: 'Ng Kah Seng', role: 'Data Migration Analyst', region: 'MY', rate: 2700, kind: 'member' },
+  { id: 'n25', p: 'n11', name: 'Ravi Subramaniam', role: 'Test Analyst', region: 'MY', rate: 2200, kind: 'member' },
+  { id: 'n26', p: 'n12', name: 'Suriani Bakar', role: 'Training Lead', region: 'MY', rate: 2100, kind: 'member' },
+  { id: 'n27', p: 'n4', name: 'Amirul Shah', role: 'PMO Analyst', region: 'MY', rate: 1400, kind: 'member' },
+  { id: 'n28', p: 'n4', name: 'Lee Kok Wai', role: 'Cutover Lead', region: 'MY', rate: 2900, kind: 'stream' },
+  { id: 'n29', p: 'n28', name: 'Firdaus Omar', role: 'Cutover Analyst', region: 'MY', rate: 2900, kind: 'member' },
+  { id: 'n30', p: 'n9', name: 'Tran Van Minh', role: 'Security Consultant', region: 'VN', rate: 1300, kind: 'sub' }
+];
+const NW = 196, NH = 74, GAPX = 22, GAPY = 104;
+const ACCENT = { lead: '#0B57D0', stream: '#0A7A47', member: '#4B5563', sub: '#8A5200' };
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.state = {
+      scale: 0.5, panX: 12, panY: 18, dragging: false, sx: 0, sy: 0, px: 0, py: 0,
+      collapsed: {}, selected: 'n1', showRate: true, parents: {},
+      reparenting: false, targetIdx: 0,
+      announce: 'Org chart ready. 30 people, 4 levels. Arrow keys move between cards, C collapses a subtree, R reparents.'
+    };
+  }
+
+  parentOf(id) { const o = PEOPLE.find(p => p.id === id); return this.state.parents[id] !== undefined ? this.state.parents[id] : (o ? o.p : null); }
+  childrenOf(id) { return PEOPLE.filter(p => this.parentOf(p.id) === id); }
+
+  layout() {
+    const S = this.state;
+    const pos = {};
+    let cursorX = 0;
+    const walk = (id, depth) => {
+      const kids = S.collapsed[id] ? [] : this.childrenOf(id);
+      if (!kids.length) {
+        pos[id] = { x: cursorX, y: depth * GAPY, depth };
+        cursorX += NW + GAPX;
+        return pos[id];
+      }
+      const childPos = kids.map(k => walk(k.id, depth + 1));
+      const minX = childPos[0].x, maxX = childPos[childPos.length - 1].x;
+      pos[id] = { x: (minX + maxX) / 2, y: depth * GAPY, depth };
+      return pos[id];
+    };
+    walk('n1', 0);
+    return pos;
+  }
+
+  visibleIds(pos) { return PEOPLE.filter(p => pos[p.id]).map(p => p.id); }
+
+  descendants(id) {
+    const out = [];
+    const walk = (i) => this.childrenOf(i).forEach(c => { out.push(c.id); walk(c.id); });
+    walk(id);
+    return out;
+  }
+
+  say(m) { this.setState({ announce: m }); }
+
+  extents(pos) {
+    let maxX = 0, maxY = 0;
+    Object.keys(pos).forEach(k => { maxX = Math.max(maxX, pos[k].x + NW); maxY = Math.max(maxY, pos[k].y + NH); });
+    return { w: maxX, h: maxY };
+  }
+
+  // Fit never goes below the 40% legibility floor. If the full tree cannot
+  // fit at 40%, collapse the deepest level that still can, and say so.
+  fitView(quiet) {
+    const el = this._canvas;
+    const cw = (el ? el.clientWidth : 1400) - 32;
+    const ch = (el ? el.clientHeight : 560) - 32;
+    const FLOOR = 0.4;
+    const ratio = (collapsed) => {
+      const saved = this.state.collapsed;
+      this.state.collapsed = collapsed;
+      const pos = this.layout();
+      this.state.collapsed = saved;
+      const ex = this.extents(pos);
+      return { r: Math.min(cw / ex.w, ch / ex.h, 1), ex, pos };
+    };
+    const collapseDepth = (d) => {
+      const c = {};
+      const pos = this.layout();
+      PEOPLE.forEach(p => { if (pos[p.id] && pos[p.id].depth >= d && this.childrenOf(p.id).length) c[p.id] = true; });
+      return c;
+    };
+    const attempts = [
+      { c: {}, label: 'all four levels' },
+      { c: collapseDepth(2), label: 'levels 1 to 3' },
+      { c: collapseDepth(1), label: 'levels 1 to 2' }
+    ];
+    let chosen = attempts[attempts.length - 1];
+    let res = ratio(chosen.c);
+    for (let i = 0; i < attempts.length; i++) {
+      const t = ratio(attempts[i].c);
+      if (t.r >= FLOOR) { chosen = attempts[i]; res = t; break; }
+    }
+    const scale = Math.max(FLOOR, Math.min(res.r, 1));
+    const root = res.pos['n1'];
+    const rootCentreX = root ? (root.x + NW / 2) * scale : 0;
+    this.setState({
+      collapsed: chosen.c,
+      scale,
+      panX: Math.round(cw / 2 - rootCentreX + 16),
+      panY: 16
+    });
+    if (!quiet) {
+      const hidden = PEOPLE.length - Object.keys(res.pos).length;
+      this.say('Fitted at ' + Math.round(scale * 100) + '%, showing ' + chosen.label +
+        (hidden > 0 ? '. ' + hidden + ' people are collapsed; press C on a card or Expand all to reveal them.' : '. Everyone is visible.'));
+    }
+  }
+
+  componentDidMount() { setTimeout(() => this.fitView(true), 0); }
+
+  legalTargets() {
+    const bad = [this.state.selected].concat(this.descendants(this.state.selected));
+    return PEOPLE.filter(p => bad.indexOf(p.id) < 0);
+  }
+
+  onKey(e) {
+    const k = e.key;
+    const S = this.state;
+    const pos = this.layout();
+    const vis = this.visibleIds(pos);
+    const cur = PEOPLE.find(p => p.id === S.selected);
+    if (S.reparenting) {
+      const targets = this.legalTargets();
+      if (k === 'ArrowDown' || k === 'ArrowUp') {
+        e.preventDefault();
+        const n = Math.max(0, Math.min(targets.length - 1, S.targetIdx + (k === 'ArrowDown' ? 1 : -1)));
+        this.setState({ targetIdx: n });
+        this.say('Target ' + targets[n].name + ', ' + targets[n].role + '. ' + (n + 1) + ' of ' + targets.length + '.');
+        return;
+      }
+      if (k === 'Enter') {
+        e.preventDefault();
+        const t = targets[S.targetIdx];
+        const par = Object.assign({}, S.parents); par[S.selected] = t.id;
+        this.setState({ parents: par, reparenting: false });
+        this.say(cur.name + ' now reports to ' + t.name + '. ' + (this.descendants(S.selected).length) + ' people moved with them. Saved locally, 1 change pending sync.');
+        return;
+      }
+      if (k === 'Escape') { e.preventDefault(); this.setState({ reparenting: false }); this.say('Reparent cancelled. ' + cur.name + ' still reports to ' + (PEOPLE.find(p => p.id === this.parentOf(cur.id)) || { name: 'no one' }).name + '.'); return; }
+      return;
+    }
+    if (k === 'ArrowDown' || k === 'ArrowUp' || k === 'ArrowLeft' || k === 'ArrowRight') {
+      e.preventDefault();
+      let next = S.selected;
+      if (k === 'ArrowDown') { const kids = S.collapsed[S.selected] ? [] : this.childrenOf(S.selected); if (kids.length) next = kids[0].id; }
+      if (k === 'ArrowUp') { const p = this.parentOf(S.selected); if (p) next = p; }
+      if (k === 'ArrowLeft' || k === 'ArrowRight') {
+        const p = this.parentOf(S.selected);
+        const sibs = p ? this.childrenOf(p) : [PEOPLE[0]];
+        const i = sibs.findIndex(s => s.id === S.selected);
+        const j = Math.max(0, Math.min(sibs.length - 1, i + (k === 'ArrowRight' ? 1 : -1)));
+        next = sibs[j].id;
+      }
+      const o = PEOPLE.find(p => p.id === next);
+      const kids = this.childrenOf(next).length;
+      this.setState({ selected: next });
+      this.say(o.name + ', ' + o.role + ', ' + o.region + ', MYR ' + o.rate.toLocaleString() + ' per day, level ' + (pos[next] ? pos[next].depth + 1 : 1) +
+        (kids ? ', ' + kids + ' direct report' + (kids === 1 ? '' : 's') + ', ' + (S.collapsed[next] ? 'collapsed' : 'expanded') : ', no direct reports') + '.');
+      return;
+    }
+    if (k === 'c' || k === 'C') {
+      e.preventDefault();
+      const kids = this.childrenOf(S.selected).length;
+      if (!kids) { this.say(cur.name + ' has no direct reports to collapse.'); return; }
+      const c = Object.assign({}, S.collapsed);
+      const now = !c[S.selected];
+      if (now) c[S.selected] = true; else delete c[S.selected];
+      this.setState({ collapsed: c });
+      this.say(cur.name + ' subtree ' + (now ? 'collapsed, ' + this.descendants(S.selected).length + ' people hidden' : 'expanded') + '.');
+      return;
+    }
+    if (k === 'r' || k === 'R') {
+      e.preventDefault();
+      if (S.selected === 'n1') { this.say('The programme director has no manager to change.'); return; }
+      const targets = this.legalTargets();
+      const idx = Math.max(0, targets.findIndex(t => t.id === this.parentOf(S.selected)));
+      this.setState({ reparenting: true, targetIdx: idx });
+      this.say('Reparent mode. Moving ' + cur.name + ' with ' + this.descendants(S.selected).length + ' people. Up and down arrows choose a new manager from ' + targets.length + ' legal targets. Enter commits, Escape cancels.');
+      return;
+    }
+    if (k === '+' || k === '=') { e.preventDefault(); this.setState(s => ({ scale: Math.min(1.6, s.scale + 0.1) })); }
+    if (k === '-' || k === '_') { e.preventDefault(); this.setState(s => ({ scale: Math.max(0.4, s.scale - 0.1) })); }
+  }
+
+  renderVals() {
+    const S = this.state;
+    const pos = this.layout();
+    const targets = this.legalTargets();
+    const targetId = S.reparenting && targets[S.targetIdx] ? targets[S.targetIdx].id : null;
+
+    const nodes = PEOPLE.filter(p => pos[p.id]).map(p => {
+      const sel = S.selected === p.id;
+      const kids = this.childrenOf(p.id).length;
+      const hidden = S.collapsed[p.id] ? this.descendants(p.id).length : 0;
+      return {
+        domId: 'org-' + p.id, x: pos[p.id].x + 'px', y: pos[p.id].y + 'px',
+        level: pos[p.id].depth + 1, selAttr: sel ? 'true' : 'false',
+        expAttr: kids ? (S.collapsed[p.id] ? 'false' : 'true') : undefined,
+        aria: p.name + ', ' + p.role + ', ' + p.region + ', MYR ' + p.rate.toLocaleString() + ' per day' + (kids ? ', ' + kids + ' direct reports' : ', no direct reports'),
+        name: p.name, role: p.role, region: p.region,
+        rateText: S.showRate ? p.rate.toLocaleString() + '/day' : '•••',
+        initials: p.name.split(' ').map(w => w[0]).slice(0, 2).join(''),
+        avBg: p.kind === 'lead' ? '#E8F0FE' : p.kind === 'stream' ? '#E3F5EB' : p.kind === 'sub' ? '#FBF0DC' : '#F1F3F7',
+        avFg: p.kind === 'lead' ? '#0B57D0' : p.kind === 'stream' ? '#0A7A47' : p.kind === 'sub' ? '#8A5200' : '#4B5563',
+        bg: sel ? '#E8F0FE' : '#FFFFFF',
+        border: sel ? '1.5px solid #0B57D0' : '1px solid #7D8799',
+        shadow: sel ? '0 4px 12px rgba(16,23,32,.10)' : '0 1px 2px rgba(16,23,32,.06)',
+        compact: S.scale < 0.6,
+        full: S.scale >= 0.6,
+        minH: S.scale < 0.6 ? '52px' : '74px',
+        kids: kids ? (S.collapsed[p.id] ? '+' + hidden : String(kids)) : '',
+        chev: kids ? (S.collapsed[p.id] ? '▸' : '▾') : '',
+        toggleLabel: (S.collapsed[p.id] ? 'Expand ' : 'Collapse ') + p.name + ' subtree',
+        isTarget: targetId === p.id,
+        on: () => { this.setState({ selected: p.id }); this.say(p.name + ', ' + p.role + ', ' + p.region + ', MYR ' + p.rate.toLocaleString() + ' per day.'); },
+        toggle: (e) => {
+          e.stopPropagation();
+          const c = Object.assign({}, S.collapsed);
+          const now = !c[p.id];
+          if (now) c[p.id] = true; else delete c[p.id];
+          this.setState({ collapsed: c, selected: p.id });
+          this.say(p.name + ' subtree ' + (now ? 'collapsed, ' + this.descendants(p.id).length + ' people hidden' : 'expanded') + '.');
+        }
+      };
+    });
+
+    const links = [];
+    PEOPLE.forEach(p => {
+      const par = this.parentOf(p.id);
+      if (!par || !pos[p.id] || !pos[par]) return;
+      const cx = pos[p.id].x + NW / 2, cy = pos[p.id].y;
+      const px = pos[par].x + NW / 2, py = pos[par].y + NH;
+      const midY = py + (GAPY - NH) / 2;
+      links.push({ left: (px - 0.5) + 'px', top: py + 'px', w: '1px', h: (midY - py) + 'px', bl: '1px solid', bt: 'none', color: '#7D8799' });
+      links.push({ left: Math.min(px, cx) + 'px', top: midY + 'px', w: Math.abs(cx - px) + 'px', h: '1px', bl: 'none', bt: '1px solid', color: '#7D8799' });
+      links.push({ left: (cx - 0.5) + 'px', top: midY + 'px', w: '1px', h: (cy - midY) + 'px', bl: '1px solid', bt: 'none', color: '#7D8799' });
+    });
+
+    const printPos = {};
+    const pw = 168, pgx = 14, pgy = 96;
+    let px2 = 0;
+    const walkP = (id, depth) => {
+      if (depth > 2) return null;
+      const kids = this.childrenOf(id).filter(k => depth < 2);
+      if (!kids.length) { printPos[id] = { x: px2, y: depth * pgy, depth }; px2 += pw + pgx; return printPos[id]; }
+      const cp = kids.map(k => walkP(k.id, depth + 1)).filter(Boolean);
+      printPos[id] = { x: (cp[0].x + cp[cp.length - 1].x) / 2, y: depth * pgy, depth };
+      return printPos[id];
+    };
+    walkP('n1', 0);
+    const printNodes = PEOPLE.filter(p => printPos[p.id]).map(p => ({
+      x: printPos[p.id].x + 'px', y: printPos[p.id].y + 'px',
+      name: p.name, role: p.role, region: p.region, rate: 'MYR ' + p.rate.toLocaleString(),
+      accent: ACCENT[p.kind]
+    }));
+    const printLinks = [];
+    PEOPLE.forEach(p => {
+      const par = this.parentOf(p.id);
+      if (!par || !printPos[p.id] || !printPos[par]) return;
+      const cx = printPos[p.id].x + pw / 2, cy = printPos[p.id].y;
+      const ppx = printPos[par].x + pw / 2, ppy = printPos[par].y + 62;
+      const midY = ppy + 16;
+      printLinks.push({ left: (ppx - 0.5) + 'px', top: ppy + 'px', w: '1px', h: (midY - ppy) + 'px', bl: '1px solid', bt: 'none' });
+      printLinks.push({ left: Math.min(ppx, cx) + 'px', top: midY + 'px', w: Math.abs(cx - ppx) + 'px', h: '1px', bl: 'none', bt: '1px solid' });
+      printLinks.push({ left: (cx - 0.5) + 'px', top: midY + 'px', w: '1px', h: (cy - midY) + 'px', bl: '1px solid', bt: 'none' });
+    });
+
+    let pMaxX = 0, pMaxY = 0;
+    Object.keys(printPos).forEach(k => { pMaxX = Math.max(pMaxX, printPos[k].x + pw); pMaxY = Math.max(pMaxY, printPos[k].y + 62); });
+    const printScale = Math.min(1034 / pMaxX, 1);
+
+    const cur = PEOPLE.find(p => p.id === S.selected) || PEOPLE[0];
+    const blended = Math.round(PEOPLE.reduce((a, p) => a + p.rate, 0) / PEOPLE.length).toLocaleString();
+
+    return {
+      printScale: String(printScale), printScalePct: Math.round(printScale * 100) + '%',
+      nodeCount: String(PEOPLE.length), visibleCount: String(nodes.length),
+      blended, nodes, links, printNodes, printLinks,
+      activeId: 'org-' + S.selected,
+      zoomPct: Math.round(S.scale * 100) + '%',
+      scale: String(S.scale), panX: S.panX + 'px', panY: S.panY + 'px',
+      cursor: S.dragging ? 'grabbing' : 'grab',
+      announce: S.announce, statusBg: S.reparenting ? '#E8F0FE' : '#FFFFFF',
+      reparenting: S.reparenting,
+      movingName: cur.name,
+      targetName: targets[S.targetIdx] ? targets[S.targetIdx].name : '',
+      showRate: S.showRate,
+      rateMark: S.showRate ? '✓' : '○',
+      rateBg: S.showRate ? '#E8F0FE' : '#FFFFFF',
+      rateFg: S.showRate ? '#0B57D0' : '#4B5563',
+      rateBd: S.showRate ? '#BBD0F6' : '#CBD2DC',
+      toggleRate: () => this.setState(s => ({ showRate: !s.showRate })),
+      zoomIn: () => this.setState(s => ({ scale: Math.min(1.6, s.scale + 0.1) })),
+      zoomOut: () => this.setState(s => ({ scale: Math.max(0.4, s.scale - 0.1) })),
+      fit: () => this.fitView(false),
+      canvasRef: (el) => { if (el && !this._canvas) { this._canvas = el; setTimeout(() => this.fitView(true), 0); } },
+      collapseL3: () => { const c = {}; PEOPLE.forEach(p => { if (pos[p.id] && pos[p.id].depth === 2 && this.childrenOf(p.id).length) c[p.id] = true; }); this.setState({ collapsed: c }); this.say('Collapsed level 3. Only leads and their counts are shown.'); },
+      expandAll: () => { this.setState({ collapsed: {} }); this.say('All subtrees expanded. 30 people shown.'); },
+      onDown: (e) => this.setState({ dragging: true, sx: e.clientX, sy: e.clientY, px: S.panX, py: S.panY }),
+      onMove: (e) => { if (this.state.dragging) this.setState({ panX: this.state.px + (e.clientX - this.state.sx), panY: this.state.py + (e.clientY - this.state.sy) }); },
+      onUp: () => { if (this.state.dragging) this.setState({ dragging: false }); },
+      onKey: (e) => this.onKey(e),
+
+      anatomy: [
+        { k: 'Card', v: '196 × 74, radius/lg, 1px border/strong at 3.62:1. Selected takes 1.5px accent and accent/subtle fill; the border weight change means selection survives greyscale.' },
+        { k: 'Line 1', v: 'Name, type/body-sm weight 600, one line, ellipsis. Names are never abbreviated to initials on the card — the avatar already does that.' },
+        { k: 'Line 2', v: 'Role, type/label, content/secondary. This is the role in the programme, not the HR title.' },
+        { k: 'Meta row', v: 'Region chip, day rate in tabular numerals, and the direct-report counter. Rate obeys cost visibility: at level 1 it renders as ••• with the same width, never blank.' },
+        { k: 'Counter', v: 'A real button, 20px tall inside a 74px card so the composite target clears 24px. Shows the child count when expanded, “+N” hidden when collapsed.' },
+        { k: 'Connectors', v: 'Orthogonal, 1px border/strong, routed through a mid-gutter 15px below the parent. Never diagonal — a diagonal line at 60% zoom aliases into the dot grid.' }
+      ],
+
+      rules: [
+        'Layout is a tidy tree: leaves are packed left to right at a fixed pitch, parents centre over their children. Nothing overlaps at any zoom, so panning is the only navigation needed.',
+        'Collapse is per-subtree and its state is part of the saved view — a delivery manager who always works from a collapsed PMO branch gets it back on reload.',
+        'A collapsed node shows “+N”: the count of everyone hidden beneath it, not just direct children, so nothing disappears silently.',
+        'Zoom runs 40% to 160% in 10-point steps. Below 60% the meta row is dropped and the card shrinks to name plus role — a legibility floor, not a smooth scale.',
+        'Rate visibility is inherited from the project’s cost-visibility level, not a chart-local toggle; the switch here only hides rates on screen for a client-facing walkthrough and says so in its tooltip.',
+        'Reparenting moves the whole subtree, and the confirmation always names the count: “Moves Goh Mei Yee and 3 people.”',
+        'The chart is a view of the resource plan, not a second source of truth: renaming a person here renames them everywhere, and a person can appear exactly once.'
+      ],
+
+      keys: [
+        { k: '↑ ↓', v: 'Move to the manager or the first direct report.' },
+        { k: '← →', v: 'Move between siblings under the same manager.' },
+        { k: 'C', v: 'Collapse or expand the selected subtree; announces how many people were hidden.' },
+        { k: 'R', v: 'Enter reparent mode — the keyboard equivalent of drag-to-reparent.' },
+        { k: '↑ ↓ (R)', v: 'Walk the legal-target list, which excludes the node itself and all its descendants.' },
+        { k: 'Enter / Esc', v: 'Commit or cancel the reparent; both are announced with the resulting reporting line.' },
+        { k: '+ / −', v: 'Zoom in 10-point steps, anchored on the selected card.' }
+      ],
+
+      sayExamples: [
+        { k: '↓', v: 'Aisyah Rahman, Finance Lead (FI/CO), MY, MYR 2,400 per day, level 3, 3 direct reports, expanded.' },
+        { k: 'C', v: 'Aisyah Rahman subtree collapsed, 3 people hidden.' },
+        { k: 'R', v: 'Reparent mode. Moving Goh Mei Yee with 3 people. Up and down arrows choose a new manager from 26 legal targets. Enter commits, Escape cancels.' },
+        { k: 'Enter', v: 'Goh Mei Yee now reports to Chan Wei Ling. 3 people moved with them. Saved locally, 1 change pending sync.' }
+      ],
+
+      printRules: [
+        { k: 'Pagination', v: 'Levels 1–3 on page 1, scaled as one block to the 1,034 pt content width — here that lands at ' + Math.round(printScale * 100) + '% — with a floor of 70%. Below the floor the sheet drops to levels 1–2 and pushes level 3 to page 2 rather than shrinking type further. Level 4 always continues on page 2 grouped by workstream, each group repeating its lead as a stub card; subtrees are never split mid-branch.' },
+        { k: 'Ink', v: 'No fills. Structure is carried by a 1px black rule and a 3px coloured top edge per role class, which still reads as three distinct greys when printed mono.' },
+        { k: 'Header', v: 'Programme, client, project code and the “as at” date on every page, because a printed org chart outlives its accuracy.' },
+        { k: 'Rates', v: 'Included only when the exporter’s cost visibility allows it; otherwise the column is omitted entirely and the footer states “Rates withheld — cost visibility level 1”, rather than printing a masked column.' }
+      ],
+
+      a11y: [
+        { k: 'Tree', v: 'role="tree" with aria-activedescendant; each card is role="treeitem" with aria-level, aria-selected and aria-expanded. One tab stop for the whole canvas.' },
+        { k: 'Card name', v: 'The accessible name carries name, role, region, day rate and direct-report count, so the card is comprehensible without seeing its position in the layout.' },
+        { k: 'Pan / zoom', v: 'Pointer pan has arrow-key equivalents at the container level and is never the only way to reach a node; zoom respects the browser’s own zoom and never traps ⌘+.' },
+        { k: 'Reparent', v: 'Announced at entry, on every target change, and on commit or cancel — with the subtree size each time, because the consequence is what the user is deciding about.' },
+        { k: 'Live region', v: '#org-status is role="status" aria-live="polite" aria-atomic="true", shown visibly here for review, visually hidden in the product.' },
+        { k: 'Dot grid', v: 'Decorative and aria-hidden; it is below the 3:1 boundary threshold on purpose, because it conveys nothing.' }
+      ],
+
+      responsive: [
+        { k: '1920+', v: 'Canvas at 100%, right drawer available alongside for the selected person without panning.' },
+        { k: '1440', v: 'Default 78% zoom, drawer overlays the canvas edge.' },
+        { k: '1024', v: 'Zoom drops to 62%, meta row retained, toolbar collapses its labels to icons with tooltips.' },
+        { k: '768', v: 'Chart becomes an indented list — level, name, role, rate — with the same collapse behaviour. Reparent stays available; pan and zoom disappear.' },
+        { k: '320', v: 'Indented list only, two lines per person, 44px rows. This is the read-only mobile form, and the “Open on desktop to restructure” link states it.' }
+      ],
+
+      darkNodes: [
+        { name: 'Nurul Iman', role: 'Programme Director', region: 'MY', rate: '4,000/day', initials: 'NI', bg: '#16294A', border: '1.5px solid #7FB0FF', avBg: '#16294A', avFg: '#7FB0FF' },
+        { name: 'Rajesh Menon', role: 'Solution Architect', region: 'MY', rate: '3,200/day', initials: 'RM', bg: '#171C24', border: '1px solid #748196', avBg: '#0F2E22', avFg: '#56D69A' },
+        { name: 'Nguyen Thi Lan', role: 'Security Consultant', region: 'VN', rate: '1,300/day', initials: 'NL', bg: '#171C24', border: '1px solid #748196', avBg: '#33240B', avFg: '#E9B45A' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/primitives.html
+++ b/docs/design/primitives.html
@@ -1,0 +1,1118 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; text-decoration:underline; text-underline-offset:2px; }
+  a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  input, textarea, select { font-family:inherit; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes pulse { 0%,100% { opacity:.55 } 50% { opacity:1 } }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { animation-duration:1ms !important; animation-iteration-count:1 !important; transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1360px;margin:0 auto;padding:72px 40px 40px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 2 of 5</div>
+  <h1 style="margin:14px 0 0;font-size:44px;line-height:50px;font-weight:600;letter-spacing:-0.025em;max-width:22ch;text-wrap:pretty">Primitives: every variant, every state</h1>
+  <p style="margin:20px 0 0;max-width:70ch;font-size:16px;line-height:26px;color:#4B5563;text-wrap:pretty">Twenty-nine primitives, each with anatomy, sizes, all variants and the full state set — default, hover, focus-visible, active, disabled, loading, error, read-only and empty where they apply. Every value is a token from Foundations; no primitive introduces a new one. Light matrices are complete; each group closes with the same component authored on dark surfaces.</p>
+  <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:24px">
+    <span style="display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:12px;font-weight:500;border:1px solid #BBD0F6">Focus ring 2px / offset 2px on every focusable</span>
+    <span style="display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:999px;background:#FFFFFF;color:#4B5563;font-size:12px;font-weight:500;border:1px solid #CBD2DC">Pointer target ≥ 24px, touch ≥ 44px</span>
+    <span style="display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:999px;background:#FFFFFF;color:#4B5563;font-size:12px;font-weight:500;border:1px solid #CBD2DC">Live controls marked ⌁</span>
+  </div>
+</header>
+
+<section style="max-width:1360px;margin:0 auto;padding:16px 40px 0">
+  <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:20px">
+    <div>
+      <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Reading the matrices</div>
+      <p style="margin:8px 0 0;font-size:13px;line-height:20px;color:#4B5563">Columns are states. A state that is visually identical to another is still listed, with the reason it is identical, so an engineer never has to guess.</p>
+    </div>
+    <div>
+      <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Anatomy notation</div>
+      <p style="margin:8px 0 0;font-size:13px;line-height:20px;color:#4B5563"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px">h36 · px-space/3 · gap-space/2 · r-md</span> reads: height 36, horizontal padding 12, internal gap 8, radius/md.</p>
+    </div>
+    <div>
+      <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Accessibility line</div>
+      <p style="margin:8px 0 0;font-size:13px;line-height:20px;color:#4B5563">Each group ends with role, accessible name and ARIA relationships. Anything not stated there is a plain semantic element with no ARIA at all — which is the preferred outcome.</p>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1360px;margin:0 auto;padding:56px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">A — Actions</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Button</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Anatomy: <span style="font-family:'IBM Plex Mono',monospace;font-size:13px">[focus ring] → [container: bg, 1px border, radius/md] → [leading icon 16px] → gap → [label type/body 500] → gap → [trailing icon 16px]</span>. Label is sentence case, verb-first, and never wraps — a button that cannot fit its label gets the next size down, not two lines. One primary button per view region.</p>
+
+  <div style="margin-top:24px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+    <div style="display:grid;grid-template-columns:118px repeat(6,minmax(0,1fr));gap:12px;padding:10px 20px;background:#F1F3F7;border-bottom:1px solid #CBD2DC;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">
+      <div>Variant</div><div>Default</div><div>Hover</div><div>Focus-visible</div><div>Active</div><div>Disabled</div><div>Loading</div>
+    </div>
+    <sc-for list="{{ btnLight }}" as="row" hint-placeholder-count="5">
+      <div style="display:grid;grid-template-columns:118px repeat(6,minmax(0,1fr));gap:12px;padding:16px 20px;border-bottom:1px solid #E4E7EC;align-items:center">
+        <div>
+          <div style="font-size:13px;line-height:18px;font-weight:600;color:#101720">{{ row.name }}</div>
+          <div style="font-size:12px;line-height:17px;color:#667085;text-wrap:pretty">{{ row.use }}</div>
+        </div>
+        <sc-for list="{{ row.cells }}" as="c" hint-placeholder-count="6">
+          <div>
+            <button style="display:inline-flex;align-items:center;justify-content:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;font-size:14px;line-height:20px;font-weight:500;white-space:nowrap;cursor:{{ c.cursor }};background:{{ c.bg }};color:{{ c.fg }};border:1px solid {{ c.bd }};box-shadow:{{ c.ring }};text-decoration:{{ c.deco }}">
+              <sc-if value="{{ c.loading }}" hint-placeholder-val="{{ false }}"><span style="width:14px;height:14px;border-radius:999px;border:2px solid {{ c.spinTrack }};border-top-color:{{ c.fg }};animation:spin 700ms linear infinite"></span></sc-if>
+              {{ c.label }}
+            </button>
+          </div>
+        </sc-for>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1.15fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Sizes and content shapes</h3>
+      <p style="margin:0 0 18px;font-size:13px;line-height:20px;color:#4B5563">sm is for table row actions and toolbars only. md is the default. lg is reserved for auth screens and empty-state calls to action, where it also satisfies the 44px touch minimum.</p>
+      <div style="display:flex;flex-direction:column;gap:16px">
+        <sc-for list="{{ btnSizes }}" as="s" hint-placeholder-count="3">
+          <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+            <div style="width:150px;flex:none">
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;line-height:17px;color:#101720">{{ s.token }}</div>
+              <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:16px;color:#667085">{{ s.spec }}</div>
+            </div>
+            <button style="display:inline-flex;align-items:center;justify-content:center;gap:{{ s.gap }};height:{{ s.h }};padding:0 {{ s.px }};border-radius:6px;background:#0B57D0;color:#FFFFFF;border:1px solid #0B57D0;font-size:{{ s.fs }};line-height:{{ s.lh }};font-weight:500;cursor:pointer">Save plan</button>
+            <button style="display:inline-flex;align-items:center;justify-content:center;gap:{{ s.gap }};height:{{ s.h }};padding:0 {{ s.px }};border-radius:6px;background:#FFFFFF;color:#101720;border:1px solid #7D8799;font-size:{{ s.fs }};line-height:{{ s.lh }};font-weight:500;cursor:pointer"><span style="font-family:'IBM Plex Mono',monospace">+</span>Add phase</button>
+            <button aria-label="More actions" style="display:inline-flex;align-items:center;justify-content:center;width:{{ s.h }};height:{{ s.h }};border-radius:6px;background:#FFFFFF;color:#101720;border:1px solid #7D8799;font-size:{{ s.fs }};cursor:pointer">⋯</button>
+          </div>
+        </sc-for>
+        <div style="border-top:1px solid #E4E7EC;padding-top:16px">
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#667085;margin-bottom:8px">full-width — drawer footers and mobile only</div>
+          <button style="display:flex;align-items:center;justify-content:center;width:100%;height:44px;border-radius:6px;background:#0B57D0;color:#FFFFFF;border:1px solid #0B57D0;font-size:15px;font-weight:500;cursor:pointer">Generate proposal</button>
+        </div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Rules an engineer needs</h3>
+      <div style="display:flex;flex-direction:column;gap:10px;margin-top:14px">
+        <sc-for list="{{ btnRules }}" as="r" hint-placeholder-count="6">
+          <div style="display:grid;grid-template-columns:16px 1fr;gap:10px;align-items:start">
+            <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#0B57D0;line-height:20px">§</span>
+            <div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">{{ r }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:24px">
+    <div style="display:flex;align-items:baseline;gap:12px;margin-bottom:6px">
+      <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Button — dark</h3>
+      <span style="font-size:12px;color:#8592A6">authored, not inverted: accent lightens and carries dark text at 8.52:1; secondary sits on surface/raised, not on the canvas</span>
+    </div>
+    <div style="margin-top:16px;display:grid;grid-template-columns:118px repeat(6,minmax(0,1fr));gap:12px;font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA;padding-bottom:10px;border-bottom:1px solid #333C4A">
+      <div>Variant</div><div>Default</div><div>Hover</div><div>Focus-visible</div><div>Active</div><div>Disabled</div><div>Loading</div>
+    </div>
+    <sc-for list="{{ btnDark }}" as="row" hint-placeholder-count="5">
+      <div style="display:grid;grid-template-columns:118px repeat(6,minmax(0,1fr));gap:12px;padding:14px 0;border-bottom:1px solid #232A35;align-items:center">
+        <div style="font-size:13px;line-height:18px;font-weight:600;color:#E9EEF6">{{ row.name }}</div>
+        <sc-for list="{{ row.cells }}" as="c" hint-placeholder-count="6">
+          <div>
+            <button style="display:inline-flex;align-items:center;justify-content:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;font-size:14px;line-height:20px;font-weight:500;white-space:nowrap;cursor:{{ c.cursor }};background:{{ c.bg }};color:{{ c.fg }};border:1px solid {{ c.bd }};box-shadow:{{ c.ring }};text-decoration:{{ c.deco }}">
+              <sc-if value="{{ c.loading }}" hint-placeholder-val="{{ false }}"><span style="width:14px;height:14px;border-radius:999px;border:2px solid {{ c.spinTrack }};border-top-color:{{ c.fg }};animation:spin 700ms linear infinite"></span></sc-if>
+              {{ c.label }}
+            </button>
+          </div>
+        </sc-for>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="margin-top:16px;display:grid;grid-template-columns:1fr 1fr;gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Icon button</h3>
+      <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#4B5563">Square, radius/md, always with an <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">aria-label</span> and a tooltip carrying the same string. sm (28px) is allowed only inside a 32px-or-taller row and must keep 8px clear space so the composite pointer target reaches 36px; on touch it grows to 44px.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:12px">
+        <sc-for list="{{ iconBtns }}" as="i" hint-placeholder-count="7">
+          <div style="text-align:center;width:82px">
+            <button aria-label="{{ i.name }}" style="display:inline-flex;align-items:center;justify-content:center;width:{{ i.size }};height:{{ i.size }};border-radius:6px;background:{{ i.bg }};color:{{ i.fg }};border:1px solid {{ i.bd }};box-shadow:{{ i.ring }};cursor:{{ i.cursor }};font-size:15px;font-family:'IBM Plex Mono',monospace">{{ i.glyph }}</button>
+            <div style="font-size:11px;line-height:15px;color:#667085;margin-top:6px">{{ i.label }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Link, Kbd, Divider</h3>
+      <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#4B5563">Links are underlined at all times inside body text — in a table full of blue figures, colour alone would not distinguish a link from a value.</p>
+      <div style="display:flex;flex-direction:column;gap:14px">
+        <div style="font-size:14px;line-height:22px;color:#101720">Inline: the phase inherits its calendar from <a href="#" style="color:#0B57D0">Malaysia (MY) public holidays</a>, hover <span style="color:#08429E;text-decoration:underline;text-underline-offset:2px">Malaysia (MY) public holidays</span>, visited <span style="color:#06337A;text-decoration:underline;text-underline-offset:2px">Malaysia (MY)</span>, focus <span style="color:#0B57D0;text-decoration:underline;text-underline-offset:2px;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;border-radius:2px">Malaysia (MY)</span>.</div>
+        <div style="font-size:14px;line-height:22px;color:#101720">Standalone link (no underline until hover, has a trailing chevron): <span style="color:#0B57D0;font-weight:500">Open rate card ›</span></div>
+        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:13px;color:#4B5563">Keyboard hints:
+          <sc-for list="{{ kbds }}" as="k" hint-placeholder-count="5">
+            <kbd style="display:inline-flex;align-items:center;justify-content:center;min-width:24px;height:24px;padding:0 6px;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ k }}</kbd>
+          </sc-for>
+        </div>
+        <div>
+          <div style="height:1px;background:#E4E7EC"></div>
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-top:6px">divider/subtle — inside a card</div>
+        </div>
+        <div>
+          <div style="display:flex;align-items:center;gap:12px"><div style="height:1px;background:#CBD2DC;flex:1"></div><span style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Subcontractors</span><div style="height:1px;background:#CBD2DC;flex:1"></div></div>
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-top:6px">divider/labelled — separates groups in a menu or list</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — actions</div>
+    <sc-for list="{{ a11yActions }}" as="a" hint-placeholder-count="5">
+      <div style="display:grid;grid-template-columns:170px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1360px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">B — Text entry</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Input, Textarea, Number, Search</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Anatomy: <span style="font-family:'IBM Plex Mono',monospace;font-size:13px">[label type/label, space/1 below] → [container h36, 1px border/strong, radius/md, px space/3] → [prefix] → [value type/body] → [suffix / clear / status icon] → [helper type/label, space/1 above]</span>. The helper slot is reserved at all times so validation never shifts the form.</p>
+
+  <div style="margin-top:24px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:24px">
+    <sc-for list="{{ fieldsLight }}" as="f" hint-placeholder-count="8">
+      <div>
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:15px;color:#667085;margin-bottom:8px">{{ f.state }}</div>
+        <label style="display:block;font-size:12px;line-height:16px;font-weight:500;letter-spacing:0.005em;color:{{ f.labelColor }};margin-bottom:4px">{{ f.label }}</label>
+        <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:{{ f.bg }};border:1px solid {{ f.bd }};box-shadow:{{ f.ring }};cursor:{{ f.cursor }}">
+          <sc-if value="{{ f.icon }}" hint-placeholder-val="{{ false }}"><span style="font-size:12px;font-weight:500;color:{{ f.iconColor }};font-variant-numeric:tabular-nums">{{ f.icon }}</span></sc-if>
+          <span style="flex:1;font-size:14px;line-height:20px;color:{{ f.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ f.value }}{{ f.placeholder }}</span>
+        </div>
+        <div style="min-height:32px;margin-top:4px;font-size:12px;line-height:16px;color:{{ f.helperColor }};text-wrap:pretty">{{ f.helper }}</div>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">Sizes</h3>
+      <sc-for list="{{ fieldSizes }}" as="s" hint-placeholder-count="3">
+        <div style="display:grid;grid-template-columns:110px 1fr;gap:12px;padding:7px 0;border-bottom:1px solid #E4E7EC">
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ s.token }}</div>
+          <div style="font-size:12px;line-height:18px;color:#4B5563">{{ s.spec }}</div>
+        </div>
+      </sc-for>
+      <h3 style="margin:22px 0 10px;font-size:16px;line-height:22px;font-weight:600">Textarea</h3>
+      <label style="display:block;font-size:12px;font-weight:500;color:#101720;margin-bottom:4px">Assumption</label>
+      <div style="border:1px solid #7D8799;border-radius:6px;background:#FFFFFF;padding:8px 12px;min-height:88px;font-size:14px;line-height:20px;color:#101720;position:relative">Client provides a cleansed vendor master by 30 Sep 2026. Any slippage moves Realize start day-for-day.
+        <span style="position:absolute;right:10px;bottom:6px;font-size:11px;color:#667085;font-variant-numeric:tabular-nums">128 / 500</span>
+      </div>
+      <div style="font-size:12px;line-height:16px;color:#667085;margin-top:6px">Resizes vertically only, 3 rows minimum, 12 rows maximum, then scrolls. The counter turns status/warning at 90% and status/danger at 100%; it is aria-live="polite" but only announces at those two thresholds.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 4px;font-size:16px;line-height:22px;font-weight:600">Number &amp; currency</h3>
+      <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#4B5563">All figures right-aligned with tabular numerals so a column of rates reads as a column.</p>
+      <div style="display:flex;flex-direction:column;gap:16px">
+        <sc-for list="{{ numericFields }}" as="n" hint-placeholder-count="4">
+          <div>
+            <label style="display:block;font-size:12px;font-weight:500;color:#101720;margin-bottom:4px">{{ n.label }}</label>
+            <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799">
+              <span style="font-size:12px;font-weight:500;color:#667085">{{ n.prefix }}</span>
+              <span style="flex:1;text-align:right;font-size:14px;line-height:20px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">{{ n.value }}</span>
+              <span style="font-size:12px;color:#667085">{{ n.suffix }}</span>
+              <span style="display:flex;flex-direction:column;gap:1px;margin-left:2px">
+                <span style="display:flex;align-items:center;justify-content:center;width:18px;height:13px;border:1px solid #CBD2DC;border-radius:3px 3px 0 0;font-size:8px;color:#4B5563">▲</span>
+                <span style="display:flex;align-items:center;justify-content:center;width:18px;height:13px;border:1px solid #CBD2DC;border-radius:0 0 3px 3px;font-size:8px;color:#4B5563">▼</span>
+              </span>
+            </div>
+            <div style="font-size:12px;line-height:17px;color:#667085;margin-top:5px;text-wrap:pretty">{{ n.note }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">Select — trigger states</h3>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+        <sc-for list="{{ selects }}" as="s" hint-placeholder-count="4">
+          <div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-bottom:6px">{{ s.state }}</div>
+            <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:{{ s.bg }};border:1px solid {{ s.bd }};box-shadow:{{ s.ring }}">
+              <span style="flex:1;font-size:14px;color:{{ s.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ s.value }}</span>
+              <span style="font-size:10px;color:{{ s.fg }}">▼</span>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+      <h3 style="margin:22px 0 10px;font-size:16px;line-height:22px;font-weight:600">Listbox</h3>
+      <div style="border:1px solid #CBD2DC;border-radius:6px;background:#FFFFFF;box-shadow:0 4px 12px rgba(16,23,32,0.10);overflow:hidden">
+        <sc-for list="{{ selectOptions }}" as="o" hint-placeholder-count="5">
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 12px;border-bottom:1px solid #E4E7EC;background:{{ o.bg }}">
+            <span style="width:14px;font-size:12px;color:#0B57D0">{{ o.tick }}</span>
+            <span style="flex:1;font-size:14px;line-height:20px;color:#101720">{{ o.label }}</span>
+            <span style="font-size:12px;color:#667085;font-variant-numeric:tabular-nums">{{ o.meta }}</span>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:17px;color:#667085;margin-top:8px">Row 3 shows hover/active-descendant: surface/sunken fill plus a 2px accent bar on the leading edge, so the pointer position is not carried by colour alone. Max height 320px, then scrolls; the selected option is scrolled into view on open.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+        <h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Combobox, async</h3>
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0">⌁ live</span>
+      </div>
+      <p style="margin:0 0 14px;font-size:13px;line-height:20px;color:#4B5563">Type to search the delivery roster. 450ms simulated latency; try “ar”, “lead”, or something with no match.</p>
+      <label for="cb" style="display:block;font-size:12px;font-weight:500;color:#101720;margin-bottom:4px">Assign resource</label>
+      <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span>
+        <input id="cb" type="text" value="{{ cbQuery }}" onInput="{{ cbOnInput }}" placeholder="Search by name or role" style="flex:1;border:none;outline:none;background:transparent;font-size:14px;line-height:20px;color:#101720" />
+        <sc-if value="{{ cbLoading }}" hint-placeholder-val="{{ false }}"><span style="width:14px;height:14px;border-radius:999px;border:2px solid #CBD2DC;border-top-color:#0B57D0;animation:spin 700ms linear infinite"></span></sc-if>
+      </div>
+      <div aria-live="polite" style="font-size:12px;line-height:16px;color:#667085;margin-top:5px">{{ cbStatus }}</div>
+      <div style="margin-top:8px;border:1px solid #CBD2DC;border-radius:6px;overflow:hidden;max-height:232px;overflow-y:auto">
+        <sc-for list="{{ cbResults }}" as="r" hint-placeholder-count="3">
+          <div style="display:flex;align-items:center;gap:10px;padding:8px 12px;border-bottom:1px solid #E4E7EC">
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:11px;font-weight:600">{{ r.initials }}</span>
+            <span style="flex:1;min-width:0">
+              <span style="display:block;font-size:13px;line-height:18px;color:#101720;font-weight:500">{{ r.name }}</span>
+              <span style="display:block;font-size:12px;line-height:16px;color:#667085">{{ r.role }} · {{ r.region }}</span>
+            </span>
+            <span style="font-size:13px;color:#101720;font-variant-numeric:tabular-nums;font-weight:500">{{ r.rate }}</span>
+          </div>
+        </sc-for>
+        <sc-if value="{{ cbEmpty }}" hint-placeholder-val="{{ false }}">
+          <div style="padding:20px 16px;text-align:center">
+            <div style="font-size:13px;line-height:19px;color:#101720;font-weight:500">No resource matches “{{ cbQuery }}”</div>
+            <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:4px">Search covers name and role across the MY, SG, IN and VN rosters. Try a role such as “Basis”, or invite an external contributor.</div>
+            <button style="margin-top:12px;height:32px;padding:0 12px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13px;font-weight:500;color:#101720;cursor:pointer">Invite by email</button>
+          </div>
+        </sc-if>
+      </div>
+      <h3 style="margin:22px 0 10px;font-size:16px;line-height:22px;font-weight:600">Multi-select &amp; Search field</h3>
+      <div style="display:flex;align-items:center;flex-wrap:wrap;gap:6px;min-height:36px;padding:4px 8px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF">
+        <sc-for list="{{ multiChips }}" as="c" hint-placeholder-count="3">
+          <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 4px 0 8px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">{{ c.label }}<span style="color:#4B5563;font-variant-numeric:tabular-nums">{{ c.n }}</span><span aria-label="Remove" style="display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:3px;background:#D6E4FD;font-size:10px;cursor:pointer">×</span></span>
+        </sc-for>
+        <span style="font-size:14px;color:#667085">Add workstream…</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;margin-top:12px">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span>
+        <span style="flex:1;font-size:14px;color:#101720">cutover</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:999px;background:#E4E7EC;font-size:10px;color:#4B5563;cursor:pointer">×</span>
+        <kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">⌘K</kbd>
+      </div>
+      <div style="font-size:12px;line-height:17px;color:#667085;margin-top:6px">Search debounces at 250ms, shows the clear affordance only when non-empty, and Escape clears before it closes.</div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:24px">
+    <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Text entry — dark</h3>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:24px">
+      <sc-for list="{{ fieldsDark }}" as="f" hint-placeholder-count="5">
+        <div>
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:15px;color:#8592A6;margin-bottom:8px">{{ f.state }}</div>
+          <label style="display:block;font-size:12px;line-height:16px;font-weight:500;color:{{ f.labelColor }};margin-bottom:4px">{{ f.label }}</label>
+          <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:{{ f.bg }};border:1px solid {{ f.bd }};box-shadow:{{ f.ring }}">
+            <sc-if value="{{ f.icon }}" hint-placeholder-val="{{ false }}"><span style="font-size:12px;font-weight:500;color:{{ f.iconColor }}">{{ f.icon }}</span></sc-if>
+            <span style="flex:1;font-size:14px;line-height:20px;color:{{ f.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ f.value }}{{ f.placeholder }}</span>
+          </div>
+          <div style="min-height:32px;margin-top:4px;font-size:12px;line-height:16px;color:{{ f.helperColor }};text-wrap:pretty">{{ f.helper }}</div>
+        </div>
+      </sc-for>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — text entry</div>
+    <sc-for list="{{ a11yFields }}" as="a" hint-placeholder-count="7">
+      <div style="display:grid;grid-template-columns:170px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1360px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">C — Choice</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Checkbox, Radio, Toggle, Segmented, Slider</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">Control boxes are 18px with a 44px touch target achieved by padding the label row, never by growing the box. A toggle commits immediately and is used only for settings that take effect at once; anything needing Save is a checkbox.</p>
+
+  <div style="display:grid;grid-template-columns:1.4fr 1fr;gap:16px;margin-top:24px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Checkbox</h3>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:16px">
+        <sc-for list="{{ checksLight }}" as="c" hint-placeholder-count="9">
+          <div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-bottom:6px">{{ c.state }}</div>
+            <div style="display:flex;align-items:center;gap:10px;min-height:28px">
+              <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;flex:none;border-radius:2px;background:{{ c.bg }};border:1px solid {{ c.bd }};box-shadow:{{ c.ring }};color:{{ c.gfg }};font-size:12px;font-weight:600">{{ c.glyph }}</span>
+              <span style="font-size:14px;line-height:20px;color:{{ c.lfg }}">{{ c.label }}</span>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+
+      <h3 style="margin:24px 0 12px;font-size:16px;line-height:22px;font-weight:600">Radio group</h3>
+      <div style="display:flex;flex-direction:column;gap:4px">
+        <sc-for list="{{ radios }}" as="r" hint-placeholder-count="4">
+          <div style="display:flex;align-items:flex-start;gap:10px;padding:8px 0">
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;flex:none;margin-top:1px;border-radius:999px;background:{{ r.bg }};border:1px solid {{ r.bd }};box-shadow:{{ r.ring }}"><span style="width:8px;height:8px;border-radius:999px;background:{{ r.dot }}"></span></span>
+            <span>
+              <span style="display:block;font-size:14px;line-height:20px;color:#101720">{{ r.label }}</span>
+              <span style="display:block;font-size:12px;line-height:17px;color:#667085">{{ r.desc }}</span>
+            </span>
+            <span style="margin-left:auto;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085">{{ r.state }}</span>
+          </div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#667085;margin-top:10px;text-wrap:pretty">A radio group is a <span style="font-family:'IBM Plex Mono',monospace">fieldset</span> with a <span style="font-family:'IBM Plex Mono',monospace">legend</span>; Tab enters the group once and arrows move within it. Radios never appear without a pre-selected default unless “no choice” is a valid submission.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+        <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">Toggle</h3>
+        <div style="display:flex;flex-direction:column;gap:12px">
+          <sc-for list="{{ toggles }}" as="t" hint-placeholder-count="5">
+            <div style="display:flex;align-items:center;gap:12px">
+              <span style="position:relative;display:inline-flex;align-items:center;width:40px;height:24px;flex:none;border-radius:999px;background:{{ t.bg }};border:1px solid {{ t.bd }};box-shadow:{{ t.ring }}"><span style="position:absolute;left:{{ t.x }};width:18px;height:18px;border-radius:999px;background:{{ t.knob }};box-shadow:0 1px 2px rgba(16,23,32,.2)"></span></span>
+              <span style="font-size:13px;color:#4B5563">{{ t.state }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <div style="margin-top:14px;padding-top:14px;border-top:1px solid #E4E7EC;display:flex;align-items:center;gap:12px">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0">⌁ live</span>
+          <button role="switch" onClick="{{ toggleCrit }}" style="position:relative;display:inline-flex;align-items:center;width:40px;height:24px;flex:none;border-radius:999px;border:1px solid #7D8799;background:{{ critBg }};cursor:pointer;padding:0"><span style="position:absolute;left:{{ critX }};width:18px;height:18px;border-radius:999px;background:#FFFFFF;box-shadow:0 1px 2px rgba(16,23,32,.2);transition:left 120ms cubic-bezier(.2,0,0,1)"></span></button>
+          <span style="font-size:14px;color:#101720">Highlight critical path</span>
+          <span style="margin-left:auto;font-size:12px;font-weight:500;color:#4B5563;font-variant-numeric:tabular-nums">{{ critLabel }}</span>
+        </div>
+        <div style="font-size:12px;line-height:17px;color:#667085;margin-top:8px">The state word beside the toggle is not decoration: it is the non-colour carrier of on/off, and it is what a screen reader announces via role="switch".</div>
+      </div>
+
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px"><h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Segmented control</h3><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0">⌁ live</span></div>
+        <div role="radiogroup" style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC">
+          <sc-for list="{{ zoomCells }}" as="z" hint-placeholder-count="4">
+            <button onClick="{{ z.on }}" style="height:28px;padding:0 14px;border-radius:4px;font-size:13px;font-weight:500;cursor:pointer;background:{{ z.bg }};color:{{ z.fg }};border:1px solid {{ z.bd }};box-shadow:{{ z.sh }}">{{ z.label }}</button>
+          </sc-for>
+        </div>
+        <div style="font-size:12px;line-height:17px;color:#667085;margin-top:10px">Two to five segments, equal width when used as a filter, content width when used as a zoom. Selected carries a raised surface <em>and</em> a border — on a projector the fill alone disappears. Arrow keys move selection; Tab leaves the group.</div>
+      </div>
+
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px"><h3 style="margin:0;font-size:16px;line-height:22px;font-weight:600">Slider</h3><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0">⌁ live</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+          <label for="alloc" style="font-size:12px;font-weight:500;color:#101720">Allocation — Aisyah Rahman, Realize</label>
+          <span style="font-size:14px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">{{ allocPct }}</span>
+        </div>
+        <div style="position:relative;height:24px;display:flex;align-items:center">
+          <div style="position:absolute;left:0;right:0;height:6px;border-radius:999px;background:#E4E7EC;border:1px solid #CBD2DC"></div>
+          <div style="position:absolute;left:0;height:6px;border-radius:999px;background:#0B57D0;width:{{ allocFill }}"></div>
+          <div style="position:absolute;left:66.6%;top:0;bottom:0;width:1px;background:#7D8799"></div>
+          <div style="position:absolute;left:{{ allocKnob }};width:18px;height:18px;border-radius:999px;background:#FFFFFF;border:1.5px solid #0B57D0;box-shadow:0 1px 2px rgba(16,23,32,.2)"></div>
+          <input id="alloc" type="range" min="0" max="150" step="5" value="{{ alloc }}" onInput="{{ onAlloc }}" style="position:absolute;left:0;right:0;width:100%;opacity:0;height:24px;cursor:pointer;margin:0" />
+        </div>
+        <div style="display:flex;justify-content:space-between;font-size:11px;color:#667085;font-variant-numeric:tabular-nums;margin-top:4px"><span>0%</span><span>100% capacity</span><span>150%</span></div>
+        <div style="font-size:12px;line-height:17px;color:#4B5563;margin-top:8px">{{ allocNote }} Sliders always pair with a numeric input; the slider is the coarse gesture and the field is the authoritative value.</div>
+      </div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:24px">
+    <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Choice — dark</h3>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:16px">
+      <sc-for list="{{ checksDark }}" as="c" hint-placeholder-count="5">
+        <div>
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#8592A6;margin-bottom:6px">{{ c.state }}</div>
+          <div style="display:flex;align-items:center;gap:10px;min-height:28px">
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;flex:none;border-radius:2px;background:{{ c.bg }};border:1px solid {{ c.bd }};box-shadow:{{ c.ring }};color:{{ c.gfg }};font-size:12px;font-weight:600">{{ c.glyph }}</span>
+            <span style="font-size:14px;line-height:20px;color:{{ c.lfg }}">{{ c.label }}</span>
+          </div>
+        </div>
+      </sc-for>
+    </div>
+    <div style="display:flex;flex-wrap:wrap;gap:32px;align-items:center;margin-top:20px;padding-top:20px;border-top:1px solid #232A35">
+      <div style="display:flex;align-items:center;gap:12px">
+        <span style="position:relative;display:inline-flex;align-items:center;width:40px;height:24px;border-radius:999px;background:#7FB0FF;border:1px solid #7FB0FF"><span style="position:absolute;left:20px;width:18px;height:18px;border-radius:999px;background:#0B1220"></span></span>
+        <span style="font-size:13px;color:#E9EEF6">Toggle on — knob is content/inverse, not white</span>
+      </div>
+      <div style="display:inline-flex;gap:2px;padding:2px;border-radius:6px;background:#0A0D12;border:1px solid #333C4A">
+        <span style="height:28px;padding:0 14px;display:inline-flex;align-items:center;border-radius:4px;background:#232A35;color:#E9EEF6;border:1px solid #748196;font-size:13px;font-weight:500">Week</span>
+        <span style="height:28px;padding:0 14px;display:inline-flex;align-items:center;border-radius:4px;color:#AFBACA;font-size:13px;font-weight:500">Month</span>
+        <span style="height:28px;padding:0 14px;display:inline-flex;align-items:center;border-radius:4px;color:#AFBACA;font-size:13px;font-weight:500">Quarter</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:10px;min-width:220px;flex:1">
+        <div style="position:relative;flex:1;height:6px;border-radius:999px;background:#232A35;border:1px solid #333C4A"><div style="position:absolute;left:0;top:-1px;height:6px;border-radius:999px;background:#7FB0FF;width:53%"></div><div style="position:absolute;left:calc(53% - 9px);top:-7px;width:18px;height:18px;border-radius:999px;background:#171C24;border:1.5px solid #7FB0FF"></div></div>
+        <span style="font-size:13px;color:#E9EEF6;font-variant-numeric:tabular-nums">80%</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1360px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">D — Dates</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Date picker with a working calendar</h2>
+  <p style="margin:12px 0 0;max-width:72ch;font-size:14px;line-height:22px;color:#4B5563">In an SAP programme a date is never just a date — it is a working day in a named region. The picker therefore renders weekends and that region’s public holidays, and states which calendar it is using.</p>
+
+  <div style="display:grid;grid-template-columns:auto 1fr;gap:16px;margin-top:24px;align-items:start">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px;width:328px">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
+        <button aria-label="Previous month" style="width:28px;height:28px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#101720;cursor:pointer">‹</button>
+        <div style="font-size:14px;font-weight:600;color:#101720">September 2026</div>
+        <button aria-label="Next month" style="width:28px;height:28px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;color:#101720;cursor:pointer">›</button>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px;margin-bottom:4px">
+        <sc-for list="{{ weekDays }}" as="d" hint-placeholder-count="7">
+          <div style="text-align:center;font-size:11px;font-weight:600;letter-spacing:0.04em;color:#667085">{{ d }}</div>
+        </sc-for>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:2px">
+        <sc-for list="{{ calendar }}" as="c" hint-placeholder-count="35">
+          <div title="{{ c.title }}" style="position:relative;height:36px;display:flex;align-items:center;justify-content:center;border-radius:4px;background:{{ c.bg }};color:{{ c.fg }};font-size:13px;font-variant-numeric:tabular-nums;font-weight:500">{{ c.n }}<span style="position:absolute;bottom:3px;font-size:7px;color:#8A5200;line-height:1">{{ c.mark }}</span></div>
+        </sc-for>
+      </div>
+      <div style="margin-top:14px;padding-top:12px;border-top:1px solid #E4E7EC;display:flex;flex-direction:column;gap:6px;font-size:11px;line-height:16px;color:#4B5563">
+        <div style="display:flex;align-items:center;gap:8px"><span style="width:14px;height:14px;border-radius:3px;background:#F1F3F7;border:1px solid #CBD2DC"></span>Weekend — non-working</div>
+        <div style="display:flex;align-items:center;gap:8px"><span style="width:14px;height:14px;border-radius:3px;background:#FBF0DC;border:1px solid #E0C089;display:inline-flex;align-items:end;justify-content:center;font-size:7px;color:#8A5200">●</span>Public holiday (MY) — 15 Sep, Malaysia Day</div>
+        <div style="display:flex;align-items:center;gap:8px"><span style="width:14px;height:14px;border-radius:3px;background:#E8F0FE;border:1px solid #BBD0F6"></span>Selected range — 7 to 18 Sep, 8 working days</div>
+      </div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Date and range fields</h3>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+          <div>
+            <label style="display:block;font-size:12px;font-weight:500;color:#101720;margin-bottom:4px">Start</label>
+            <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799"><span style="flex:1;font-size:14px;color:#101720;font-variant-numeric:tabular-nums">07 Sep 2026</span><span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">▦</span></div>
+          </div>
+          <div>
+            <label style="display:block;font-size:12px;font-weight:500;color:#101720;margin-bottom:4px">Finish</label>
+            <div style="display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:6px;background:#FFFFFF;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0"><span style="flex:1;font-size:14px;color:#101720;font-variant-numeric:tabular-nums">18 Sep 2026</span><span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">▦</span></div>
+          </div>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:16px;margin-top:14px;padding-top:14px;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px;color:#4B5563">
+          <span><span style="font-weight:600;color:#101720">8</span> working days</span>
+          <span><span style="font-weight:600;color:#101720">12</span> calendar days</span>
+          <span style="color:#8A5200">1 public holiday excluded (15 Sep)</span>
+          <span>Calendar: Malaysia (MY)</span>
+        </div>
+      </div>
+
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Rules</h3>
+        <div style="display:flex;flex-direction:column;gap:10px">
+          <sc-for list="{{ dateRules }}" as="r" hint-placeholder-count="5">
+            <div style="display:grid;grid-template-columns:16px 1fr;gap:10px;align-items:start">
+              <span style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#0B57D0;line-height:20px">§</span>
+              <div style="font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">{{ r }}</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:20px;display:flex;gap:20px;align-items:center;flex-wrap:wrap">
+        <div style="font-size:13px;color:#AFBACA;max-width:36ch;line-height:20px">Dark: the holiday tint drops to status/warning/subtle <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">#33240B</span> with <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">#E9B45A</span> numerals at 7.97:1, and the selected range uses accent/subtle <span style="font-family:'IBM Plex Mono',monospace;font-size:12px">#16294A</span>.</div>
+        <div style="display:grid;grid-template-columns:repeat(7,32px);gap:2px">
+          <sc-for list="{{ darkWeek }}" as="d" hint-placeholder-count="14">
+            <div style="height:32px;display:flex;align-items:center;justify-content:center;border-radius:4px;background:{{ d.bg }};color:{{ d.fg }};font-size:13px;font-variant-numeric:tabular-nums;font-weight:500">{{ d.n }}</div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1360px;margin:0 auto;padding:64px 40px 0">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">E — Display &amp; feedback</div>
+  <h2 style="margin:12px 0 0;font-size:28px;line-height:34px;font-weight:600;letter-spacing:-0.02em">Identity, status, progress, waiting</h2>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:24px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Avatar &amp; avatar group</h3>
+      <div style="display:flex;align-items:flex-end;gap:20px;flex-wrap:wrap">
+        <sc-for list="{{ avatars }}" as="a" hint-placeholder-count="5">
+          <div style="text-align:center">
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:{{ a.size }};height:{{ a.size }};border-radius:999px;background:{{ a.bg }};color:{{ a.fg }};font-size:{{ a.fs }};font-weight:600;border:1px solid rgba(16,23,32,.08)">{{ a.i }}</span>
+            <div style="font-size:11px;line-height:15px;color:#667085;margin-top:6px;max-width:88px">{{ a.label }}</div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="margin-top:20px;padding-top:16px;border-top:1px solid #E4E7EC;display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+        <div style="display:flex">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#E8F0FE;color:#0B57D0;font-size:12px;font-weight:600;border:2px solid #FFFFFF">RM</span>
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#E3F5EB;color:#0A7A47;font-size:12px;font-weight:600;border:2px solid #FFFFFF;margin-left:-8px">AR</span>
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#FBF0DC;color:#8A5200;font-size:12px;font-weight:600;border:2px solid #FFFFFF;margin-left:-8px">CW</span>
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#F1F3F7;color:#4B5563;font-size:12px;font-weight:600;border:2px solid #FFFFFF;margin-left:-8px">+6</span>
+        </div>
+        <div style="font-size:12px;line-height:18px;color:#4B5563;flex:1;min-width:200px">Max 3 faces then a counter. Presence is a 8px dot at the lower-right with a 2px surface ring — <span style="color:#0A7A47;font-weight:500">● editing now</span>, <span style="color:#4B5563;font-weight:500">● viewing</span>, and it is always accompanied by the state word in the collaborator popover.</div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Tag / Chip</h3>
+      <div style="display:flex;flex-direction:column;gap:10px">
+        <sc-for list="{{ chips }}" as="c" hint-placeholder-count="5">
+          <div style="display:flex;align-items:center;gap:12px">
+            <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 4px 0 8px;border-radius:4px;background:{{ c.bg }};color:{{ c.fg }};border:1px solid {{ c.bd }};font-size:12px;font-weight:500">{{ c.label }}<sc-if value="{{ c.x }}" hint-placeholder-val="{{ true }}"><span aria-label="Remove" style="display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:3px;background:rgba(16,23,32,.06);font-size:10px;cursor:pointer">×</span></sc-if></span>
+            <span style="font-size:12px;color:#667085">{{ c.note }}</span>
+          </div>
+        </sc-for>
+      </div>
+      <h3 style="margin:22px 0 12px;font-size:16px;line-height:22px;font-weight:600">Status pill</h3>
+      <div style="display:flex;flex-wrap:wrap;gap:8px">
+        <sc-for list="{{ pills }}" as="p" hint-placeholder-count="8">
+          <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:{{ p.bg }};color:{{ p.fg }};border:1px solid {{ p.bd }};font-size:12px;font-weight:500"><span style="font-size:11px" aria-hidden="true">{{ p.g }}</span>{{ p.label }}</span>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:17px;color:#667085;margin-top:10px">Eight statuses, fixed vocabulary, glyph + word every time. “Blocked” takes a full-strength border so it survives a greyscale print of the plan.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1.3fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600">Progress bar &amp; ring</h3>
+      <div style="display:flex;flex-direction:column;gap:16px">
+        <sc-for list="{{ progress }}" as="p" hint-placeholder-count="4">
+          <div>
+            <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:6px">
+              <span style="font-size:13px;font-weight:500;color:#101720">{{ p.label }}</span>
+              <span style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ p.note }}</span>
+            </div>
+            <div style="height:8px;border-radius:999px;background:{{ p.bg }};overflow:hidden"><div style="height:100%;border-radius:999px;background:{{ p.fill }};width:{{ p.w }}"></div></div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="display:flex;align-items:center;gap:28px;margin-top:22px;padding-top:18px;border-top:1px solid #E4E7EC;flex-wrap:wrap">
+        <div style="text-align:center">
+          <div style="width:64px;height:64px;border-radius:999px;background:conic-gradient(#0B57D0 0 62%, #E4E7EC 62% 100%);display:flex;align-items:center;justify-content:center"><div style="width:48px;height:48px;border-radius:999px;background:#FFFFFF;display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:600;color:#101720;font-variant-numeric:tabular-nums">62%</div></div>
+          <div style="font-size:11px;color:#667085;margin-top:6px">ring/lg 64</div>
+        </div>
+        <div style="text-align:center">
+          <div style="width:40px;height:40px;border-radius:999px;background:conic-gradient(#0A7A47 0 100%, #E4E7EC 0);display:flex;align-items:center;justify-content:center"><div style="width:30px;height:30px;border-radius:999px;background:#FFFFFF;display:flex;align-items:center;justify-content:center;font-size:12px;color:#0A7A47">✓</div></div>
+          <div style="font-size:11px;color:#667085;margin-top:6px">ring/md complete</div>
+        </div>
+        <div style="text-align:center">
+          <div style="width:24px;height:24px;border-radius:999px;border:2px solid #CBD2DC;border-top-color:#0B57D0;animation:spin 700ms linear infinite;margin:8px auto"></div>
+          <div style="font-size:11px;color:#667085;margin-top:6px">spinner/md 24</div>
+        </div>
+        <div style="flex:1;min-width:200px;font-size:12px;line-height:18px;color:#4B5563">A spinner alone is never shown for longer than 1 second without accompanying text. Beyond 3 seconds it becomes a determinate bar with a count, because “how many left” is the only useful answer during a 1,200-task sync.</div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Skeletons</h3>
+      <div style="display:flex;flex-direction:column;gap:8px;padding:12px;background:#F6F7F9;border-radius:6px">
+        <div style="display:flex;gap:10px;align-items:center"><div style="width:32px;height:32px;border-radius:999px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div><div style="flex:1"><div style="height:13px;width:40%;border-radius:2px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div><div style="height:11px;width:22%;border-radius:2px;background:#EDEFF3;margin-top:6px;animation:pulse 1400ms ease-in-out infinite"></div></div><div style="height:13px;width:15%;border-radius:2px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div></div>
+        <div style="display:flex;gap:10px;align-items:center"><div style="width:32px;height:32px;border-radius:999px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div><div style="flex:1"><div style="height:13px;width:55%;border-radius:2px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div><div style="height:11px;width:30%;border-radius:2px;background:#EDEFF3;margin-top:6px;animation:pulse 1400ms ease-in-out infinite"></div></div><div style="height:13px;width:15%;border-radius:2px;background:#E4E7EC;animation:pulse 1400ms ease-in-out infinite"></div></div>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:6px;margin-top:12px">
+        <sc-for list="{{ skeletons }}" as="s" hint-placeholder-count="5">
+          <div style="font-size:12px;line-height:18px;color:#4B5563">— {{ s }}</div>
+        </sc-for>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#667085;margin-top:10px">Skeletons match the real row height exactly so nothing jumps on arrival. They appear only after 300ms of waiting; faster responses render nothing at all.</div>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">File upload</h3>
+      <div style="display:flex;flex-direction:column;gap:12px">
+        <sc-for list="{{ uploadStates }}" as="u" hint-placeholder-count="3">
+          <div>
+            <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-bottom:6px">{{ u.state }}</div>
+            <div style="border:1.5px {{ u.dash }} {{ u.bd }};background:{{ u.bg }};border-radius:8px;padding:18px;text-align:center">
+              <div style="font-size:14px;font-weight:500;color:{{ u.fg }}">{{ u.title }}</div>
+              <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:4px">{{ u.sub }}</div>
+            </div>
+          </div>
+        </sc-for>
+        <div>
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-bottom:6px">Uploading</div>
+          <div style="border:1px solid #CBD2DC;border-radius:8px;padding:12px 14px;display:flex;align-items:center;gap:12px">
+            <span style="font-family:'IBM Plex Mono',monospace;font-size:14px;color:#4B5563">▤</span>
+            <div style="flex:1">
+              <div style="display:flex;justify-content:space-between;font-size:13px;color:#101720"><span>resource-plan-v4.xlsx</span><span style="font-variant-numeric:tabular-nums;color:#4B5563">2.4 MB · 68%</span></div>
+              <div style="height:6px;border-radius:999px;background:#E4E7EC;margin-top:6px;overflow:hidden"><div style="height:100%;width:68%;background:#0B57D0"></div></div>
+            </div>
+            <button aria-label="Cancel upload" style="width:28px;height:28px;border-radius:6px;border:1px solid #CBD2DC;background:#FFFFFF;cursor:pointer;color:#4B5563">×</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">Tooltip</h3>
+      <div style="display:flex;gap:24px;flex-wrap:wrap;align-items:flex-start">
+        <div>
+          <div style="display:inline-block;background:#101720;color:#FFFFFF;border-radius:6px;padding:6px 10px;font-size:12px;line-height:17px;max-width:240px;box-shadow:0 4px 12px rgba(16,23,32,.10)">Finish-to-start, 2-day lag<br /><span style="color:#CBD2DC">Predecessor: Data cleansing sign-off</span></div>
+          <div style="width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:6px solid #101720;margin-left:16px"></div>
+          <div style="font-size:11px;color:#667085;margin-top:4px">Light theme — inverse surface</div>
+        </div>
+        <div>
+          <div style="display:inline-block;background:#E9EEF6;color:#0B1220;border-radius:6px;padding:6px 10px;font-size:12px;line-height:17px;max-width:240px;box-shadow:0 4px 12px rgba(0,0,0,.5)">Finish-to-start, 2-day lag<br /><span style="color:#4B5563">Predecessor: Data cleansing sign-off</span></div>
+          <div style="width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:6px solid #E9EEF6;margin-left:16px"></div>
+          <div style="font-size:11px;color:#667085;margin-top:4px">Dark theme — inverse again, so it still stands off the surface</div>
+        </div>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:14px">Two lines maximum, 240px maximum width, 400ms open / 0ms close, 8px offset from the trigger, flipping side rather than overflowing the viewport. A tooltip never contains an interactive element — that is a popover.</div>
+      <h3 style="margin:22px 0 10px;font-size:16px;line-height:22px;font-weight:600">Redacted value</h3>
+      <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:4px;background:repeating-linear-gradient(135deg,#F1F3F7,#F1F3F7 4px,#E4E7EC 4px,#E4E7EC 8px);border:1px solid #7D8799;font-family:'IBM Plex Mono',monospace;font-size:13px;color:#4B5563">🔒 ▪▪▪,▪▪▪</span>
+        <span style="font-size:12px;line-height:18px;color:#4B5563;flex:1;min-width:180px">Fixed-width mask, hatched fill, lock glyph, and on focus the reason: “Restricted — needs cost visibility level 2.” Any subtotal containing a masked line is masked too.</span>
+      </div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:24px">
+    <h3 style="margin:0 0 16px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Display — dark</h3>
+    <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:18px">
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:#0F2E22;color:#56D69A;border:1px solid #2C6B4E;font-size:12px;font-weight:500"><span aria-hidden="true">✓</span>On track</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:#33240B;color:#E9B45A;border:1px solid #7A5A22;font-size:12px;font-weight:500"><span aria-hidden="true">⚠</span>At risk</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:#3A1512;color:#FF8A80;border:1px solid #8A3A33;font-size:12px;font-weight:500"><span aria-hidden="true">✕</span>Late</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:#1B222C;color:#AFBACA;border:1px solid #333C4A;font-size:12px;font-weight:500"><span aria-hidden="true">●</span>Not started</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px 0 7px;border-radius:4px;background:#16294A;color:#7FB0FF;border:1px solid #2F4E82;font-size:12px;font-weight:500"><span aria-hidden="true">◐</span>In progress</span>
+      <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:4px;background:repeating-linear-gradient(135deg,#12161C,#12161C 4px,#1B222C 4px,#1B222C 8px);border:1px solid #748196;font-family:'IBM Plex Mono',monospace;font-size:13px;color:#AFBACA">🔒 ▪▪▪,▪▪▪</span>
+    </div>
+    <div style="display:flex;gap:24px;flex-wrap:wrap;align-items:center">
+      <div style="display:flex">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#16294A;color:#7FB0FF;font-size:12px;font-weight:600;border:2px solid #0E1116">RM</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#0F2E22;color:#56D69A;font-size:12px;font-weight:600;border:2px solid #0E1116;margin-left:-8px">AR</span>
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:999px;background:#1B222C;color:#AFBACA;font-size:12px;font-weight:600;border:2px solid #0E1116;margin-left:-8px">+6</span>
+      </div>
+      <div style="flex:1;min-width:240px"><div style="display:flex;justify-content:space-between;font-size:13px;color:#E9EEF6;margin-bottom:6px"><span>Realize — progress</span><span style="font-variant-numeric:tabular-nums;color:#AFBACA">62%</span></div><div style="height:8px;border-radius:999px;background:#232A35;overflow:hidden"><div style="height:100%;width:62%;background:#7FB0FF"></div></div></div>
+      <div style="width:24px;height:24px;border-radius:999px;border:2px solid #333C4A;border-top-color:#7FB0FF;animation:spin 700ms linear infinite"></div>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Accessibility — display &amp; feedback</div>
+    <sc-for list="{{ a11yDisplay }}" as="a" hint-placeholder-count="8">
+      <div style="display:grid;grid-template-columns:170px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+
+  <div style="margin-top:16px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px 24px;margin-bottom:96px">
+    <div style="font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085;margin-bottom:10px">Implementation notes</div>
+    <sc-for list="{{ impl }}" as="a" hint-placeholder-count="5">
+      <div style="display:grid;grid-template-columns:170px 1fr;gap:16px;padding:8px 0;border-top:1px solid #E4E7EC;font-size:13px;line-height:20px">
+        <div style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#101720">{{ a.k }}</div>
+        <div style="color:#4B5563;text-wrap:pretty">{{ a.v }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900}}">
+const ROSTER = [
+  { name: 'Aisyah Rahman', role: 'FI/CO Consultant', region: 'MY', rate: '2,400' },
+  { name: 'Arun Prakash', role: 'ABAP Developer', region: 'IN', rate: '1,100' },
+  { name: 'Chan Wei Ling', role: 'Delivery Manager', region: 'MY', rate: '2,900' },
+  { name: 'Daniel Okafor', role: 'Data Migration Lead', region: 'MY', rate: '2,700' },
+  { name: 'Farah Nasution', role: 'Change Manager', region: 'MY', rate: '2,100' },
+  { name: 'Goh Mei Yee', role: 'Integration Architect', region: 'SG', rate: '3,800' },
+  { name: 'Nguyen Thi Lan', role: 'Security Consultant (subcon)', region: 'VN', rate: '1,300' },
+  { name: 'Rajesh Menon', role: 'Solution Architect', region: 'MY', rate: '3,200' },
+  { name: 'Siti Nurhaliza', role: 'Test Lead', region: 'MY', rate: '2,200' }
+];
+
+class Component extends DCLogic {
+  state = { cbQuery: 'ra', cbLoading: false, cbResults: ROSTER.filter(r => /ra/i.test(r.name)), cbStatus: '3 resources found',
+    critOnly: true, zoom: 'Week', alloc: 80 };
+
+  search(q) {
+    this.setState({ cbQuery: q, cbLoading: true, cbStatus: 'Searching…' });
+    clearTimeout(this._t);
+    this._t = setTimeout(() => {
+      const res = q.trim() ? ROSTER.filter(r => (r.name + ' ' + r.role).toLowerCase().includes(q.toLowerCase())) : [];
+      this.setState({ cbLoading: false, cbResults: res, cbStatus: q.trim() ? res.length + ' resources found' : 'Type to search the roster' });
+    }, 450);
+  }
+
+  renderVals() {
+    const mk = (label, bg, fg, bd, opts) => Object.assign({
+      label, bg, fg, bd, ring: 'none', cursor: 'pointer', deco: 'none', loading: false, spinTrack: 'rgba(255,255,255,.35)'
+    }, opts || {});
+
+    // ---- light buttons -------------------------------------------------
+    const ringL = (inner) => '0 0 0 2px ' + inner + ',0 0 0 4px #0B57D0';
+    const btnLight = [
+      { name: 'Primary', use: 'The one committing action in a region', cells: [
+        mk('Save plan', '#0B57D0', '#FFFFFF', '#0B57D0'),
+        mk('Save plan', '#08429E', '#FFFFFF', '#08429E'),
+        mk('Save plan', '#0B57D0', '#FFFFFF', '#0B57D0', { ring: ringL('#FFFFFF') }),
+        mk('Save plan', '#06337A', '#FFFFFF', '#06337A'),
+        mk('Save plan', '#F1F3F7', '#98A2B3', '#E4E7EC', { cursor: 'not-allowed' }),
+        mk('Saving…', '#0B57D0', '#FFFFFF', '#0B57D0', { loading: true, cursor: 'progress' })
+      ] },
+      { name: 'Secondary', use: 'Equal-weight alternatives; the default choice', cells: [
+        mk('Add phase', '#FFFFFF', '#101720', '#7D8799'),
+        mk('Add phase', '#F1F3F7', '#101720', '#6E7A8C'),
+        mk('Add phase', '#FFFFFF', '#101720', '#7D8799', { ring: ringL('#FFFFFF') }),
+        mk('Add phase', '#E4E7EC', '#101720', '#6E7A8C'),
+        mk('Add phase', '#F6F7F9', '#98A2B3', '#E4E7EC', { cursor: 'not-allowed' }),
+        mk('Adding…', '#FFFFFF', '#101720', '#7D8799', { loading: true, cursor: 'progress', spinTrack: '#CBD2DC' })
+      ] },
+      { name: 'Tertiary', use: 'Low-emphasis action beside a primary', cells: [
+        mk('Compare', 'transparent', '#0B57D0', 'transparent'),
+        mk('Compare', '#E8F0FE', '#08429E', 'transparent'),
+        mk('Compare', 'transparent', '#0B57D0', 'transparent', { ring: ringL('#FFFFFF') }),
+        mk('Compare', '#D6E4FD', '#06337A', 'transparent'),
+        mk('Compare', 'transparent', '#98A2B3', 'transparent', { cursor: 'not-allowed' }),
+        mk('Loading…', 'transparent', '#0B57D0', 'transparent', { loading: true, cursor: 'progress', spinTrack: '#BBD0F6' })
+      ] },
+      { name: 'Ghost', use: 'Toolbar and table-row actions; neutral text', cells: [
+        mk('Filter', 'transparent', '#4B5563', 'transparent'),
+        mk('Filter', '#F1F3F7', '#101720', 'transparent'),
+        mk('Filter', 'transparent', '#4B5563', 'transparent', { ring: ringL('#FFFFFF') }),
+        mk('Filter', '#E4E7EC', '#101720', 'transparent'),
+        mk('Filter', 'transparent', '#98A2B3', 'transparent', { cursor: 'not-allowed' }),
+        mk('Filtering…', 'transparent', '#4B5563', 'transparent', { loading: true, cursor: 'progress', spinTrack: '#CBD2DC' })
+      ] },
+      { name: 'Danger', use: 'Irreversible action; always behind a confirm', cells: [
+        mk('Delete phase', '#B3261E', '#FFFFFF', '#B3261E'),
+        mk('Delete phase', '#8F1D17', '#FFFFFF', '#8F1D17'),
+        mk('Delete phase', '#B3261E', '#FFFFFF', '#B3261E', { ring: '0 0 0 2px #FFFFFF,0 0 0 4px #B3261E' }),
+        mk('Delete phase', '#711511', '#FFFFFF', '#711511'),
+        mk('Delete phase', '#F1F3F7', '#98A2B3', '#E4E7EC', { cursor: 'not-allowed' }),
+        mk('Deleting…', '#B3261E', '#FFFFFF', '#B3261E', { loading: true, cursor: 'progress' })
+      ] }
+    ];
+
+    // ---- dark buttons --------------------------------------------------
+    const ringD = (inner) => '0 0 0 2px ' + inner + ',0 0 0 4px #8FC0FF';
+    const btnDark = [
+      { name: 'Primary', cells: [
+        mk('Save plan', '#7FB0FF', '#0B1220', '#7FB0FF', { spinTrack: 'rgba(11,18,32,.3)' }),
+        mk('Save plan', '#A6C8FF', '#0B1220', '#A6C8FF'),
+        mk('Save plan', '#7FB0FF', '#0B1220', '#7FB0FF', { ring: ringD('#0E1116') }),
+        mk('Save plan', '#5C97F5', '#0B1220', '#5C97F5'),
+        mk('Save plan', '#1B222C', '#5C6779', '#232A35', { cursor: 'not-allowed' }),
+        mk('Saving…', '#7FB0FF', '#0B1220', '#7FB0FF', { loading: true, cursor: 'progress', spinTrack: 'rgba(11,18,32,.3)' })
+      ] },
+      { name: 'Secondary', cells: [
+        mk('Add phase', '#171C24', '#E9EEF6', '#748196', { spinTrack: '#3D4757' }),
+        mk('Add phase', '#1D242E', '#E9EEF6', '#8894A8'),
+        mk('Add phase', '#171C24', '#E9EEF6', '#748196', { ring: ringD('#0E1116') }),
+        mk('Add phase', '#222A35', '#E9EEF6', '#8894A8'),
+        mk('Add phase', '#12161C', '#5C6779', '#232A35', { cursor: 'not-allowed' }),
+        mk('Adding…', '#171C24', '#E9EEF6', '#748196', { loading: true, cursor: 'progress', spinTrack: '#3D4757' })
+      ] },
+      { name: 'Tertiary', cells: [
+        mk('Compare', 'transparent', '#7FB0FF', 'transparent', { spinTrack: '#2F4E82' }),
+        mk('Compare', '#16294A', '#A6C8FF', 'transparent'),
+        mk('Compare', 'transparent', '#7FB0FF', 'transparent', { ring: ringD('#0E1116') }),
+        mk('Compare', '#1D3357', '#A6C8FF', 'transparent'),
+        mk('Compare', 'transparent', '#5C6779', 'transparent', { cursor: 'not-allowed' }),
+        mk('Loading…', 'transparent', '#7FB0FF', 'transparent', { loading: true, cursor: 'progress', spinTrack: '#2F4E82' })
+      ] },
+      { name: 'Ghost', cells: [
+        mk('Filter', 'transparent', '#AFBACA', 'transparent', { spinTrack: '#3D4757' }),
+        mk('Filter', '#1D242E', '#E9EEF6', 'transparent'),
+        mk('Filter', 'transparent', '#AFBACA', 'transparent', { ring: ringD('#0E1116') }),
+        mk('Filter', '#222A35', '#E9EEF6', 'transparent'),
+        mk('Filter', 'transparent', '#5C6779', 'transparent', { cursor: 'not-allowed' }),
+        mk('Filtering…', 'transparent', '#AFBACA', 'transparent', { loading: true, cursor: 'progress', spinTrack: '#3D4757' })
+      ] },
+      { name: 'Danger', cells: [
+        mk('Delete phase', '#FF8A80', '#2A0A07', '#FF8A80', { spinTrack: 'rgba(42,10,7,.3)' }),
+        mk('Delete phase', '#FFA9A1', '#2A0A07', '#FFA9A1'),
+        mk('Delete phase', '#FF8A80', '#2A0A07', '#FF8A80', { ring: '0 0 0 2px #0E1116,0 0 0 4px #FFC2BC' }),
+        mk('Delete phase', '#E8756B', '#2A0A07', '#E8756B'),
+        mk('Delete phase', '#1B222C', '#5C6779', '#232A35', { cursor: 'not-allowed' }),
+        mk('Deleting…', '#FF8A80', '#2A0A07', '#FF8A80', { loading: true, cursor: 'progress', spinTrack: 'rgba(42,10,7,.3)' })
+      ] }
+    ];
+
+    const btnSizes = [
+      { token: 'button/sm', spec: 'h28 · px10 · gap6 · 13/18', h: '28px', px: '10px', gap: '6px', fs: '13px', lh: '18px' },
+      { token: 'button/md', spec: 'h36 · px14 · gap8 · 14/20', h: '36px', px: '14px', gap: '8px', fs: '14px', lh: '20px' },
+      { token: 'button/lg', spec: 'h44 · px18 · gap8 · 15/22', h: '44px', px: '18px', gap: '8px', fs: '15px', lh: '22px' }
+    ];
+
+    const btnRules = [
+      'Loading replaces the leading icon with a 14px spinner and swaps the label to its progressive form (“Save plan” → “Saving…”). Width is locked to the resting width so the row does not reflow; aria-busy="true" and the label change are announced once.',
+      'Disabled is only for a state the user can fix in this view. If the reason is elsewhere — no permission, no cost visibility — the button stays enabled and explains on activation, because a disabled control cannot carry a tooltip reliably.',
+      'Danger never appears as the default focus target in a confirm dialog; focus lands on Cancel, and the destructive label always names the object.',
+      'Icon-only buttons are forbidden for destructive actions outside a table row, and every icon-only button repeats its label in a tooltip after 400ms.',
+      'A button that opens a menu carries aria-haspopup="menu" and aria-expanded, and shows a 12px chevron that rotates 180° over duration/fast.',
+      'Buttons never use type/label — 12px on a 36px control looks like a disabled chip. The smallest button text in Cockpit is 13px.'
+    ];
+
+    const iconBtns = [
+      { name: 'Add task', glyph: '+', label: 'default', size: '32px', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799', ring: 'none', cursor: 'pointer' },
+      { name: 'Add task', glyph: '+', label: 'hover', size: '32px', bg: '#F1F3F7', fg: '#101720', bd: '#6E7A8C', ring: 'none', cursor: 'pointer' },
+      { name: 'Add task', glyph: '+', label: 'focus', size: '32px', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799', ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', cursor: 'pointer' },
+      { name: 'Add task', glyph: '+', label: 'disabled', size: '32px', bg: '#F6F7F9', fg: '#98A2B3', bd: '#E4E7EC', ring: 'none', cursor: 'not-allowed' },
+      { name: 'Row menu', glyph: '⋯', label: 'ghost / sm 28', size: '28px', bg: 'transparent', fg: '#4B5563', bd: 'transparent', ring: 'none', cursor: 'pointer' },
+      { name: 'Filters', glyph: '≡', label: 'selected', size: '32px', bg: '#E8F0FE', fg: '#0B57D0', bd: '#0B57D0', ring: 'none', cursor: 'pointer' },
+      { name: 'Remove resource', glyph: '×', label: 'danger', size: '32px', bg: '#FDE9E7', fg: '#B3261E', bd: '#F0B5AF', ring: 'none', cursor: 'pointer' },
+      { name: 'Add task', glyph: '+', label: 'touch / 44', size: '44px', bg: '#FFFFFF', fg: '#101720', bd: '#7D8799', ring: 'none', cursor: 'pointer' }
+    ];
+
+    const kbds = ['⌘K', '⌥↑', '⇧', 'Esc', 'Enter', '⌘Z'];
+
+    const a11yActions = [
+      { k: 'Button', v: 'Native <button type="button">. Never a div with a click handler. Accessible name is the visible label; icon-only uses aria-label with the identical string that the tooltip shows.' },
+      { k: 'Loading button', v: 'aria-busy="true" on the button; the label text itself changes so screen readers announce progress without a separate live region. Activation is blocked, not disabled, so focus is retained.' },
+      { k: 'Menu button', v: 'aria-haspopup="menu", aria-expanded, aria-controls pointing at the menu id. Focus moves to the first item on open and returns to the button on Escape.' },
+      { k: 'Link', v: 'Native <a href>. Anything that does not navigate is a button. Standalone links append a visually hidden destination hint where the label is ambiguous ("Open rate card, EMEA").' },
+      { k: 'Kbd', v: 'Native <kbd>. Shortcut hints inside menu items are aria-hidden and the shortcut is instead appended to the item’s accessible name as "Command K".' },
+      { k: 'Divider', v: 'Decorative dividers are aria-hidden CSS borders. A labelled divider that groups menu items is role="separator" or a <fieldset>/<legend> in forms.' }
+    ];
+
+    // ---- B: text entry -------------------------------------------------
+    const F = (state, o) => Object.assign({
+      state, label: 'Task name', value: 'Chart of accounts workshop', placeholder: '',
+      bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', ring: 'none', helper: '', helperColor: '#667085',
+      icon: '', iconColor: '#667085', labelColor: '#101720', cursor: 'text', req: false
+    }, o);
+
+    const fieldsLight = [
+      F('Default (empty)', { value: '', placeholder: 'e.g. Chart of accounts workshop', fg: '#667085', helper: 'Shown in the Gantt tree and in the proposal.' }),
+      F('Hover', { bd: '#6E7A8C', helper: 'Border steps one level darker; nothing else moves.' }),
+      F('Focus-visible', { bd: '#0B57D0', ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', helper: 'Ring is outside the border so the field does not resize.' }),
+      F('Filled / valid', { helper: 'No green tick — a valid field is simply not an error.' }),
+      F('Error', { bd: '#B3261E', bg: '#FDE9E7', value: '', placeholder: 'e.g. Chart of accounts workshop', fg: '#667085', icon: '✕', iconColor: '#B3261E', helper: 'Task name is required. Add a name so the task can be found in search and shown in the proposal.', helperColor: '#B3261E', req: true }),
+      F('Read-only', { bg: '#F1F3F7', bd: '#CBD2DC', helper: 'Set by the baseline. Read-only keeps text at content/primary — the value is real.', cursor: 'default' }),
+      F('Disabled', { bg: '#F6F7F9', bd: '#E4E7EC', fg: '#98A2B3', helper: 'Unavailable until a phase is selected.', cursor: 'not-allowed' }),
+      F('With prefix / suffix', { value: '2,400', icon: 'MYR', helper: 'Prefix is a static adornment inside the border, never a separate control.' })
+    ];
+
+    const fieldsDark = [
+      F('Default (empty)', { value: '', placeholder: 'e.g. Chart of accounts workshop', bg: '#171C24', bd: '#748196', fg: '#8592A6', labelColor: '#E9EEF6', helper: 'Fields sit on surface/raised in dark, never on the canvas.', helperColor: '#AFBACA' }),
+      F('Focus-visible', { bg: '#171C24', bd: '#8FC0FF', fg: '#E9EEF6', labelColor: '#E9EEF6', ring: '0 0 0 2px #0E1116,0 0 0 4px #8FC0FF', helper: 'Ring 10.04:1 against the canvas, 9.08:1 against the field.', helperColor: '#AFBACA' }),
+      F('Error', { bg: '#3A1512', bd: '#FF8A80', fg: '#8592A6', value: '', placeholder: 'e.g. Chart of accounts workshop', labelColor: '#E9EEF6', icon: '✕', iconColor: '#FF8A80', helper: 'Task name is required.', helperColor: '#FF8A80' }),
+      F('Read-only', { bg: '#0A0D12', bd: '#333C4A', fg: '#E9EEF6', labelColor: '#E9EEF6', helper: 'Sunken surface signals “not yours to change”.', helperColor: '#AFBACA', cursor: 'default' }),
+      F('Disabled', { bg: '#12161C', bd: '#232A35', fg: '#5C6779', labelColor: '#8592A6', helper: 'Unavailable until a phase is selected.', helperColor: '#8592A6', cursor: 'not-allowed' })
+    ];
+
+    const fieldSizes = [
+      { token: 'field/sm', spec: 'h32 · px10 · 13/18 — inline table edit, filter bar' },
+      { token: 'field/md', spec: 'h36 · px12 · 14/20 — the default, all forms' },
+      { token: 'field/lg', spec: 'h44 · px14 · 15/22 — auth screens and mobile' }
+    ];
+
+    const numericFields = [
+      { label: 'Day rate', value: '2,400.00', prefix: 'MYR', suffix: '/ day', note: 'Currency input: prefix is the ISO code, never a symbol — MYR, SGD and USD all use $ or RM ambiguously.' },
+      { label: 'Intercompany markup', value: '15.0', prefix: '', suffix: '%', note: 'Percent input: one decimal, step 0.5, clamped 0–100. Arrow keys step; Shift+Arrow steps ×10.' },
+      { label: 'Allocation', value: '80', prefix: '', suffix: '%', note: 'Allocation is integer-only and clamped 0–150; above 100 the field turns warning and the helper names the conflict.' },
+      { label: 'Duration', value: '15', prefix: '', suffix: 'working days', note: 'Duration excludes weekends and the region’s public holidays; the helper states which calendar was applied.' }
+    ];
+
+    const selects = [
+      { label: 'Region calendar', value: 'Malaysia (MY)', state: 'Closed', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720', ring: 'none' },
+      { label: 'Region calendar', value: 'Malaysia (MY)', state: 'Focus', bg: '#FFFFFF', bd: '#0B57D0', fg: '#101720', ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' },
+      { label: 'Region calendar', value: 'Select a calendar', state: 'Empty', bg: '#FFFFFF', bd: '#7D8799', fg: '#667085', ring: 'none' },
+      { label: 'Region calendar', value: 'Malaysia (MY)', state: 'Disabled', bg: '#F6F7F9', bd: '#E4E7EC', fg: '#98A2B3', ring: 'none' }
+    ];
+
+    const selectOptions = [
+      { label: 'Malaysia (MY)', meta: '14 public holidays 2026', tick: '✓', bg: '#FFFFFF' },
+      { label: 'Singapore (SG)', meta: '11 public holidays 2026', tick: '', bg: '#FFFFFF' },
+      { label: 'India (IN)', meta: '17 public holidays 2026', tick: '', bg: '#F1F3F7' },
+      { label: 'Vietnam (VN)', meta: '11 public holidays 2026', tick: '', bg: '#FFFFFF' },
+      { label: 'Germany (DE) — Bavaria', meta: '13 public holidays 2026', tick: '', bg: '#FFFFFF' }
+    ];
+
+    const multiChips = [
+      { label: 'FI/CO', n: 4 }, { label: 'MM/SD', n: 6 }, { label: 'Basis', n: 2 }
+    ];
+
+    const a11yFields = [
+      { k: 'Input / Textarea', v: 'Native control with a real <label for>. Helper text is joined by aria-describedby; the error message replaces the helper in the same node so the description does not grow, and the field gets aria-invalid="true".' },
+      { k: 'Required', v: 'required + aria-required. The asterisk is aria-hidden and the legend “Required fields are marked *” appears once per form, above the first field.' },
+      { k: 'Error summary', v: 'On submit failure, focus moves to a role="alert" summary listing each failed field as a link to it. Individual errors are announced on blur, never on keystroke.' },
+      { k: 'Select', v: 'Native <select> wherever options are static and short. The custom listbox below is only for options that need a two-line row: role="combobox" + aria-expanded + aria-controls, listbox with role="option" and aria-selected.' },
+      { k: 'Combobox (async)', v: 'aria-autocomplete="list", aria-busy while fetching, and a polite live region announcing “7 resources found”. Results never steal focus; ↓ moves into the list, Esc closes and restores the typed text.' },
+      { k: 'Multi-select', v: 'Selected values render as removable chips before the input. Each chip’s remove button is aria-label="Remove FI/CO"; removing announces “FI/CO removed, 2 remaining” politely.' },
+      { k: 'Numeric', v: 'inputmode="decimal", a spinbutton role only when steppers are shown, and aria-valuemin/max/now on allocation so the 150% ceiling is discoverable without trial.' }
+    ];
+
+    // ---- C: choice -----------------------------------------------------
+    const CB = (state, o) => Object.assign({ state, bg: '#FFFFFF', bd: '#7D8799', glyph: '', gfg: '#FFFFFF', ring: 'none', label: 'Include in proposal', lfg: '#101720' }, o);
+    const checksLight = [
+      CB('Unchecked'), CB('Unchecked · hover', { bd: '#6E7A8C', bg: '#F1F3F7' }),
+      CB('Unchecked · focus', { ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0' }),
+      CB('Checked', { bg: '#0B57D0', bd: '#0B57D0', glyph: '✓' }),
+      CB('Checked · hover', { bg: '#08429E', bd: '#08429E', glyph: '✓' }),
+      CB('Indeterminate', { bg: '#0B57D0', bd: '#0B57D0', glyph: '–', label: '3 of 12 tasks selected' }),
+      CB('Error', { bd: '#B3261E', bg: '#FDE9E7', label: 'Accept the rate card', lfg: '#B3261E' }),
+      CB('Disabled · checked', { bg: '#E4E7EC', bd: '#CBD2DC', glyph: '✓', gfg: '#98A2B3', lfg: '#98A2B3' }),
+      CB('Read-only · checked', { bg: '#F1F3F7', bd: '#CBD2DC', glyph: '✓', gfg: '#4B5563' })
+    ];
+    const checksDark = [
+      CB('Unchecked', { bg: '#171C24', bd: '#748196', lfg: '#E9EEF6' }),
+      CB('Checked', { bg: '#7FB0FF', bd: '#7FB0FF', glyph: '✓', gfg: '#0B1220', lfg: '#E9EEF6' }),
+      CB('Indeterminate', { bg: '#7FB0FF', bd: '#7FB0FF', glyph: '–', gfg: '#0B1220', label: '3 of 12 tasks selected', lfg: '#E9EEF6' }),
+      CB('Focus', { bg: '#171C24', bd: '#8FC0FF', ring: '0 0 0 2px #0E1116,0 0 0 4px #8FC0FF', lfg: '#E9EEF6' }),
+      CB('Disabled · checked', { bg: '#232A35', bd: '#333C4A', glyph: '✓', gfg: '#5C6779', lfg: '#5C6779' })
+    ];
+
+    const radios = [
+      { state: 'Unselected', bd: '#7D8799', dot: 'transparent', bg: '#FFFFFF', ring: 'none', label: 'Fixed price', desc: 'One agreed fee for the scope in this plan.' },
+      { state: 'Selected', bd: '#0B57D0', dot: '#0B57D0', bg: '#FFFFFF', ring: 'none', label: 'Time and materials', desc: 'Billed on actual effort against the rate card.' },
+      { state: 'Focus', bd: '#0B57D0', dot: 'transparent', bg: '#FFFFFF', ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', label: 'Capped T&M', desc: 'T&M up to an agreed ceiling, then fixed.' },
+      { state: 'Disabled', bd: '#E4E7EC', dot: 'transparent', bg: '#F6F7F9', ring: 'none', label: 'Outcome-based', desc: 'Requires a signed benefits baseline.' }
+    ];
+
+    const toggles = [
+      { state: 'Off', on: false, bg: '#CBD2DC', knob: '#FFFFFF', x: '2px', ring: 'none', bd: '#7D8799' },
+      { state: 'On', on: true, bg: '#0B57D0', knob: '#FFFFFF', x: '20px', ring: 'none', bd: '#0B57D0' },
+      { state: 'Focus', on: false, bg: '#CBD2DC', knob: '#FFFFFF', x: '2px', ring: '0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0', bd: '#7D8799' },
+      { state: 'Disabled on', on: true, bg: '#E4E7EC', knob: '#F6F7F9', x: '20px', ring: 'none', bd: '#CBD2DC' },
+      { state: 'Pending', on: true, bg: '#98A2B3', knob: '#FFFFFF', x: '20px', ring: 'none', bd: '#7D8799' }
+    ];
+
+    const zoomOptions = ['Day', 'Week', 'Month', 'Quarter'];
+
+    // ---- D: dates ------------------------------------------------------
+    const weekDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+    const holidays = { 15: 'Malaysia Day', 31: 'Merdeka observed' };
+    const calendar = [];
+    for (let i = -1; i <= 30; i++) {
+      const d = i + 1;
+      const inMonth = d >= 1 && d <= 30;
+      const dow = ((i + 1) % 7 + 7) % 7;
+      const weekend = dow === 5 || dow === 6;
+      const hol = holidays[d];
+      const inRange = inMonth && d >= 7 && d <= 18;
+      calendar.push({
+        n: inMonth ? String(d) : '',
+        fg: !inMonth ? 'transparent' : hol ? '#8A5200' : weekend ? '#98A2B3' : '#101720',
+        bg: !inMonth ? 'transparent' : d === 7 || d === 18 ? '#0B57D0' : inRange ? '#E8F0FE' : hol ? '#FBF0DC' : weekend ? '#F1F3F7' : '#FFFFFF',
+        end: d === 7 || d === 18,
+        mark: hol ? '●' : weekend ? '' : '',
+        title: hol || (weekend ? 'Weekend — non-working' : '')
+      });
+    }
+    calendar.forEach(c => { if (c.end) c.fg = '#FFFFFF'; });
+
+    const dateRules = [
+      'Non-working days are drawn on surface/sunken with content/tertiary text and carry aria-disabled plus the reason in their accessible name ("Saturday 12 September, weekend, non-working").',
+      'Public holidays add a status/warning dot and the holiday name in the cell’s accessible name. The legend under the grid names every marker in words.',
+      'The date field accepts typing in ISO (2026-09-14) and in the display format (14 Sep 2026); it echoes the parsed date under the field before commit.',
+      'Range picking uses two inputs, not one. Selecting a start beyond the end swaps them and announces "Dates swapped — 14 Sep to 2 Oct".',
+      'Arrow keys move one day, PageUp/PageDown one month, Shift+PageUp/Down one year, Home/End to week bounds. Enter commits, Escape reverts.'
+    ];
+
+    // ---- E: display ----------------------------------------------------
+    const avatars = [
+      { i: 'RM', bg: '#E8F0FE', fg: '#0B57D0', size: '24px', fs: '10px', label: 'xs 24 — table rows' },
+      { i: 'AR', bg: '#E3F5EB', fg: '#0A7A47', size: '28px', fs: '11px', label: 'sm 28 — lists' },
+      { i: 'CW', bg: '#FBF0DC', fg: '#8A5200', size: '32px', fs: '12px', label: 'md 32 — default' },
+      { i: 'GM', bg: '#FDE9E7', fg: '#B3261E', size: '40px', fs: '14px', label: 'lg 40 — org chart' },
+      { i: 'NL', bg: '#F1F3F7', fg: '#4B5563', size: '56px', fs: '18px', label: 'xl 56 — profile' }
+    ];
+
+    const chips = [
+      { label: 'Realize', bg: '#F1F3F7', fg: '#101720', bd: '#CBD2DC', x: true, note: 'neutral filter chip' },
+      { label: 'Region: MY', bg: '#E8F0FE', fg: '#0B57D0', bd: '#BBD0F6', x: true, note: 'active filter' },
+      { label: 'Over 100%', bg: '#FBF0DC', fg: '#8A5200', bd: '#E0C089', x: true, note: 'condition filter' },
+      { label: 'Subcontractor', bg: '#FFFFFF', fg: '#4B5563', bd: '#7D8799', x: false, note: 'static tag, not removable' },
+      { label: 'Draft', bg: '#F6F7F9', fg: '#98A2B3', bd: '#E4E7EC', x: false, note: 'disabled' }
+    ];
+
+    const pills = [
+      { g: '✓', label: 'On track', bg: '#E3F5EB', fg: '#0A7A47', bd: '#9AD9BB' },
+      { g: '⚠', label: 'At risk', bg: '#FBF0DC', fg: '#8A5200', bd: '#E0C089' },
+      { g: '✕', label: 'Late', bg: '#FDE9E7', fg: '#B3261E', bd: '#F0B5AF' },
+      { g: '●', label: 'Not started', bg: '#F1F3F7', fg: '#4B5563', bd: '#CBD2DC' },
+      { g: '◐', label: 'In progress', bg: '#E8F0FE', fg: '#0B57D0', bd: '#BBD0F6' },
+      { g: '✓', label: 'Complete', bg: '#FFFFFF', fg: '#4B5563', bd: '#CBD2DC' },
+      { g: '⛌', label: 'Blocked', bg: '#FDE9E7', fg: '#B3261E', bd: '#B3261E' },
+      { g: '🔒', label: 'Restricted', bg: '#F1F3F7', fg: '#4B5563', bd: '#7D8799' }
+    ];
+
+    const progress = [
+      { label: 'Realize — progress', pct: 62, w: '62%', fill: '#0B57D0', bg: '#E4E7EC', note: '62% of 184 tasks complete' },
+      { label: 'Data migration — at risk', pct: 34, w: '34%', fill: '#8A5200', bg: '#E4E7EC', note: '34% complete, 12 days behind baseline' },
+      { label: 'Proposal generation', pct: 100, w: '100%', fill: '#0A7A47', bg: '#E4E7EC', note: 'Determinate, complete' },
+      { label: 'Syncing 148 changes', pct: -1, w: '40%', fill: '#0B57D0', bg: '#E4E7EC', note: 'Indeterminate — a 40% band travels the track over 1.2s; reduced motion shows a static 40% band and relies on the text' }
+    ];
+
+    const skeletons = ['Table row — 3 bars at 40% / 22% / 15% width, 13px tall, radius/xs', 'Card — 1 title bar 60%, 2 body bars 100% / 80%', 'Gantt row — a 20px tree bar plus one 120px canvas bar at the row’s real height', 'Avatar — 32px circle', 'Chart — one 140px block with an axis line'];
+
+    const uploadStates = [
+      { state: 'Idle', bd: '#7D8799', bg: '#FFFFFF', dash: 'dashed', title: 'Drop a resource list here', sub: 'CSV or XLSX up to 10 MB · or browse', fg: '#101720' },
+      { state: 'Drag-over', bd: '#0B57D0', bg: '#E8F0FE', dash: 'solid', title: 'Release to upload', sub: 'resource-plan-v4.xlsx', fg: '#0B57D0' },
+      { state: 'Error', bd: '#B3261E', bg: '#FDE9E7', dash: 'solid', title: 'That file type is not supported', sub: 'resource-plan.pdf — use CSV or XLSX. Nothing was uploaded.', fg: '#B3261E' }
+    ];
+
+    const a11yDisplay = [
+      { k: 'Avatar', v: 'The image has alt="" and the name is rendered as text beside it. A lone avatar is a <span> with aria-hidden plus a visually hidden name; initials are never the accessible name.' },
+      { k: 'Avatar group', v: 'role="list" with the overflow counter as a real list item: "and 6 more". The full roster is reachable from a popover, not only a tooltip.' },
+      { k: 'Chip (removable)', v: 'The chip is not focusable; its remove button is, with aria-label "Remove filter Region MY". After removal focus moves to the next chip, or to the filter bar when the last one goes.' },
+      { k: 'Status pill', v: 'Plain text — no ARIA. The glyph is aria-hidden because the word already carries the meaning. When a pill changes as a result of a background event, the change is announced by the owning live region, not the pill.' },
+      { k: 'Tooltip', v: 'aria-describedby, 400ms open delay, 0ms close, dismissible with Escape, and hoverable so a pointer can travel into it. Never the only place a piece of information exists.' },
+      { k: 'Progress', v: 'role="progressbar" with aria-valuenow/min/max and a visible percentage. Indeterminate omits aria-valuenow and states the phase in words ("Syncing 148 changes").' },
+      { k: 'Skeleton', v: 'The region is aria-busy="true" with aria-live="polite" carrying "Loading resource plan". Skeletons are aria-hidden shapes; on completion the live region announces "Resource plan loaded, 42 rows".' },
+      { k: 'File upload', v: 'A real <input type="file"> is the accessible name holder; the drop zone is a label for it. Drag-and-drop always has the Browse button as its keyboard equivalent; upload results are announced politely, failures assertively.' }
+    ];
+
+    const impl = [
+      { k: 'Composed from', v: 'Combobox = Input + Listbox + Spinner + Avatar. Multi-select = Combobox + Chip. Date-range = 2 × Date field + Calendar. Filter bar = Search + Chip + Dropdown menu. Every composite in layer 3 names its primitives this way.' },
+      { k: 'Naming', v: 'Component/Variant/Size/State, e.g. Button/Primary/md/Loading. Tokens are role-based paths, never appearance: accent/default, not blue-600.' },
+      { k: 'Size discipline', v: 'Three sizes exist product-wide: sm 28–32, md 36, lg 44. A fourth size is a design bug, not a request.' },
+      { k: 'Density', v: 'Compact mode reduces row height only — 36 → 28 — and never reduces type size below 13px or removes padding from a hit target.' },
+      { k: 'Iconography', v: '16px stroke icons at 1.5px, on a 24px box, currentColor only. Icons never carry status colour on their own; the status pill does.' }
+    ];
+
+    return { btnLight, btnDark, btnSizes, btnRules, iconBtns, kbds, a11yActions,
+      avatars, chips, pills, progress, skeletons, uploadStates, a11yDisplay, impl,
+      checksLight, checksDark, radios, toggles, zoomOptions, weekDays, calendar, dateRules,
+      darkWeek: [7, 8, 9, 10, 11, 12, 13].concat([14, 15, 16, 17, 18, 19, 20]).map(n => ({
+        n: String(n),
+        bg: n === 7 || n === 18 ? '#7FB0FF' : n === 15 ? '#33240B' : (n === 12 || n === 13 || n === 19 || n === 20) ? '#0A0D12' : (n > 7 && n < 18) ? '#16294A' : '#171C24',
+        fg: n === 7 || n === 18 ? '#0B1220' : n === 15 ? '#E9B45A' : (n === 12 || n === 13 || n === 19 || n === 20) ? '#8592A6' : '#E9EEF6'
+      })),
+      critOnly: this.state.critOnly, zoom: this.state.zoom, alloc: this.state.alloc,
+      allocPct: this.state.alloc + '%',
+      allocFill: (this.state.alloc / 150 * 100) + '%',
+      allocKnob: 'calc(' + (this.state.alloc / 150 * 100) + '% - 9px)',
+      allocOver: this.state.alloc > 100,
+      allocNote: this.state.alloc > 100 ? 'Over-allocated by ' + (this.state.alloc - 100) + ' points in this window.' : 'Within capacity.',
+      toggleCrit: () => this.setState(s => ({ critOnly: !s.critOnly })),
+      setZoom: (z) => () => this.setState({ zoom: z }),
+      zoomIs: (z) => this.state.zoom === z,
+      onAlloc: (e) => this.setState({ alloc: Number(e.target.value) }),
+      critBg: this.state.critOnly ? '#0B57D0' : '#CBD2DC',
+      critX: this.state.critOnly ? '20px' : '2px',
+      critLabel: this.state.critOnly ? 'On' : 'Off',
+      zoomCells: zoomOptions.map(z => ({
+        label: z,
+        bg: this.state.zoom === z ? '#FFFFFF' : 'transparent',
+        fg: this.state.zoom === z ? '#101720' : '#4B5563',
+        bd: this.state.zoom === z ? '#7D8799' : 'transparent',
+        sh: this.state.zoom === z ? '0 1px 2px rgba(16,23,32,.06)' : 'none',
+        on: () => this.setState({ zoom: z })
+      })),
+      fieldsLight, fieldsDark, fieldSizes, numericFields, selects, selectOptions, multiChips, a11yFields,
+      cbQuery: this.state.cbQuery, cbLoading: this.state.cbLoading,
+      cbResults: this.state.cbResults.map(r => Object.assign({ initials: r.name.split(' ').map(w => w[0]).slice(0, 2).join('') }, r)),
+      cbEmpty: !this.state.cbLoading && this.state.cbQuery.trim().length > 0 && this.state.cbResults.length === 0,
+      cbOnInput: (e) => this.search(e.target.value), cbStatus: this.state.cbStatus };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/screens-admin.html
+++ b/docs/design/screens-admin.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1600px;margin:0 auto;padding:56px 32px 26px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 5, part 3 of 3</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Account, settings &amp; admin</h1>
+  <p style="margin:16px 0 0;max-width:80ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">The unglamorous screens, held to the same standard as the workspace: passkey management, sessions and account lockdown, user provisioning, three approval queues, recovery requests and the security dashboard. The document closes with the complete keyboard map and the contrast audit.</p>
+</header>
+
+<section style="max-width:1600px;margin:0 auto;padding:0 32px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(470px,1fr));gap:20px">
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/settings/security</span>
+        <span style="font-size:12px;color:#4B5563">Passkeys · sessions · lockdown</span>
+      </div>
+      <div role="main" aria-label="Security settings" style="padding:18px;background:#F6F7F9;display:flex;flex-direction:column;gap:12px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;padding:11px 14px;border-bottom:1px solid #E4E7EC"><span style="font-size:14px;font-weight:600">Passkeys</span><span style="font-size:12px;color:#4B5563">2 of a recommended 2</span><button style="margin-left:auto;height:30px;padding:0 11px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Add passkey</button></div>
+          <sc-for list="{{ passkeys }}" as="p" hint-placeholder-count="2">
+            <div style="display:grid;grid-template-columns:1fr 118px 104px 82px;gap:10px;align-items:center;padding:10px 14px;border-bottom:1px solid #E4E7EC">
+              <div style="min-width:0"><div style="font-size:13px;font-weight:500">{{ p.name }}</div><div style="font-size:11.5px;color:#667085;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ p.detail }}</div></div>
+              <div style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ p.added }}</div>
+              <div style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ p.used }}</div>
+              <div style="text-align:right"><button style="height:28px;padding:0 9px;border-radius:5px;border:1px solid {{ p.bd }};background:{{ p.bg }};color:{{ p.fg }};font-size:12px;font-weight:500;cursor:pointer">{{ p.action }}</button></div>
+            </div>
+          </sc-for>
+          <div style="padding:9px 14px;font-size:11.5px;line-height:17px;color:#667085;text-wrap:pretty">The last remaining passkey cannot be removed — the button explains why on activation rather than sitting disabled: “This is your only passkey. Add a second one first, or you will need an administrator to recover the account.”</div>
+        </div>
+
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;padding:11px 14px;border-bottom:1px solid #E4E7EC;flex-wrap:wrap"><span style="font-size:14px;font-weight:600">Active sessions</span><span style="font-size:12px;color:#4B5563">4 devices</span><button style="margin-left:auto;height:30px;padding:0 11px;border-radius:6px;border:1px solid #F0B5AF;background:#FDE9E7;color:#B3261E;font-size:12.5px;font-weight:500;cursor:pointer">Sign out everywhere else</button></div>
+          <sc-for list="{{ sessions }}" as="s" hint-placeholder-count="4">
+            <div style="display:grid;grid-template-columns:1fr 120px 108px 74px;gap:10px;align-items:center;padding:10px 14px;border-bottom:1px solid #E4E7EC;background:{{ s.bg }}">
+              <div style="min-width:0"><div style="display:flex;align-items:center;gap:7px"><span style="font-size:13px;font-weight:500">{{ s.device }}</span><sc-if value="{{ s.current }}" hint-placeholder-val="{{ false }}"><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;flex:none;border-radius:3px;background:#E3F5EB;border:1px solid #9AD9BB;font-size:10px;font-weight:600;color:#0A7A47">THIS DEVICE</span></sc-if></div><div style="font-size:11.5px;color:#667085;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ s.agent }}</div></div>
+              <div style="font-size:12px;color:#4B5563">{{ s.location }}</div>
+              <div style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ s.seen }}</div>
+              <div style="text-align:right"><button style="height:28px;padding:0 9px;border-radius:5px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;cursor:pointer">Revoke</button></div>
+            </div>
+          </sc-for>
+        </div>
+
+        <div role="region" aria-label="Account lockdown" style="background:#FFFFFF;border:1px solid #F0B5AF;border-radius:8px;padding:15px 17px">
+          <div style="display:flex;align-items:center;gap:9px"><span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:999px;background:#FDE9E7;color:#B3261E;font-size:11px;font-weight:700">!</span><span style="font-size:14px;font-weight:600;color:#B3261E">Lock down this account</span></div>
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:6px;text-wrap:pretty">Immediately revokes all 4 sessions, disables both passkeys and blocks new sign-ins until an administrator restores access. Your 148 queued local changes stay on this device and are not deleted. Use this if a laptop is stolen.</div>
+          <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap"><button style="height:34px;padding:0 13px;border-radius:6px;border:1px solid #B3261E;background:#B3261E;color:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Lock down account</button><button style="height:34px;padding:0 13px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Download recovery codes</button></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/account · /settings · /account/add-passkey</span>
+      </div>
+      <div role="main" aria-label="Account and settings" style="padding:18px;background:#F6F7F9;display:flex;flex-direction:column;gap:12px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:16px">
+          <div style="display:flex;align-items:center;gap:12px">
+            <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:56px;height:56px;flex:none;border-radius:999px;background:#FBF0DC;color:#8A5200;font-size:18px;font-weight:600">CW</span>
+            <div style="min-width:0"><div style="font-size:16px;font-weight:600">Chan Wei Ling</div><div style="font-size:12.5px;color:#4B5563">Delivery Manager · Malaysia · chan.weiling@abeam.com</div><div style="font-size:11.5px;color:#667085;margin-top:2px">Cost visibility level 2 of 3 · granted by Nurul Iman, 12 Jun 2026</div></div>
+          </div>
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px;margin-top:16px">
+            <sc-for list="{{ prefs }}" as="p" hint-placeholder-count="6">
+              <div>
+                <label style="display:block;font-size:12px;font-weight:500;margin-bottom:4px">{{ p.k }}</label>
+                <div style="display:flex;align-items:center;justify-content:space-between;height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:13.5px;color:#101720">{{ p.v }}<span aria-hidden="true" style="font-size:9px;color:#4B5563">▼</span></div>
+                <div style="font-size:11px;line-height:16px;color:#667085;margin-top:4px;text-wrap:pretty">{{ p.note }}</div>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:16px">
+          <div style="font-size:14px;font-weight:600">/account/add-passkey</div>
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:5px;text-wrap:pretty">A single-purpose screen, reachable from Security and from the “only one passkey” warning. It states what will be stored and where, requires a fresh WebAuthn ceremony even inside an active session, and returns to Security announcing “Passkey added — iPhone 17, Face ID. You now have 2 passkeys.”</div>
+          <div style="display:flex;gap:8px;margin-top:12px"><button style="height:34px;padding:0 13px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Create passkey</button><button style="height:34px;padding:0 13px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">Cancel</button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+    <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/admin/users</span>
+      <span style="font-size:12px;color:#4B5563">Provisioning — the same data table as the workspace, at no lesser standard</span>
+    </div>
+    <div role="main" aria-label="Admin users" style="background:#FFFFFF">
+      <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #E4E7EC;flex-wrap:wrap">
+        <div style="display:flex;align-items:center;gap:8px;height:32px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;min-width:180px"><span aria-hidden="true" style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span><span style="font-size:13px;color:#667085">Name, email or role</span></div>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 6px 0 10px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">Status: Active<span aria-label="Remove filter" style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:3px;background:#D6E4FD;font-size:11px;cursor:pointer">×</span></span>
+        <button style="height:28px;padding:0 8px;border-radius:4px;border:1px dashed #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#4B5563;cursor:pointer">+ Add filter</button>
+        <span style="margin-left:auto;display:flex;gap:8px"><button style="height:32px;padding:0 11px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Export CSV</button><button style="height:32px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Issue access code</button></span>
+      </div>
+      <div role="region" aria-label="Bulk actions" style="display:flex;align-items:center;gap:12px;padding:8px 14px;background:#E8F0FE;border-bottom:1px solid #BBD0F6;flex-wrap:wrap">
+        <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:12px;font-weight:600">–</span>
+        <span style="font-size:12.5px;font-weight:500;font-variant-numeric:tabular-nums">2 of 214 users selected</span>
+        <button style="height:26px;padding:0 9px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;cursor:pointer">Change cost visibility</button>
+        <button style="height:26px;padding:0 9px;border-radius:4px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;cursor:pointer">Reset passkeys</button>
+        <button style="height:26px;padding:0 9px;border-radius:4px;border:1px solid #F0B5AF;background:#FDE9E7;color:#B3261E;font-size:12px;font-weight:500;cursor:pointer">Suspend</button>
+        <button style="margin-left:auto;height:26px;padding:0 8px;border-radius:4px;border:none;background:transparent;font-size:12px;color:#0B57D0;cursor:pointer">Clear selection · Esc</button>
+      </div>
+      <div style="overflow-x:auto">
+        <div role="grid" aria-label="Users" aria-rowcount="214" aria-colcount="7" aria-multiselectable="true" style="min-width:960px">
+          <div role="row" style="display:grid;grid-template-columns:34px 1.6fr 1.1fr 84px 104px 124px 112px 44px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+            <sc-for list="{{ userCols }}" as="c" hint-placeholder-count="8">
+              <div role="columnheader" aria-sort="{{ c.sort }}" style="padding:8px 12px;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563;text-align:{{ c.align }}">{{ c.label }}</div>
+            </sc-for>
+          </div>
+          <sc-for list="{{ users }}" as="u" hint-placeholder-count="7">
+            <div role="row" aria-rowindex="{{ u.rowIndex }}" aria-selected="{{ u.selAttr }}" tabindex="{{ u.tab }}" style="display:grid;grid-template-columns:34px 1.6fr 1.1fr 84px 104px 124px 112px 44px;align-items:center;min-height:44px;border-bottom:1px solid #E4E7EC;background:{{ u.bg }};box-shadow:{{ u.bar }}">
+              <div style="display:flex;justify-content:center"><span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:2px;background:{{ u.cbBg }};border:1px solid {{ u.cbBd }};color:#FFFFFF;font-size:11px;font-weight:600">{{ u.cb }}</span></div>
+              <div role="rowheader" style="padding:6px 12px;min-width:0;display:flex;align-items:center;gap:8px"><span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:none;border-radius:999px;background:#F1F3F7;color:#4B5563;font-size:10px;font-weight:600">{{ u.initials }}</span><span style="min-width:0"><span style="display:block;font-size:13px;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ u.name }}</span><span style="display:block;font-size:11.5px;color:#667085;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ u.email }}</span></span></div>
+              <div style="padding:6px 12px;font-size:12.5px;color:#4B5563;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ u.role }}</div>
+              <div style="padding:6px 12px;font-size:12.5px;color:#4B5563">{{ u.region }}</div>
+              <div style="padding:6px 12px;font-size:12.5px;color:#101720;font-variant-numeric:tabular-nums">{{ u.cost }}</div>
+              <div style="padding:6px 12px;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ u.lastSeen }}</div>
+              <div style="padding:6px 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ u.pillBg }};color:{{ u.pillFg }};border:1px solid {{ u.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ u.pillG }}</span>{{ u.pill }}</span></div>
+              <div style="display:flex;align-items:center;justify-content:center;color:#4B5563">⋯</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+      <div style="display:flex;align-items:center;gap:14px;padding:9px 14px;border-top:1px solid #CBD2DC;font-size:12.5px;color:#4B5563;flex-wrap:wrap">
+        <span style="font-variant-numeric:tabular-nums">1–7 of 214</span>
+        <span style="display:flex;gap:4px"><span style="display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:26px;padding:0 7px;border-radius:5px;background:#0B57D0;color:#FFFFFF;border:1px solid #0B57D0;font-size:12.5px;font-weight:500">1</span><span style="display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:26px;padding:0 7px;border-radius:5px;background:#FFFFFF;border:1px solid #CBD2DC;font-size:12.5px">2</span><span style="display:inline-flex;align-items:center;justify-content:center;min-width:26px;height:26px;padding:0 7px;border-radius:5px;background:#FFFFFF;border:1px solid #CBD2DC;font-size:12.5px">3</span></span>
+        <span style="margin-left:auto;max-width:60ch;text-wrap:pretty">Suspended users keep their audit history and their name on past plans. Deletion is not offered here, because a delivery record has to stay attributable.</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(330px,1fr));gap:16px">
+    <sc-for list="{{ queues }}" as="q" hint-placeholder-count="4">
+      <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;display:flex;flex-direction:column">
+        <div style="display:flex;align-items:baseline;gap:10px;padding:10px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">{{ q.route }}</span>
+          <span style="margin-left:auto;font-size:11.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ q.count }}</span>
+        </div>
+        <div role="main" aria-label="{{ q.route }}" style="flex:1;padding:12px 14px;background:#FFFFFF">
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ q.blurb }}</div>
+          <sc-for list="{{ q.items }}" as="i" hint-placeholder-count="3">
+            <article style="border:1px solid #E4E7EC;border-radius:6px;padding:11px 12px;margin-top:10px;background:{{ i.bg }}">
+              <div style="display:flex;align-items:baseline;gap:8px"><h3 style="margin:0;font-size:13px;font-weight:500;color:#101720">{{ i.title }}</h3><span style="margin-left:auto;flex:none;font-size:11px;color:#667085;font-variant-numeric:tabular-nums">{{ i.when }}</span></div>
+              <div style="font-size:11.5px;line-height:17px;color:#4B5563;margin-top:4px;text-wrap:pretty">{{ i.detail }}</div>
+              <sc-if value="{{ i.risk }}" hint-placeholder-val="{{ false }}">
+                <div role="alert" style="display:flex;align-items:flex-start;gap:7px;margin-top:8px;padding:7px 9px;border-radius:5px;background:#FBF0DC;border:1px solid #E0C089"><span aria-hidden="true" style="font-size:11px;color:#8A5200">⚠</span><span style="font-size:11.5px;line-height:17px;color:#8A5200;text-wrap:pretty">{{ i.risk }}</span></div>
+              </sc-if>
+              <div style="display:flex;gap:7px;margin-top:9px;flex-wrap:wrap"><button style="height:30px;padding:0 11px;border-radius:5px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">{{ i.approve }}</button><button style="height:30px;padding:0 11px;border-radius:5px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">{{ i.deny }}</button></div>
+            </article>
+          </sc-for>
+        </div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+    <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/admin/security</span>
+      <span style="font-size:12px;color:#4B5563">Event dashboard · blocked IPs · geography</span>
+    </div>
+    <div role="main" aria-label="Security dashboard" style="padding:16px;background:#F6F7F9">
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px">
+        <sc-for list="{{ secStats }}" as="s" hint-placeholder-count="4">
+          <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:14px 15px">
+            <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">{{ s.label }}</div>
+            <div style="font-size:24px;font-weight:600;letter-spacing:-0.02em;color:{{ s.fg }};margin-top:6px;font-variant-numeric:tabular-nums">{{ s.value }}</div>
+            <div style="font-size:11.5px;line-height:17px;color:#4B5563;margin-top:4px;text-wrap:pretty">{{ s.note }}</div>
+          </div>
+        </sc-for>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(400px,1fr));gap:12px;margin-top:12px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+          <div style="padding:10px 14px;border-bottom:1px solid #E4E7EC;font-size:13.5px;font-weight:600">Security events</div>
+          <div role="table" aria-label="Security events, last 24 hours" aria-rowcount="5">
+          <sc-for list="{{ events }}" as="e" hint-placeholder-count="5">
+            <div role="row" style="display:grid;grid-template-columns:64px 1fr 132px;gap:10px;padding:10px 14px;border-bottom:1px solid #E4E7EC;align-items:start">
+              <div role="rowheader"><div style="font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ e.time }}</div><span style="display:inline-flex;align-items:center;height:18px;padding:0 6px;margin-top:4px;border-radius:3px;background:{{ e.sevBg }};border:1px solid {{ e.sevBd }};font-size:10px;font-weight:600;color:{{ e.sevFg }}">{{ e.sev }}</span></div>
+              <div role="cell"><div style="font-size:12.5px;font-weight:500;color:#101720">{{ e.title }}</div><div style="font-size:11.5px;line-height:17px;color:#4B5563;margin-top:3px;text-wrap:pretty">{{ e.detail }}</div></div>
+              <div role="cell" style="text-align:right"><button style="height:28px;padding:0 9px;border-radius:5px;border:1px solid #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;cursor:pointer">{{ e.act }}</button></div>
+            </div>
+          </sc-for>
+          </div>
+        </div>
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;overflow:hidden">
+          <div style="padding:10px 14px;border-bottom:1px solid #E4E7EC;font-size:13.5px;font-weight:600">Sign-ins by country, last 24 hours</div>
+          <sc-for list="{{ geo }}" as="g" hint-placeholder-count="5">
+            <div style="display:grid;grid-template-columns:110px 1fr 56px 1fr;gap:10px;padding:10px 14px;border-bottom:1px solid #E4E7EC;align-items:center">
+              <div style="font-size:12.5px;color:#101720">{{ g.country }}</div>
+              <div style="height:8px;border-radius:999px;background:#E4E7EC;overflow:hidden"><div style="height:100%;width:{{ g.pct }};background:{{ g.fill }}"></div></div>
+              <div style="text-align:right;font-size:12px;color:#101720;font-variant-numeric:tabular-nums">{{ g.signins }}</div>
+              <div style="display:flex;align-items:center;gap:5px;font-size:11.5px;color:{{ g.fg }}"><span aria-hidden="true">{{ g.glyph }}</span>{{ g.flag }}</div>
+            </div>
+          </sc-for>
+          <div style="padding:10px 14px;font-size:11.5px;line-height:17px;color:#667085;text-wrap:pretty">Geography is stated in words and counts, never as a colour-only map. An unexpected country is flagged with a glyph, a word and a full-strength border — and it sorts to the bottom where the eye finishes.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(430px,1fr));gap:20px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h2 style="margin:0 0 4px;font-size:20px;line-height:26px;font-weight:600;letter-spacing:-0.015em">Complete keyboard map</h2>
+      <p style="margin:0 0 14px;font-size:12.5px;line-height:19px;color:#4B5563">Also reachable in-product from <kbd style="font-family:'IBM Plex Mono',monospace;background:#F1F3F7;border:1px solid #CBD2DC;border-radius:3px;padding:1px 5px;font-size:11.5px">?</kbd>, grouped identically.</p>
+      <sc-for list="{{ keymap }}" as="k" hint-placeholder-count="23">
+        <div style="display:grid;grid-template-columns:78px 132px 1fr;gap:10px;padding:6px 0;border-top:1px solid #E4E7EC;align-items:baseline">
+          <div style="font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#667085">{{ k.g }}</div>
+          <kbd style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;background:#F1F3F7;border:1px solid #CBD2DC;border-bottom-width:2px;border-radius:4px;padding:2px 6px;justify-self:start">{{ k.k }}</kbd>
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ k.v }}</div>
+        </div>
+      </sc-for>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h2 style="margin:0 0 4px;font-size:20px;line-height:26px;font-weight:600;letter-spacing:-0.015em">Contrast audit</h2>
+      <p style="margin:0 0 14px;font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">Every pairing the product actually renders, measured against the surface it sits on — not against white by default. One row is an exemption and says so.</p>
+      <div style="display:grid;grid-template-columns:1.7fr 58px 62px 1.5fr;gap:10px;padding:8px 0;border-bottom:1px solid #CBD2DC;font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">
+        <div>Pairing</div><div style="text-align:right">Target</div><div style="text-align:right">Measured</div><div>Where</div>
+      </div>
+      <sc-for list="{{ audit }}" as="a" hint-placeholder-count="23">
+        <div style="display:grid;grid-template-columns:1.7fr 58px 62px 1.5fr;gap:10px;padding:7px 0;border-bottom:1px solid #E4E7EC;align-items:start">
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;line-height:17px;color:#101720;word-break:break-word">{{ a.pair }}</div>
+          <div style="text-align:right;font-size:11.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ a.target }}</div>
+          <div style="text-align:right;font-size:11.5px;font-weight:600;color:{{ a.fg }};font-variant-numeric:tabular-nums">{{ a.got }}</div>
+          <div style="font-size:11.5px;line-height:17px;color:#4B5563;text-wrap:pretty">{{ a.where }}</div>
+        </div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 96px">
+  <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px">
+    <h2 style="margin:0 0 4px;font-size:20px;line-height:26px;font-weight:600;letter-spacing:-0.015em">Admin screens — states, responsive and accessibility</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:20px;margin-top:14px">
+      <div>
+        <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Loading · empty · error</div>
+        <sc-for list="{{ adminStates }}" as="r" hint-placeholder-count="4">
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;padding:7px 0;border-top:1px solid #E4E7EC;text-wrap:pretty"><span style="font-weight:600;color:#101720">{{ r.k }} — </span>{{ r.v }}</div>
+        </sc-for>
+      </div>
+      <div>
+        <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Responsive</div>
+        <sc-for list="{{ adminResponsive }}" as="r" hint-placeholder-count="5">
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;padding:7px 0;border-top:1px solid #E4E7EC;text-wrap:pretty"><span style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</span> — {{ r.v }}</div>
+        </sc-for>
+      </div>
+      <div>
+        <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Accessibility</div>
+        <sc-for list="{{ adminA11y }}" as="r" hint-placeholder-count="5">
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;padding:7px 0;border-top:1px solid #E4E7EC;text-wrap:pretty"><span style="font-weight:600;color:#101720">{{ r.k }} — </span>{{ r.v }}</div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1600,&quot;height&quot;:980}}">
+class Component extends DCLogic {
+  renderVals() {
+    const passkeys = [
+      { name: 'MacBook Pro', detail: 'Touch ID · Safari 19 · Kuala Lumpur', added: '12 Jun 2026', used: '2 min ago', action: 'Rename', bg: '#FFFFFF', bd: '#7D8799', fg: '#101720' },
+      { name: 'iPhone 17', detail: 'Face ID · iOS 20 · added from a QR handoff', added: '14 Jun 2026', used: '3 days ago', action: 'Remove', bg: '#FDE9E7', bd: '#F0B5AF', fg: '#B3261E' }
+    ];
+
+    const sessions = [
+      { device: 'MacBook Pro', agent: 'Safari 19 · macOS 16 · 203.82.14.7', location: 'Kuala Lumpur, MY', seen: 'Active now', current: true, bg: '#F6F7F9' },
+      { device: 'iPhone 17', agent: 'Safari · iOS 20 · 118.100.44.2', location: 'Kuala Lumpur, MY', seen: '3 days ago', current: false, bg: '#FFFFFF' },
+      { device: 'Windows workstation', agent: 'Edge 141 · Windows 11 · 175.140.9.88', location: 'Kuching, MY', seen: '11 days ago', current: false, bg: '#FFFFFF' },
+      { device: 'Unrecognised device', agent: 'Chrome 143 · Windows 11 · 45.147.230.19', location: 'Frankfurt, DE', seen: '19 days ago', current: false, bg: '#FDE9E7' }
+    ];
+
+    const prefs = [
+      { k: 'Language', v: 'English (Malaysia)', note: 'Interface only. Project content is never machine-translated.' },
+      { k: 'Time zone', v: 'Asia/Kuala_Lumpur (MYT)', note: 'All timestamps in the interface follow this; exports carry UTC offsets.' },
+      { k: 'Date format', v: 'DD MMM YYYY', note: 'Exports and accessible names always use ISO 8601 regardless.' },
+      { k: 'Display currency', v: 'MYR (project base)', note: 'A display preference only — it never changes a stored figure.' },
+      { k: 'Theme', v: 'Match system', note: 'Light and dark are both first-class; this only chooses which.' },
+      { k: 'Motion', v: 'Match system', note: 'Set to Reduced, every transition collapses to 0ms and only opacity remains.' }
+    ];
+
+    const userCols = [
+      { label: '', align: 'center', sort: 'none' }, { label: 'User', align: 'left', sort: 'ascending' }, { label: 'Role', align: 'left', sort: 'none' },
+      { label: 'Region', align: 'left', sort: 'none' }, { label: 'Cost level', align: 'left', sort: 'none' }, { label: 'Last seen', align: 'left', sort: 'none' },
+      { label: 'Status', align: 'left', sort: 'none' }, { label: '', align: 'center', sort: 'none' }
+    ];
+
+    const U = (name, email, role, region, cost, lastSeen, pill, tone, sel) => ({
+      name, email, role, region, cost, lastSeen, pill,
+      initials: name.split(' ').map(w => w[0]).slice(0, 2).join(''),
+      pillG: tone === 'ok' ? '✓' : tone === 'warn' ? '⚠' : tone === 'bad' ? '✕' : '●',
+      pillBg: tone === 'ok' ? '#E3F5EB' : tone === 'warn' ? '#FBF0DC' : tone === 'bad' ? '#FDE9E7' : '#F1F3F7',
+      pillFg: tone === 'ok' ? '#0A7A47' : tone === 'warn' ? '#8A5200' : tone === 'bad' ? '#B3261E' : '#4B5563',
+      pillBd: tone === 'ok' ? '#9AD9BB' : tone === 'warn' ? '#E0C089' : tone === 'bad' ? '#F0B5AF' : '#CBD2DC',
+      bg: sel ? '#E8F0FE' : '#FFFFFF', bar: sel ? 'inset 2px 0 0 #0B57D0' : 'none',
+      selAttr: sel ? 'true' : 'false', tab: sel ? 0 : -1,
+      cb: sel ? '✓' : '', cbBg: sel ? '#0B57D0' : '#FFFFFF', cbBd: sel ? '#0B57D0' : '#7D8799'
+    });
+
+    const usersRaw = [
+      U('Nurul Iman', 'nurul.iman@abeam.com', 'Programme Director', 'MY', 'Level 3', 'Active now', 'Active', 'ok', false),
+      U('Chan Wei Ling', 'chan.weiling@abeam.com', 'Delivery Manager', 'MY', 'Level 2', '2 min ago', 'Active', 'ok', false),
+      U('Arun Prakash', 'arun.prakash@abeam.co.in', 'ABAP Developer', 'IN', 'Level 1', '4 h ago', 'Active', 'ok', true),
+      U('Nguyen Thi Lan', 'lan.nguyen@partner.vn', 'Security Consultant', 'VN', 'Level 1', '2 days ago', 'Subcontractor', 'warn', true),
+      U('Priya Raghavan', 'priya.r@abeam.co.in', 'ABAP Developer', 'IN', 'Level 1', '38 days ago', 'Dormant', 'none', false),
+      U('Lee Kok Wai', 'lee.kokwai@abeam.com', 'Cutover Lead', 'MY', 'Level 2', '6 h ago', 'Active', 'ok', false),
+      U('Tan Boon Hock', 'tan.bh@abeam.com', 'FI/CO Consultant', 'MY', 'Level 1', '91 days ago', 'Suspended', 'bad', false)
+    ];
+    const users = usersRaw.map((u, i) => Object.assign({ rowIndex: i + 2 }, u));
+
+    const Q = (route, count, blurb, items, empty) => ({ route, count, blurb, items, empty });
+    const I = (title, when, detail, approve, deny, risk, tone) => ({
+      title, when, detail, approve, deny, risk,
+      bg: tone === 'warn' ? '#FFFDF8' : '#FFFFFF'
+    });
+
+    const queues = [
+      Q('/admin/approvals', '3 pending', 'Access requests to projects and cost-visibility levels. Each carries the requester, the object and the reason they gave.', [
+        I('Amirul Shah → cost visibility level 2', '2 h ago', 'PMO Analyst, MY. Needs rate figures to build the weekly cost report for Sarawak Energy. Currently level 1.', 'Grant level 2', 'Decline', 'Level 2 exposes internal delivery cost on 6 programmes, not only the one requested.', 'warn'),
+        I('Kavitha Nair → S/4HANA Migration', '5 h ago', 'Integration Consultant, SG. Requested EDITOR after being staffed to the Integration workstream on 06 Aug.', 'Approve as EDITOR', 'Approve as VIEWER', '', 'plain'),
+        I('External: PwC audit team → Perak Water', '1 day ago', 'Three named auditors, read-only, requested by Nurul Iman for the 18 Aug review.', 'Approve for 14 days', 'Decline', 'External domain. Access will expire automatically and cannot be extended in place.', 'warn')
+      ], ''),
+      Q('/admin/email-approvals', '2 pending', 'Sign-in from an unrecognised email domain, or a domain change on an existing account. Approving here does not grant project access.', [
+        I('lan.nguyen@partner.vn', '3 h ago', 'Subcontractor, Vietnam. Domain partner.vn is not on the allow-list. Sponsored by Goh Mei Yee until 31 Mar 2027.', 'Allow this address', 'Block', 'Allow the address, not the domain — partner.vn has 40+ mailboxes.', 'warn'),
+        I('c.tan@abeam.com.sg', '2 days ago', 'Existing user Cheryl Tan changed from abeam.com to abeam.com.sg after transferring to Singapore delivery.', 'Approve change', 'Keep old address', '', 'plain')
+      ], ''),
+      Q('/admin/recovery-requests', '1 pending', 'Raised when a user has lost every passkey. Approval issues a one-time enrolment link valid for 60 minutes.', [
+        I('Tan Boon Hock — all passkeys lost', '19 min ago', 'Laptop stolen in Kuching on 06 Aug; account was locked down by the user at 18:42. Identity confirmed by Chan Wei Ling on a video call at 09:10.', 'Issue enrolment link', 'Reject request', 'The account was self-locked. Confirm the lockdown was the user and not the thief before issuing.', 'warn')
+      ], ''),
+      Q('/admin — console home', '4 queues', 'Not a dashboard of charts: a list of what needs a human decision, newest first, with the count and the oldest age per queue.', [
+        I('Approvals · 3 pending', 'oldest 1 day', 'Access requests and cost-visibility changes.', 'Open queue', 'Snooze 1 day', '', 'plain'),
+        I('Recovery requests · 1 pending', 'oldest 19 min', 'Passkey recovery. Target response is 4 hours.', 'Open queue', 'Assign to someone', '', 'plain'),
+        I('Security · 2 unreviewed', 'oldest 3 h', 'Impossible-travel sign-in and a blocked IP range.', 'Open dashboard', 'Mark reviewed', '', 'plain')
+      ], '')
+    ];
+
+    const secStats = [
+      { label: 'Sign-ins today', value: '312', note: '298 passkey · 11 link · 3 one-time code', fg: '#101720' },
+      { label: 'Failed attempts', value: '24', note: 'Across 9 addresses; none reached the 5-attempt lockout.', fg: '#8A5200' },
+      { label: 'Blocked IPs', value: '6', note: '4 automatic after repeated failures, 2 added by hand.', fg: '#101720' },
+      { label: 'Unreviewed events', value: '2', note: 'One impossible-travel, one new-country sign-in.', fg: '#B3261E' }
+    ];
+
+    const events = [
+      { time: '14:12', sev: 'High', title: 'Impossible travel — Chan Wei Ling', detail: 'Successful passkey sign-in from Kuala Lumpur at 14:12, 41 minutes after a session in Frankfurt, DE. Distance is not coverable.', act: 'Revoke Frankfurt session', tone: 'bad' },
+      { time: '11:47', sev: 'Medium', title: 'New country — Kavitha Nair', detail: 'First sign-in from Singapore. Matches her transfer to SG delivery recorded on 01 Aug.', act: 'Mark expected', tone: 'warn' },
+      { time: '09:31', sev: 'Low', title: 'IP range blocked automatically', detail: '45.147.230.0/24 — 38 failed sign-in attempts against 12 addresses in 6 minutes.', act: 'Review block', tone: 'none' },
+      { time: '08:05', sev: 'Medium', title: 'Passkey removed — Tan Boon Hock', detail: 'Last remaining passkey removed by administrator during account lockdown.', act: 'View audit entry', tone: 'warn' },
+      { time: 'Yesterday', sev: 'Low', title: 'Cost visibility raised — Lee Kok Wai', detail: 'Level 1 to level 2, granted by Nurul Iman with reason “cutover cost tracking”.', act: 'View audit entry', tone: 'none' }
+    ];
+
+    const geo = [
+      { country: 'Malaysia', signins: '271', pct: '87%', flag: 'Expected — primary delivery country', tone: 'ok' },
+      { country: 'Singapore', signins: '24', pct: '8%', flag: 'Expected — 4 SG-based consultants', tone: 'ok' },
+      { country: 'India', signins: '13', pct: '4%', flag: 'Expected — offshore development', tone: 'ok' },
+      { country: 'Vietnam', signins: '3', pct: '1%', flag: 'Expected — subcontracted security', tone: 'ok' },
+      { country: 'Germany', signins: '1', pct: '0%', flag: 'Unreviewed — no staff in DE', tone: 'bad' }
+    ];
+
+    const keymap = [
+      { g: 'Global', k: '⌘K', v: 'Command palette — every destination, action and object.' },
+      { g: 'Global', k: '⌘S', v: 'Force a sync now instead of waiting for the 3-second autosave.' },
+      { g: 'Global', k: '⌘Z / ⇧⌘Z', v: 'Undo and redo across move, resize, reorder, assignment and delete.' },
+      { g: 'Global', k: '?', v: 'Keyboard-shortcut help sheet, grouped by surface.' },
+      { g: 'Global', k: 'G then T/R/C/O/A/I', v: 'Go to Timeline, Resources, Cost, Org chart, Architecture, Insights.' },
+      { g: 'Global', k: 'Esc', v: 'Close the topmost overlay, then clear a selection, then leave a mode. Never destroys work.' },
+      { g: 'Navigation', k: 'Tab / ⇧Tab', v: 'Move between regions. Each grid, tree and tab-list is a single tab stop with a roving cursor inside.' },
+      { g: 'Navigation', k: '↑ ↓ ← →', v: 'Move the cursor inside a grid, tree, matrix or menu. Selection follows focus.' },
+      { g: 'Navigation', k: 'Home / End', v: 'First and last item in the current row, list or programme window.' },
+      { g: 'Navigation', k: 'PgUp / PgDn', v: 'One screen in a table; one quarter in the allocation matrix.' },
+      { g: 'Editing', k: 'Enter', v: 'Open the editor on the focused cell or row; commit and advance.' },
+      { g: 'Editing', k: 'Esc', v: 'Revert the cell being edited to its stored value and keep focus in place.' },
+      { g: 'Editing', k: 'N / ⇧N', v: 'New task under the focused phase / new phase.' },
+      { g: 'Editing', k: 'Del / ⌫', v: 'Delete the selection, always via a destructive confirm that names the object.' },
+      { g: 'Timeline', k: 'M', v: 'Move mode on the selected bar; arrows nudge by the current zoom grain.' },
+      { g: 'Timeline', k: '⌥ ← →', v: 'Resize — move the finish date only.' },
+      { g: 'Timeline', k: '⌥ ↑ ↓', v: 'Reorder within the phase — the keyboard equivalent of drag-reorder.' },
+      { g: 'Timeline', k: '+ / −', v: 'Zoom one step, anchored on the selection.' },
+      { g: 'Timeline', k: 'T', v: 'Scroll to today.' },
+      { g: 'Matrix', k: 'N', v: 'Jump to the next over-allocated cell after the cursor.' },
+      { g: 'Org chart', k: 'C / R', v: 'Collapse or expand a subtree; enter keyboard reparent mode.' },
+      { g: 'Tables', k: 'Space', v: 'Toggle the focused row in the selection; ⇧↑↓ extends a range.' },
+      { g: 'Tables', k: '⌥ ← →', v: 'Resize the focused column in 16px steps.' }
+    ];
+
+    const audit = [
+      { pair: 'content/primary #101720 on surface/base #FFFFFF', target: '4.5:1', got: '18.02:1', where: 'All body text, table cells, headings', ok: true },
+      { pair: 'content/secondary #4B5563 on #FFFFFF', target: '4.5:1', got: '7.56:1', where: 'Descriptions, column labels, helper text', ok: true },
+      { pair: 'content/tertiary #667085 on #FFFFFF', target: '4.5:1', got: '4.97:1', where: 'Metadata, timestamps, placeholder', ok: true },
+      { pair: 'content/secondary on surface/app #F6F7F9', target: '4.5:1', got: '7.05:1', where: 'Helper text over the page canvas', ok: true },
+      { pair: 'accent/default #0B57D0 on #FFFFFF', target: '4.5:1', got: '6.39:1', where: 'Links, primary fill, today marker', ok: true },
+      { pair: 'accent/default on surface/sunken #F1F3F7', target: '4.5:1', got: '5.75:1', where: 'Links inside table headers and wells', ok: true },
+      { pair: 'content/inverse #FFFFFF on accent/default', target: '4.5:1', got: '6.39:1', where: 'Primary button label', ok: true },
+      { pair: 'status/success #0A7A47 on #FFFFFF', target: '4.5:1', got: '5.40:1', where: 'Synced chip, on-track pill', ok: true },
+      { pair: 'status/warning #8A5200 on #FFFFFF', target: '4.5:1', got: '6.39:1', where: 'At-risk pill, offline chip', ok: true },
+      { pair: 'status/danger #B3261E on #FFFFFF', target: '4.5:1', got: '6.54:1', where: 'Late pill, destructive button, conflict', ok: true },
+      { pair: 'success #0A7A47 on success/subtle #E3F5EB', target: '4.5:1', got: '4.77:1', where: 'Pill text on its own fill', ok: true },
+      { pair: 'warning #8A5200 on warning/subtle #FBF0DC', target: '4.5:1', got: '5.66:1', where: 'Pill text, over-allocated cell figure', ok: true },
+      { pair: 'danger #B3261E on danger/subtle #FDE9E7', target: '4.5:1', got: '5.60:1', where: 'Pill text, invalid field, severe cell', ok: true },
+      { pair: 'border/strong #7D8799 on #FFFFFF', target: '3:1', got: '3.62:1', where: 'Input, checkbox, toggle and bar edges', ok: true },
+      { pair: 'border/strong on surface/sunken #F1F3F7', target: '3:1', got: '3.26:1', where: 'Control edges inside wells and headers', ok: true },
+      { pair: 'border/focus #0B57D0 on #FFFFFF', target: '3:1', got: '6.39:1', where: 'Focus ring against the surface', ok: true },
+      { pair: 'dark content/primary #E9EEF6 on base #0E1116', target: '4.5:1', got: '16.23:1', where: 'Dark body text', ok: true },
+      { pair: 'dark content/tertiary #8592A6 on raised #171C24', target: '4.5:1', got: '5.42:1', where: 'Dark metadata — the tightest dark text pairing', ok: true },
+      { pair: 'dark accent #7FB0FF on raised #171C24', target: '4.5:1', got: '7.78:1', where: 'Dark links and primary fill', ok: true },
+      { pair: 'dark content/inverse #0B1220 on accent #7FB0FF', target: '4.5:1', got: '8.52:1', where: 'Dark primary button label', ok: true },
+      { pair: 'dark border/strong #748196 on raised #171C24', target: '3:1', got: '4.33:1', where: 'Dark control edges', ok: true },
+      { pair: 'dark border/focus #8FC0FF on raised #171C24', target: '3:1', got: '9.08:1', where: 'Dark focus ring', ok: true },
+      { pair: 'content/disabled #98A2B3 on #FFFFFF', target: 'exempt', got: '2.58:1', where: 'Disabled labels — WCAG 1.4.3 exempts inactive controls; every disabled control is also aria-disabled and its reason is available on activation', ok: false }
+    ];
+
+    const adminStates = [
+      { k: 'Queues', v: 'Loading — three request-card skeletons at the real 96px height. Empty — “No requests waiting. The last one was cleared by Nurul Iman at 11:04”, which reassures rather than looking broken. Error — “The approvals queue could not be loaded. No request has been approved or denied.”' },
+      { k: '/admin/users', v: 'Loading — seven 44px skeleton rows. Empty after filtering — stays in the table body, names the active filters and offers a one-click removal. Error — the toolbar stays live so the filter that caused it can be undone.' },
+      { k: '/admin/security', v: 'Loading — tiles render their labels immediately and their figures as skeletons, so the shape of the dashboard is stable. Empty — “No security events in the last 24 hours”, with a range switch to 7 and 30 days. Error — the event list fails independently of the tiles.' },
+      { k: 'Destructive', v: 'Suspend, reset passkeys and lockdown all use the destructive-confirm modal naming the person and the consequence: “Suspend Tan Boon Hock? He loses access to 3 programmes immediately. His audit history and his name on past plans are kept.”' }
+    ];
+
+    const adminResponsive = [
+      { k: '1920+', v: 'Users table gains Created and Invited-by columns; the security dashboard puts events and geography side by side with a third column for blocked IPs.' },
+      { k: '1440', v: 'Reference width, as drawn.' },
+      { k: '1024', v: 'Queues stack two-up; the users table scrolls horizontally with the user column frozen.' },
+      { k: '768', v: 'Users become cards — name, role, status, last seen — with bulk selection retained through a Select mode. Security events keep their full text; only the tile grid reflows.' },
+      { k: '320', v: 'One card per row, 44px targets. Approve and Deny stay side by side because splitting them across a scroll invites the wrong tap.' }
+    ];
+
+    const adminA11y = [
+      { k: 'Queues', v: 'Each request is an <article> with a heading; the risk note is role="alert" so it is read before the buttons. Approving moves focus to the next request and announces “Approved. 2 requests remaining.”' },
+      { k: 'Tables', v: 'Identical treegrid/grid semantics to the workspace table — aria-rowcount over the whole dataset, roving tabindex, aria-sort on sortable headers.' },
+      { k: 'Sessions', v: 'The current device is marked with a visible badge and the same words in the row’s accessible name, never by row colour alone. Revoke confirms with the device, location and last-seen time.' },
+      { k: 'Security events', v: 'Severity is a word plus a bordered chip, not a colour dot. The list is a table with a date-time column so it can be sorted and read linearly by a screen reader.' },
+      { k: 'Lockdown', v: 'The confirm requires typing the word LOCKDOWN, focus starts on Cancel, and success is announced assertively: “Account locked down. 4 sessions revoked, 2 passkeys disabled. 148 local changes are still on this device.”' }
+    ];
+
+    const sev = (t) => t === 'bad'
+      ? { sevBg: '#FDE9E7', sevBd: '#F0B5AF', sevFg: '#B3261E' }
+      : t === 'warn' ? { sevBg: '#FBF0DC', sevBd: '#E0C089', sevFg: '#8A5200' }
+      : { sevBg: '#F1F3F7', sevBd: '#CBD2DC', sevFg: '#4B5563' };
+    const events2 = events.map(e => Object.assign({}, e, sev(e.tone)));
+    const geo2 = geo.map(g => Object.assign({}, g, {
+      fill: g.tone === 'ok' ? '#0B57D0' : '#B3261E',
+      fg: g.tone === 'ok' ? '#4B5563' : '#B3261E',
+      glyph: g.tone === 'ok' ? '✓' : '⚠'
+    }));
+    const audit2 = audit.map(a => Object.assign({}, a, { fg: a.ok ? '#0A7A47' : '#8A5200' }));
+
+    return { passkeys, sessions, prefs, userCols, users, queues, secStats, events: events2, geo: geo2, keymap, audit: audit2, adminStates, adminResponsive, adminA11y };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/screens-auth.html
+++ b/docs/design/screens-auth.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1560px;margin:0 auto;padding:56px 32px 26px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 5, part 1 of 3</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Authentication &amp; system screens</h1>
+  <p style="margin:16px 0 0;max-width:80ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Passkey-first sign-in with its magic-link and one-time-code fallbacks and every failure state, access-code registration with passkey enrolment, collaboration-invite acceptance, and the five system screens — each with its loading, empty and error behaviour and its 320px form.</p>
+</header>
+
+<section style="max-width:1560px;margin:0 auto;padding:0 32px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(460px,1fr));gap:20px">
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/login</span>
+        <span style="font-size:12px;color:#4B5563">Passkey primary</span>
+      </div>
+      <div style="padding:32px;background:#F6F7F9;display:flex;justify-content:center">
+        <div style="width:100%;max-width:380px;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;box-shadow:0 1px 2px rgba(16,23,32,.06);padding:28px">
+          <span style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:7px;background:#101720;color:#FFFFFF;font-size:14px;font-weight:600">C</span>
+          <h2 style="margin:16px 0 0;font-size:24px;line-height:30px;font-weight:600;letter-spacing:-0.02em">Sign in to Cockpit</h2>
+          <p style="margin:8px 0 0;font-size:13.5px;line-height:21px;color:#4B5563">Use the passkey on this device. Nothing to remember, nothing to type.</p>
+          <label for="lg-email" style="display:block;font-size:12px;font-weight:500;margin:20px 0 4px">Work email</label>
+          <div id="lg-email" style="display:flex;align-items:center;height:44px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;box-shadow:0 0 0 2px #FFFFFF,0 0 0 4px #0B57D0;font-size:15px;color:#101720">chan.weiling@abeam.com</div>
+          <button style="width:100%;height:44px;margin-top:16px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:15px;font-weight:500;display:flex;align-items:center;justify-content:center;gap:9px;cursor:pointer"><span aria-hidden="true" style="font-family:'IBM Plex Mono',monospace">⚿</span>Continue with passkey</button>
+          <div style="display:flex;align-items:center;gap:12px;margin:18px 0"><span aria-hidden="true" style="height:1px;flex:1;background:#E4E7EC"></span><span style="font-size:12px;color:#667085">or</span><span aria-hidden="true" style="height:1px;flex:1;background:#E4E7EC"></span></div>
+          <div style="display:flex;flex-direction:column;gap:8px">
+            <button style="width:100%;height:40px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:14px;font-weight:500;cursor:pointer">Email me a sign-in link</button>
+            <button style="width:100%;height:40px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:14px;font-weight:500;cursor:pointer">Send a one-time code</button>
+          </div>
+          <p style="margin:18px 0 0;font-size:12px;line-height:18px;color:#667085">New to Cockpit? <a href="#">Enter your access code</a> — accounts are issued by your delivery lead, not self-served.</p>
+        </div>
+      </div>
+      <sc-for list="{{ loginNotes }}" as="n" hint-placeholder-count="4">
+        <div style="display:grid;grid-template-columns:104px 1fr;gap:12px;padding:9px 14px;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ n.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ n.v }}</div></div>
+      </sc-for>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/login</span>
+        <span style="font-size:12px;color:#4B5563">Fallbacks and every failure state</span>
+      </div>
+      <div style="padding:18px;background:#F6F7F9;display:flex;flex-direction:column;gap:12px">
+        <sc-for list="{{ authStates }}" as="s" hint-placeholder-count="7">
+          <div role="{{ s.role }}" style="background:#FFFFFF;border:1px solid {{ s.bd }};border-radius:8px;padding:15px 17px">
+            <div style="display:flex;align-items:center;gap:9px">
+              <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;border-radius:999px;background:{{ s.glyphBg }};color:{{ s.glyphFg }};font-size:11px;font-weight:700">{{ s.glyph }}</span>
+              <span style="font-size:14px;font-weight:600;color:#101720">{{ s.title }}</span>
+              <span style="margin-left:auto;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085">{{ s.tag }}</span>
+            </div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:6px;text-wrap:pretty">{{ s.body }}</div>
+            <sc-if value="{{ s.action }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex;gap:8px;margin-top:11px">
+                <button style="height:34px;padding:0 13px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:13px;font-weight:500;cursor:pointer">{{ s.action }}</button>
+                <sc-if value="{{ s.action2 }}" hint-placeholder-val="{{ false }}"><button style="height:34px;padding:0 13px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13px;font-weight:500;cursor:pointer">{{ s.action2 }}</button></sc-if>
+              </div>
+            </sc-if>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/register</span>
+        <span style="font-size:12px;color:#4B5563">Access code → passkey enrolment</span>
+      </div>
+      <div style="padding:24px;background:#F6F7F9">
+        <div style="max-width:420px;margin:0 auto;background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:26px">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:18px;flex-wrap:wrap">
+            <sc-for list="{{ steps }}" as="st" hint-placeholder-count="3">
+              <span style="display:flex;align-items:center;gap:7px">
+                <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:999px;background:{{ st.bg }};color:{{ st.fg }};border:1px solid {{ st.bd }};font-size:11px;font-weight:600">{{ st.n }}</span>
+                <span style="font-size:12px;font-weight:{{ st.fw }};color:{{ st.labelFg }}">{{ st.label }}</span>
+                <sc-if value="{{ st.sep }}" hint-placeholder-val="{{ true }}"><span aria-hidden="true" style="width:14px;height:1px;background:#CBD2DC"></span></sc-if>
+              </span>
+            </sc-for>
+          </div>
+          <h2 style="margin:0;font-size:20px;line-height:26px;font-weight:600;letter-spacing:-0.015em">Create your passkey</h2>
+          <p style="margin:8px 0 0;font-size:13.5px;line-height:21px;color:#4B5563">Access code accepted for <span style="font-weight:600;color:#101720">amirul.shah@abeam.com</span>, issued by Wong Jia Hui on 05 Aug 2026. Your browser will ask for the device unlock you already use.</p>
+          <div style="margin-top:18px;border:1px solid #CBD2DC;border-radius:6px;background:#F6F7F9;padding:14px">
+            <div style="font-size:12.5px;font-weight:600;color:#101720">This passkey will be stored on</div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:4px">MacBook Pro · Touch ID · Safari 19 · Kuala Lumpur</div>
+          </div>
+          <button style="width:100%;height:44px;margin-top:16px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:15px;font-weight:500;cursor:pointer">Create passkey</button>
+          <div style="display:flex;gap:8px;margin-top:10px">
+            <button style="flex:1;height:40px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13.5px;font-weight:500;cursor:pointer">Use a security key</button>
+            <button style="flex:1;height:40px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13.5px;font-weight:500;cursor:pointer">Set up on my phone</button>
+          </div>
+          <p style="margin:14px 0 0;font-size:12px;line-height:18px;color:#667085">Add a second passkey later in Settings → Security. Cockpit asks every account to hold two, so a lost laptop is an inconvenience rather than a recovery request.</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/gantt-tool/invite/[token]</span>
+        <span style="font-size:12px;color:#4B5563">Accept · expired · already used</span>
+      </div>
+      <div style="padding:18px;background:#F6F7F9;display:flex;flex-direction:column;gap:12px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:20px">
+          <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Invitation</div>
+          <h3 style="margin:8px 0 0;font-size:19px;line-height:26px;font-weight:600;letter-spacing:-0.015em">Chan Wei Ling invited you to S/4HANA Migration — Sarawak Energy</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:12px">
+            <span style="display:inline-flex;align-items:center;height:26px;padding:0 9px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">Role: EDITOR</span>
+            <span style="display:inline-flex;align-items:center;height:26px;padding:0 9px;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:12px;font-weight:500;color:#4B5563">Cost visibility: level 1 of 3</span>
+            <span style="display:inline-flex;align-items:center;height:26px;padding:0 9px;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:12px;font-weight:500;color:#4B5563">Expires 09 Aug 2026, 17:00 MYT</span>
+          </div>
+          <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:12px;text-wrap:pretty">As an editor you can change the timeline, staffing and assumptions. Rates, margin and the cost breakdown stay hidden at level 1; the timeline and resource plan do not.</div>
+          <div style="display:flex;gap:8px;margin-top:16px">
+            <button style="height:40px;padding:0 16px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:14px;font-weight:500;cursor:pointer">Accept and open the project</button>
+            <button style="height:40px;padding:0 14px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:14px;font-weight:500;cursor:pointer">Decline</button>
+          </div>
+        </div>
+        <sc-for list="{{ inviteStates }}" as="s" hint-placeholder-count="2">
+          <div style="background:#FFFFFF;border:1px solid {{ s.bd }};border-radius:8px;padding:15px 17px">
+            <div style="display:flex;align-items:center;gap:9px"><span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;border-radius:999px;background:{{ s.glyphBg }};color:{{ s.glyphFg }};font-size:11px;font-weight:700">{{ s.glyph }}</span><span style="font-size:14px;font-weight:600">{{ s.title }}</span></div>
+            <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:6px;text-wrap:pretty">{{ s.body }}</div>
+            <button style="height:34px;padding:0 13px;margin-top:11px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13px;font-weight:500;cursor:pointer">{{ s.action }}</button>
+          </div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:20px 32px 0">
+  <h2 style="margin:0 0 4px;font-size:24px;line-height:30px;font-weight:600;letter-spacing:-0.02em">System screens</h2>
+  <p style="margin:0 0 16px;font-size:14px;line-height:21px;color:#4B5563;max-width:78ch">Held to the same standard as the workspace: each states what happened, what it means for the user’s unsaved work, and the next action — with a reference code wherever support might be involved.</p>
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <sc-for list="{{ systemScreens }}" as="s" hint-placeholder-count="5">
+      <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden;display:flex;flex-direction:column">
+        <div style="display:flex;align-items:baseline;gap:10px;padding:10px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+          <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">{{ s.route }}</span>
+          <span style="font-size:12px;color:#4B5563">{{ s.kind }}</span>
+        </div>
+        <div role="main" aria-label="{{ s.route }} — {{ s.kind }}" style="flex:1;padding:26px 22px;background:#F6F7F9;display:flex;flex-direction:column;align-items:{{ s.align }};text-align:{{ s.textAlign }}">
+          <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:8px;background:{{ s.iconBg }};border:1px solid {{ s.iconBd }};color:{{ s.iconFg }};font-size:17px">{{ s.glyph }}</span>
+          <h3 style="margin:13px 0 0;font-size:17px;line-height:24px;font-weight:600;letter-spacing:-0.01em">{{ s.title }}</h3>
+          <p style="margin:7px 0 0;font-size:13px;line-height:20px;color:#4B5563;max-width:46ch;text-wrap:pretty">{{ s.body }}</p>
+          <div style="display:flex;gap:8px;margin-top:16px;flex-wrap:wrap;justify-content:{{ s.justify }}">
+            <button style="height:36px;padding:0 14px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:13.5px;font-weight:500;cursor:pointer">{{ s.primary }}</button>
+            <button aria-label="{{ s.secondaryAria }}" style="height:36px;padding:0 14px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13.5px;font-weight:500;cursor:pointer">{{ s.secondary }}</button>
+          </div>
+          <sc-if value="{{ s.ref }}" hint-placeholder-val="{{ false }}">
+            <code style="margin-top:14px;display:inline-block;font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#667085">{{ s.ref }}</code>
+          </sc-if>
+        </div>
+        <div style="padding:10px 14px;border-top:1px solid #E4E7EC;font-size:12px;line-height:18px;color:#4B5563;text-wrap:pretty">{{ s.note }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1560px;margin:0 auto;padding:20px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Loading, empty and error per screen</h3>
+      <sc-for list="{{ statesTable }}" as="r" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:118px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Responsive</h3>
+      <sc-for list="{{ responsive }}" as="r" hint-placeholder-count="5">
+        <div style="display:grid;grid-template-columns:74px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+      </sc-for>
+      <h3 style="margin:18px 0 10px;font-size:16px;line-height:22px;font-weight:600">320px sign-in</h3>
+      <div style="width:320px;max-width:100%;border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;padding:18px">
+        <span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:6px;background:#101720;color:#FFFFFF;font-size:13px;font-weight:600">C</span>
+        <h4 style="margin:12px 0 0;font-size:19px;line-height:25px;font-weight:600;letter-spacing:-0.015em">Sign in</h4>
+        <div style="display:flex;align-items:center;height:44px;margin-top:12px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;font-size:15px;color:#667085">Work email</div>
+        <button style="width:100%;height:44px;margin-top:10px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:15px;font-weight:500;cursor:pointer">Continue with passkey</button>
+        <button style="width:100%;height:44px;margin-top:8px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:14px;font-weight:500;cursor:pointer">Other ways to sign in</button>
+      </div>
+    </div>
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Accessibility &amp; focus</h3>
+      <sc-for list="{{ a11y }}" as="a" hint-placeholder-count="6">
+        <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ a.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ a.v }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1560,&quot;height&quot;:980}}">
+class Component extends DCLogic {
+  renderVals() {
+    const S = (glyph, tone) => ({
+      glyph,
+      role: (tone === 'danger' || tone === 'warn') ? 'alert' : 'status',
+      bd: tone === 'danger' ? '#F0B5AF' : tone === 'warn' ? '#E0C089' : tone === 'ok' ? '#9AD9BB' : '#E4E7EC',
+      glyphBg: tone === 'danger' ? '#FDE9E7' : tone === 'warn' ? '#FBF0DC' : tone === 'ok' ? '#E3F5EB' : '#E8F0FE',
+      glyphFg: tone === 'danger' ? '#B3261E' : tone === 'warn' ? '#8A5200' : tone === 'ok' ? '#0A7A47' : '#0B57D0'
+    });
+
+    const authStates = [
+      Object.assign({ title: 'Check your email', tag: 'magic link sent', body: 'A sign-in link is on its way to chan.weiling@abeam.com. It works once and expires in 15 minutes. Keep this tab open — it will sign you in automatically when you click the link.', action: 'Resend in 0:47', action2: 'Use a different email' }, S('✉', 'info')),
+      Object.assign({ title: 'Enter the 6-digit code', tag: 'OTP', body: 'Sent to chan.weiling@abeam.com at 14:29. The code expires in 10 minutes; three wrong attempts locks this method for an hour and the passkey route stays available.', action: 'Verify', action2: 'Send a new code' }, S('#', 'info')),
+      Object.assign({ title: 'That sign-in link has expired', tag: 'expired', body: 'Links last 15 minutes and this one was sent at 13:44. Nothing is wrong with your account. Request a new link, or use the passkey on this device.', action: 'Send a new link', action2: 'Use passkey instead' }, S('⌛', 'warn')),
+      Object.assign({ title: 'That link has already been used', tag: 'used', body: 'Sign-in links work once. If you did not just sign in, someone else may have opened your email — request a new link and tell your security administrator.', action: 'Send a new link', action2: 'Report this' }, S('⚠', 'warn')),
+      Object.assign({ title: 'This link is not valid', tag: 'invalid', body: 'The address may have been broken across two lines by an email client. Copy the whole link, or start again from the sign-in page.', action: 'Back to sign in', action2: '' }, S('✕', 'danger')),
+      Object.assign({ title: 'Too many attempts', tag: 'rate-limited', body: 'Sign-in is paused for this address until 15:04 MYT — 12 minutes from now — after 5 failed attempts. Your account is not locked and your passkey still works from a device you have already registered.', action: 'Try a passkey', action2: 'Contact your administrator' }, S('⏸', 'danger')),
+      Object.assign({ title: 'This device has no passkey for Cockpit', tag: 'no credential', body: 'Passkeys are stored per device. Sign in with an emailed link on this device, then add a passkey in Settings → Security so this only happens once.', action: 'Email me a sign-in link', action2: 'Use my phone’s passkey' }, S('⚿', 'warn'))
+    ];
+
+    const inviteStates = [
+      Object.assign({ title: 'This invitation expired on 09 Aug 2026', body: 'Invitations last 72 hours so a forwarded email cannot grant access indefinitely. Chan Wei Ling can send a new one; the request below is pre-filled and goes straight to them.', action: 'Request a new invitation' }, S('⌛', 'warn')),
+      Object.assign({ title: 'This invitation has already been accepted', body: 'It was accepted by amirul.shah@abeam.com on 06 Aug 2026 at 09:12. If that was not you, tell your security administrator — the address on an invitation cannot be changed after acceptance.', action: 'Open my projects' }, S('✓', 'ok'))
+    ];
+
+    const steps = [
+      { n: '1', label: 'Access code', bg: '#E3F5EB', fg: '#0A7A47', bd: '#9AD9BB', fw: 500, labelFg: '#4B5563', sep: true },
+      { n: '2', label: 'Passkey', bg: '#0B57D0', fg: '#FFFFFF', bd: '#0B57D0', fw: 600, labelFg: '#101720', sep: true },
+      { n: '3', label: 'Backup codes', bg: '#FFFFFF', fg: '#4B5563', bd: '#CBD2DC', fw: 500, labelFg: '#667085', sep: false }
+    ];
+
+    const loginNotes = [
+      { k: 'Focus', v: 'Focus lands on the email field, not the passkey button — a keyboard user should not have to shift-tab to type their address.' },
+      { k: 'Autofill', v: 'autocomplete="username webauthn" so the browser can offer the passkey inline; the button remains for browsers that do not.' },
+      { k: 'Announce', v: 'Every state change writes to a polite region: “Sign-in link sent to chan.weiling@abeam.com. It expires in 15 minutes.”' },
+      { k: 'Fallback order', v: 'Passkey, then link, then code — never a password. There is no password field anywhere in Cockpit, so no phishing surface exists to protect.' }
+    ];
+
+    const sys = (route, kind, glyph, tone, title, body, primary, secondary, ref, note, centred) => ({
+      route, kind, glyph, title, body, primary, secondary, ref, note,
+      secondaryAria: ref ? 'Copy error reference ' + ref : secondary,
+      align: centred ? 'center' : 'flex-start',
+      textAlign: centred ? 'center' : 'left',
+      justify: centred ? 'center' : 'flex-start',
+      iconBg: tone === 'danger' ? '#FDE9E7' : tone === 'warn' ? '#FBF0DC' : '#E8F0FE',
+      iconBd: tone === 'danger' ? '#F0B5AF' : tone === 'warn' ? '#E0C089' : '#BBD0F6',
+      iconFg: tone === 'danger' ? '#B3261E' : tone === 'warn' ? '#8A5200' : '#0B57D0'
+    });
+
+    const systemScreens = [
+      sys('/404', 'Not found', '⌕', 'info', 'That page does not exist',
+        'The link may be from an older version of Cockpit, or the project may have been renamed. Nothing has been deleted — search finds projects by their old names for 90 days.',
+        'Go to my dashboard', 'Search projects', '', 'Never blames the user and never says “oops”. Offers search because a wrong URL is usually a moved object.', true),
+      sys('/500', 'Unexpected error', '✕', 'danger', 'Something failed on our side',
+        'The request could not be completed. Your unsaved work is safe in this browser and 148 changes are still queued locally — do not reload if you can avoid it. Support can trace this with the reference below.',
+        'Try again', 'Copy reference', 'PRJ-2291 · 07 Aug 2026 14:32 · e2f0-91c4', 'The reference code is copyable, not just printed. Reassurance about queued work comes before the action.', false),
+      sys('/offline', 'Offline', '⌁', 'warn', 'You are offline — keep working',
+        'Cockpit is local-first. Editing, dragging and costing all continue; 148 changes are queued on this device and will sync when the connection returns. The last sync was at 13:41.',
+        'Retry connection', 'View queued changes', '', 'Not a blocking screen: it appears as a banner over a fully usable workspace, and is shown here full-page only for the case where the app is opened cold with no cached project.', false),
+      sys('/session-expired', 'Session expired', '⌛', 'warn', 'Your session ended after 8 hours',
+        'You were signed out for security, not for inactivity. Nothing was lost: 3 changes are held locally and will sync the moment you are back in. Sign in with your passkey and you will return to this exact view.',
+        'Sign in with passkey', 'Use a sign-in link', '', 'Returns the user to the same route and scroll position after sign-in. The unsaved-work sentence is the first thing after the headline.', false),
+      sys('/no-permission', 'Insufficient permission', '🔒', 'info', 'You do not have access to this project',
+        'S/4HANA Migration — Sarawak Energy is restricted to its delivery team. Chan Wei Ling owns access. Requesting takes one click and includes your name, email and the page you were trying to reach.',
+        'Request access', 'Back to my projects', '', 'Deliberate, not broken: it names the object, the owner and the route to access, and never implies the project does not exist.', false)
+    ];
+
+    const statesTable = [
+      { k: '/login', v: 'Loading — the passkey button shows a spinner and the label becomes “Waiting for your device…”, with a 30-second timeout that offers the link fallback. Empty — never empty; the form is the content. Error — the six failure states above, each replacing the helper text rather than stacking a banner.' },
+      { k: '/register', v: 'Loading — the access code field disables with a spinner during validation. Empty — a blank code field with the format hint “8 characters, letters and digits”. Error — “That access code is not recognised. Codes expire 7 days after issue; ask Wong Jia Hui for a new one.”' },
+      { k: '/invite', v: 'Loading — a skeleton of the project name and two chips, so the shape of the decision appears before the data. Empty — impossible; a token always resolves to accept, expired or used. Error — token verification failure falls back to the 500 screen with the invite reference attached.' },
+      { k: '/404 · /500', v: 'No loading state — they are terminal. Both keep the top bar with the sync chip, so a user can still see that their queued work is safe.' },
+      { k: '/offline', v: 'Loading — none; the state is instantaneous. It resolves itself when connectivity returns, announcing “Back online. Sending 148 queued changes.”' },
+      { k: '/session-expired', v: 'Reached only by an expired token, so it has no loading state. Signing in again restores route, scroll position and any open drawer.' }
+    ];
+
+    const responsive = [
+      { k: '1920+', v: 'Auth card stays 380px and centres; the surrounding canvas carries no marketing content — this is an internal tool.' },
+      { k: '1440', v: 'Identical. Auth screens are deliberately width-independent.' },
+      { k: '1024', v: 'Identical; system screens narrow their body copy to 46ch.' },
+      { k: '768', v: 'Card goes edge-to-edge with 24px gutters; buttons become full-width.' },
+      { k: '320', v: 'Single column, 44px controls, 16px gutters, no horizontal scroll. Secondary sign-in methods collapse behind one “Other ways to sign in” button so the primary path stays above the fold.' }
+    ];
+
+    const a11y = [
+      { k: 'Landmarks', v: 'In the shipped screen each frame is a single <main> with an <h1>; in this gallery the frames carry role="main" with a route label and their headings are h3, because the page itself owns the h1. Auth screens have no navigation landmark at all — there is nowhere else to go before signing in.' },
+      { k: 'Focus on load', v: 'Focus goes to the email field on /login, to the code field on /register, and to the <h1> on every system screen so the reason is read before the actions.' },
+      { k: 'Errors', v: 'role="alert" on the failure card; the message names what happened, why, and the next action in that order. Rate-limit messages state the exact time access returns.' },
+      { k: 'Timers', v: 'The resend countdown is aria-live="off" and polled only on focus, so a screen reader is not interrupted every second; the button’s accessible name carries the remaining time.' },
+      { k: 'Passkey', v: 'The WebAuthn prompt is browser-owned; Cockpit announces before and after — “Waiting for your device” and “Signed in as Chan Wei Ling” — so the silent gap is explained.' },
+      { k: 'Reference codes', v: 'Rendered in a <code> element with a copy button whose accessible name is “Copy error reference PRJ-2291 e2f0-91c4”, because reading a hex string aloud is not a usable path.' }
+    ];
+
+    return { authStates, inviteStates, steps, loginNotes, systemScreens, statesTable, responsive, a11y };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/screens-core.html
+++ b/docs/design/screens-core.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1600px;margin:0 auto;padding:56px 32px 26px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 5, part 2 of 3</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Core screens</h1>
+  <p style="margin:16px 0 0;max-width:80ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Post-auth routing, the portfolio dashboard, the Gantt workspace and the modals it hosts, and the architecture canvas. The Gantt, allocation matrix, org chart and cost surfaces are prototyped in layer 4 — this part places them in the shell and designs the screens around them.</p>
+</header>
+
+<section style="max-width:1600px;margin:0 auto;padding:0 32px">
+  <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+    <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/dashboard</span>
+      <span style="font-size:12px;color:#4B5563">Portfolio overview · 1440px</span>
+    </div>
+
+    <div role="main" aria-label="Dashboard" style="background:#F6F7F9">
+      <div style="display:flex;align-items:center;gap:14px;height:52px;padding:0 16px;background:#FFFFFF;border-bottom:1px solid #CBD2DC">
+        <span style="display:inline-flex;align-items:center;gap:9px"><span style="display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:6px;background:#101720;color:#FFFFFF;font-size:12px;font-weight:600">C</span><span style="font-size:14.5px;font-weight:600;letter-spacing:-0.01em">Cockpit</span></span>
+        <span aria-hidden="true" style="width:1px;height:22px;background:#CBD2DC"></span>
+        <span style="font-size:13px;font-weight:600;color:#101720">All projects</span>
+        <span style="flex:1;display:flex;justify-content:center"><span style="display:flex;align-items:center;gap:8px;width:100%;max-width:420px;height:32px;padding:0 10px;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC"><span aria-hidden="true" style="font-family:'IBM Plex Mono',monospace;font-size:13px;color:#667085">⌕</span><span style="flex:1;font-size:13px;color:#667085">Search projects, tasks, resources…</span><kbd style="display:inline-flex;align-items:center;height:20px;padding:0 5px;border-radius:3px;background:#FFFFFF;border:1px solid #CBD2DC;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#4B5563">⌘K</kbd></span></span>
+        <span style="display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 10px;border-radius:999px;background:#E3F5EB;border:1px solid #9AD9BB"><span aria-hidden="true" style="font-size:11px;color:#0A7A47">✓</span><span style="font-size:12px;font-weight:500;color:#0A7A47">Synced</span><span style="font-size:11px;color:#0A7A47;font-variant-numeric:tabular-nums">14:32</span></span>
+        <button aria-label="Account — Chan Wei Ling" style="width:32px;height:32px;border-radius:999px;border:1px solid #7D8799;background:#FBF0DC;color:#8A5200;font-size:12px;font-weight:600;cursor:pointer">CW</button>
+      </div>
+
+      <div style="padding:24px 20px">
+        <div style="display:flex;align-items:flex-end;gap:16px;flex-wrap:wrap">
+          <div>
+            <h2 style="margin:0;font-size:26px;line-height:32px;font-weight:600;letter-spacing:-0.02em">Portfolio overview</h2>
+            <p style="margin:5px 0 0;font-size:13px;color:#4B5563">6 active programmes · 214 people staffed · scoped to Malaysia delivery</p>
+          </div>
+          <div style="margin-left:auto;display:flex;gap:8px">
+            <button style="height:36px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:13.5px;font-weight:500;cursor:pointer">Import a plan</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:13.5px;font-weight:500;cursor:pointer">New project</button>
+          </div>
+        </div>
+
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:12px;margin-top:18px">
+          <sc-for list="{{ tiles }}" as="t" hint-placeholder-count="4">
+            <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:15px 16px">
+              <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">{{ t.label }}</div>
+              <div style="display:flex;align-items:baseline;gap:8px;margin-top:7px">
+                <span style="font-size:26px;font-weight:600;letter-spacing:-0.02em;color:{{ t.fg }};font-variant-numeric:tabular-nums">{{ t.value }}</span>
+                <span style="font-size:12px;color:#4B5563">{{ t.unit }}</span>
+              </div>
+              <div style="font-size:12px;line-height:18px;color:#4B5563;margin-top:5px;text-wrap:pretty">{{ t.note }}</div>
+            </div>
+          </sc-for>
+        </div>
+
+        <div style="margin-top:16px;background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-bottom:1px solid #E4E7EC;flex-wrap:wrap">
+            <span style="font-size:14px;font-weight:600">Active programmes</span>
+            <span style="display:inline-flex;align-items:center;height:26px;padding:0 8px;border-radius:4px;background:#E8F0FE;border:1px solid #BBD0F6;font-size:12px;font-weight:500;color:#0B57D0">Region: MY</span>
+            <button style="height:26px;padding:0 8px;border-radius:4px;border:1px dashed #7D8799;background:#FFFFFF;font-size:12px;font-weight:500;color:#4B5563;cursor:pointer">+ Add filter</button>
+            <span style="margin-left:auto;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">6 of 11 programmes</span>
+          </div>
+          <div style="overflow-x:auto">
+            <div style="min-width:980px">
+              <div style="display:grid;grid-template-columns:2fr 108px 1fr 116px 84px 116px 124px 44px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+                <sc-for list="{{ projCols }}" as="c" hint-placeholder-count="8">
+                  <div style="padding:8px 12px;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563;text-align:{{ c.align }}">{{ c.label }}</div>
+                </sc-for>
+              </div>
+              <sc-for list="{{ projects }}" as="p" hint-placeholder-count="6">
+                <div style="display:grid;grid-template-columns:2fr 108px 1fr 116px 84px 116px 124px 44px;align-items:center;min-height:52px;border-bottom:1px solid #E4E7EC">
+                  <div style="padding:8px 12px;min-width:0">
+                    <div style="font-size:13.5px;font-weight:500;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ p.name }}</div>
+                    <div style="font-size:11.5px;color:#667085;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ p.client }} · {{ p.code }}</div>
+                  </div>
+                  <div style="padding:8px 12px"><span style="display:inline-flex;align-items:center;gap:5px;height:22px;padding:0 8px 0 6px;border-radius:4px;background:{{ p.pillBg }};color:{{ p.pillFg }};border:1px solid {{ p.pillBd }};font-size:11px;font-weight:500"><span aria-hidden="true">{{ p.pillG }}</span>{{ p.pill }}</span></div>
+                  <div style="padding:8px 12px">
+                    <div style="height:8px;border-radius:999px;background:#E4E7EC;overflow:hidden"><div style="height:100%;width:{{ p.pct }};background:{{ p.fill }}"></div></div>
+                    <div style="font-size:11px;color:#4B5563;margin-top:4px;font-variant-numeric:tabular-nums">{{ p.pct }} · {{ p.phase }}</div>
+                  </div>
+                  <div style="padding:8px 12px;font-size:12px;color:#4B5563;font-variant-numeric:tabular-nums">{{ p.dates }}</div>
+                  <div style="padding:8px 12px;text-align:right;font-size:12.5px;color:#101720;font-variant-numeric:tabular-nums">{{ p.people }}</div>
+                  <div style="padding:8px 12px;text-align:right;font-size:12.5px;font-weight:500;color:#101720;font-variant-numeric:tabular-nums">{{ p.value }}</div>
+                  <div style="padding:8px 12px;text-align:right;font-size:12.5px;font-weight:500;color:{{ p.marginFg }};font-variant-numeric:tabular-nums">{{ p.margin }}</div>
+                  <div style="display:flex;align-items:center;justify-content:center;color:#4B5563">⋯</div>
+                </div>
+              </sc-for>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:12px;padding:14px;border-top:1px solid #CBD2DC">
+      <sc-for list="{{ dashNotes }}" as="n" hint-placeholder-count="4">
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty"><span style="font-weight:600;color:#101720">{{ n.k }} — </span>{{ n.v }}</div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(430px,1fr));gap:20px">
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/</span>
+        <span style="font-size:12px;color:#4B5563">Post-auth routing</span>
+      </div>
+      <div role="main" aria-label="Routing splash" style="padding:30px 24px;background:#F6F7F9;display:flex;flex-direction:column;align-items:center;text-align:center;min-height:200px;justify-content:center">
+        <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:7px;background:#101720;color:#FFFFFF;font-size:15px;font-weight:600">C</span>
+        <div role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="100" aria-label="Restoring your last project" style="width:180px;height:6px;border-radius:999px;background:#E4E7EC;margin-top:18px;overflow:hidden"><div style="height:100%;width:64%;background:#0B57D0"></div></div>
+        <div style="font-size:13px;color:#4B5563;margin-top:12px">Restoring your last project — S/4HANA Migration</div>
+        <div style="font-size:12px;color:#667085;margin-top:4px;font-variant-numeric:tabular-nums">Reading 148 queued local changes</div>
+      </div>
+      <div style="padding:11px 14px;border-top:1px solid #E4E7EC;font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">Never a blank splash. It names what is being restored and, critically, that queued local work was found — the thing a user fears after closing a tab. Resolves to the last project, or /dashboard for a first-time user, and times out to /dashboard after 6 seconds with “Could not restore your last project — opening your dashboard instead.”</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/dashboard</span>
+        <span style="font-size:12px;color:#4B5563">First run &amp; loading</span>
+      </div>
+      <div style="padding:18px;background:#F6F7F9;display:flex;flex-direction:column;gap:12px">
+        <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:24px;text-align:center">
+          <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:8px;background:#E8F0FE;border:1px solid #BBD0F6;color:#0B57D0;font-size:17px">▤</span>
+          <h3 style="margin:12px 0 0;font-size:17px;line-height:24px;font-weight:600">Create your first programme</h3>
+          <p style="margin:7px auto 0;max-width:44ch;font-size:13px;line-height:20px;color:#4B5563;text-wrap:pretty">Start from the five SAP Activate phases, import an existing plan from Excel, or copy the structure of a programme you have delivered before.</p>
+          <div style="display:flex;gap:8px;justify-content:center;margin-top:14px;flex-wrap:wrap">
+            <button style="height:36px;padding:0 14px;border-radius:6px;background:#0B57D0;border:1px solid #0B57D0;color:#FFFFFF;font-size:13.5px;font-weight:500;cursor:pointer">Start from Activate</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13.5px;font-weight:500;cursor:pointer">Import from Excel</button>
+            <button style="height:36px;padding:0 14px;border-radius:6px;background:#FFFFFF;border:1px solid #7D8799;font-size:13.5px;font-weight:500;cursor:pointer">Copy a past programme</button>
+          </div>
+        </div>
+        <div aria-busy="true" aria-live="polite" aria-label="Loading your programmes" style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:14px">
+          <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085;margin-bottom:10px">Loading — skeleton matches the real 52px row height exactly</div>
+          <sc-for list="{{ skeletonRows }}" as="r" hint-placeholder-count="3">
+            <div aria-hidden="true" style="display:grid;grid-template-columns:2fr 90px 1fr 90px;gap:12px;align-items:center;height:52px;border-bottom:1px solid #E4E7EC">
+              <div><div style="height:13px;width:{{ r.a }};border-radius:2px;background:#E4E7EC"></div><div style="height:11px;width:{{ r.b }};border-radius:2px;background:#EDEFF3;margin-top:6px"></div></div>
+              <div style="height:20px;border-radius:4px;background:#E4E7EC"></div>
+              <div style="height:8px;border-radius:999px;background:#E4E7EC"></div>
+              <div style="height:13px;border-radius:2px;background:#E4E7EC"></div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+    <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/gantt-tool</span>
+      <span style="font-size:12px;color:#4B5563">Full-screen workspace — layout, panels and the modals it hosts</span>
+    </div>
+    <div role="main" aria-label="Gantt workspace layout" style="display:flex;height:340px;background:#F6F7F9">
+      <div style="width:50px;flex:none;background:#FFFFFF;border-right:1px solid #CBD2DC;display:flex;flex-direction:column;align-items:center;padding-top:10px;gap:6px">
+        <sc-for list="{{ rail }}" as="r" hint-placeholder-count="6">
+          <span title="{{ r.label }}" style="display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:6px;background:{{ r.bg }};color:{{ r.fg }};border:1px solid {{ r.bd }};font-family:'IBM Plex Mono',monospace;font-size:13px">{{ r.g }}</span>
+        </sc-for>
+      </div>
+      <div style="flex:1;min-width:0;display:flex;flex-direction:column">
+        <div style="display:flex;align-items:center;gap:10px;height:44px;padding:0 12px;background:#FFFFFF;border-bottom:1px solid #E4E7EC;flex-wrap:nowrap;overflow:hidden">
+          <span style="font-size:13.5px;font-weight:600;white-space:nowrap">S/4HANA Migration</span>
+          <span style="display:inline-flex;align-items:center;height:22px;padding:0 7px;flex:none;border-radius:4px;background:#F1F3F7;border:1px solid #CBD2DC;font-size:11px;font-weight:600;color:#4B5563">EDITOR</span>
+          <span style="display:inline-flex;gap:2px;padding:2px;flex:none;border-radius:6px;background:#F1F3F7;border:1px solid #CBD2DC"><span style="height:24px;padding:0 10px;display:inline-flex;align-items:center;border-radius:4px;background:#FFFFFF;border:1px solid #7D8799;font-size:12px;font-weight:500">Week</span><span style="height:24px;padding:0 10px;display:inline-flex;align-items:center;font-size:12px;color:#4B5563">Month</span></span>
+          <span style="margin-left:auto;display:flex;gap:6px;flex:none"><button style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Baseline</button><button style="height:28px;padding:0 10px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Proposal</button></span>
+        </div>
+        <div style="flex:1;display:flex;min-height:0">
+          <div style="width:250px;flex:none;background:#FFFFFF;border-right:1px solid #CBD2DC;padding:8px 0;overflow:hidden">
+            <sc-for list="{{ treeRows }}" as="t" hint-placeholder-count="8">
+              <div style="display:flex;align-items:center;gap:6px;height:30px;padding-left:{{ t.indent }};padding-right:10px;background:{{ t.bg }};box-shadow:{{ t.bar }}">
+                <span aria-hidden="true" style="width:12px;font-size:8px;color:#4B5563">{{ t.chev }}</span>
+                <span style="font-size:12px;font-weight:{{ t.fw }};color:{{ t.fg }};overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ t.name }}</span>
+              </div>
+            </sc-for>
+          </div>
+          <div style="flex:1;position:relative;background:#FFFFFF;overflow:hidden">
+            <sc-for list="{{ ganttBars }}" as="b" hint-placeholder-count="8">
+              <div style="position:absolute;top:{{ b.top }};left:{{ b.left }};width:{{ b.w }};height:{{ b.h }};border-radius:3px;background:{{ b.bg }};border:{{ b.border }}"></div>
+            </sc-for>
+            <div aria-hidden="true" style="position:absolute;top:0;bottom:0;left:38%;width:2px;background:#0B57D0"></div>
+          </div>
+          <div style="width:230px;flex:none;background:#FFFFFF;border-left:1px solid #CBD2DC;padding:12px">
+            <div style="font-size:11.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Task · Realize</div>
+            <div style="font-size:14px;font-weight:600;line-height:20px;margin-top:3px">Chart of accounts workshop</div>
+            <sc-for list="{{ inspector }}" as="i" hint-placeholder-count="5">
+              <div style="display:grid;grid-template-columns:76px 1fr;gap:8px;margin-top:8px;font-size:12px"><span style="color:#4B5563">{{ i.k }}</span><span style="color:#101720;font-variant-numeric:tabular-nums">{{ i.v }}</span></div>
+            </sc-for>
+          </div>
+        </div>
+        <div style="height:30px;display:flex;align-items:center;gap:14px;padding:0 12px;background:#F1F3F7;border-top:1px solid #CBD2DC;font-size:11.5px;color:#4B5563">
+          <span>80 phases · 1,200 tasks</span><span>Critical path 6 tasks</span><span style="margin-left:auto;font-variant-numeric:tabular-nums">Saved locally · 3 pending</span>
+        </div>
+      </div>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:12px;padding:14px;border-top:1px solid #CBD2DC">
+      <sc-for list="{{ workspaceNotes }}" as="n" hint-placeholder-count="5">
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty"><span style="font-weight:600;color:#101720">{{ n.k }} — </span>{{ n.v }}</div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 0">
+  <h2 style="margin:0 0 4px;font-size:24px;line-height:30px;font-weight:600;letter-spacing:-0.02em">Modals the workspace hosts</h2>
+  <p style="margin:0 0 16px;font-size:14px;line-height:21px;color:#4B5563;max-width:78ch">Nine, each at its stated size, each with the primitive it is composed from. Two may stack; a third replaces the second.</p>
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:12px">
+    <sc-for list="{{ modals }}" as="m" hint-placeholder-count="9">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:16px 18px">
+        <div style="display:flex;align-items:baseline;gap:8px">
+          <span style="font-size:14px;font-weight:600;color:#101720">{{ m.title }}</span>
+          <span style="margin-left:auto;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#667085">{{ m.size }}</span>
+        </div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:6px;text-wrap:pretty">{{ m.body }}</div>
+        <div style="font-size:11.5px;line-height:17px;color:#667085;margin-top:8px;padding-top:8px;border-top:1px solid #E4E7EC">Composed from: {{ m.parts }}</div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1600px;margin:0 auto;padding:20px 32px 96px">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(430px,1fr));gap:20px">
+    <div style="background:#FFFFFF;border:1px solid #CBD2DC;border-radius:8px;overflow:hidden">
+      <div style="display:flex;align-items:baseline;gap:10px;padding:11px 14px;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:500;color:#101720">/architecture · /architecture/v3</span>
+        <span style="font-size:12px;color:#4B5563">Solution diagramming</span>
+      </div>
+      <div role="main" aria-label="Architecture canvas" style="display:flex;height:300px;background:#F6F7F9">
+        <div style="width:150px;flex:none;background:#FFFFFF;border-right:1px solid #CBD2DC;padding:10px">
+          <div style="font-size:10.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Palette</div>
+          <sc-for list="{{ palette }}" as="p" hint-placeholder-count="6">
+            <div style="display:flex;align-items:center;gap:7px;margin-top:8px;padding:6px 8px;border:1px solid #CBD2DC;border-radius:6px;background:#FFFFFF;cursor:grab">
+              <span aria-hidden="true" style="width:14px;height:14px;border-radius:3px;background:{{ p.bg }};border:1px solid {{ p.bd }}"></span>
+              <span style="font-size:11.5px;color:#101720;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{ p.label }}</span>
+            </div>
+          </sc-for>
+        </div>
+        <div style="flex:1;position:relative;overflow:hidden">
+          <div aria-hidden="true" style="position:absolute;inset:0;background-image:radial-gradient(#E4E7EC 1px,transparent 1px);background-size:20px 20px"></div>
+          <sc-for list="{{ archNodes }}" as="n" hint-placeholder-count="5">
+            <div style="position:absolute;left:{{ n.x }};top:{{ n.y }};width:{{ n.w }};box-sizing:border-box;background:#FFFFFF;border:{{ n.border }};border-radius:6px;padding:8px 10px;box-shadow:0 1px 2px rgba(16,23,32,.06)">
+              <div style="font-size:11.5px;font-weight:600;color:#101720">{{ n.label }}</div>
+              <div style="font-size:10.5px;color:#4B5563">{{ n.sub }}</div>
+            </div>
+          </sc-for>
+          <sc-for list="{{ archLinks }}" as="l" hint-placeholder-count="4">
+            <div aria-hidden="true" style="position:absolute;left:{{ l.left }};top:{{ l.top }};width:{{ l.w }};height:{{ l.h }};background:#7D8799"></div>
+          </sc-for>
+        </div>
+        <div style="width:170px;flex:none;background:#FFFFFF;border-left:1px solid #CBD2DC;padding:10px">
+          <div style="font-size:10.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085">Properties</div>
+          <sc-for list="{{ archProps }}" as="p" hint-placeholder-count="5">
+            <div style="margin-top:9px"><div style="font-size:10.5px;color:#4B5563">{{ p.k }}</div><div style="height:26px;margin-top:3px;border:1px solid #7D8799;border-radius:5px;display:flex;align-items:center;padding:0 8px;font-size:11.5px;color:#101720;overflow:hidden;white-space:nowrap">{{ p.v }}</div></div>
+          </sc-for>
+        </div>
+      </div>
+      <div style="padding:12px 14px;border-top:1px solid #CBD2DC;font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty"><span style="font-weight:600;color:#101720">v3 versus v1 — </span>the /architecture route opens the most recent saved diagram; /architecture/v3 pins a named version and is read-only, with a banner reading “Viewing v3, saved 12 Jul 2026 by Rajesh Menon. Editing is disabled.” and a Duplicate to edit action. Export produces SVG for the proposal and PNG at 2× for slides; both carry the version stamp in the footer.</div>
+    </div>
+
+    <div style="display:flex;flex-direction:column;gap:20px">
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Loading, empty and error per core screen</h3>
+        <sc-for list="{{ statesTable }}" as="r" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:112px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+        </sc-for>
+      </div>
+      <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+        <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Responsive — what each screen does at each width</h3>
+        <sc-for list="{{ responsive }}" as="r" hint-placeholder-count="5">
+          <div style="display:grid;grid-template-columns:74px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+        </sc-for>
+      </div>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1600,&quot;height&quot;:980}}">
+class Component extends DCLogic {
+  renderVals() {
+    const tiles = [
+      { label: 'Contracted value', value: '184.2', unit: 'MYR m', note: 'Across 6 active programmes. Two await signature and are excluded.', fg: '#101720' },
+      { label: 'Weighted margin', value: '26.4', unit: '%', note: 'Below the 25% floor on one programme — Perak Water, at 21.8%.', fg: '#8A5200' },
+      { label: 'People staffed', value: '214', unit: 'of 260', note: '46 unassigned next month; 5 over-allocated in the cutover window.', fg: '#101720' },
+      { label: 'Needs attention', value: '7', unit: 'items', note: '2 late phases, 1 sync conflict, 3 access requests, 1 expiring rate card.', fg: '#B3261E' }
+    ];
+
+    const projCols = [
+      { label: 'Programme', align: 'left' }, { label: 'Health', align: 'left' }, { label: 'Progress', align: 'left' },
+      { label: 'Window', align: 'left' }, { label: 'People', align: 'right' }, { label: 'Value MYR', align: 'right' },
+      { label: 'Margin', align: 'right' }, { label: '', align: 'center' }
+    ];
+
+    const P = (name, client, code, pill, pct, phase, dates, people, value, margin, tone, marginTone) => ({
+      name, client, code, pct, phase, dates, people, value, margin,
+      pill, pillG: tone === 'ok' ? '✓' : tone === 'warn' ? '⚠' : tone === 'late' ? '✕' : '●',
+      pillBg: tone === 'ok' ? '#E3F5EB' : tone === 'warn' ? '#FBF0DC' : tone === 'late' ? '#FDE9E7' : '#F1F3F7',
+      pillFg: tone === 'ok' ? '#0A7A47' : tone === 'warn' ? '#8A5200' : tone === 'late' ? '#B3261E' : '#4B5563',
+      pillBd: tone === 'ok' ? '#9AD9BB' : tone === 'warn' ? '#E0C089' : tone === 'late' ? '#F0B5AF' : '#CBD2DC',
+      fill: tone === 'late' ? '#B3261E' : tone === 'warn' ? '#8A5200' : '#0B57D0',
+      marginFg: marginTone === 'bad' ? '#B3261E' : marginTone === 'warn' ? '#8A5200' : '#101720'
+    });
+
+    const projects = [
+      P('S/4HANA Migration', 'Sarawak Energy', 'PRJ-2291', 'At risk', '62%', 'Realize', '05 Jan 26 – 26 Dec 27', '42', '38.6 m', '27.1%', 'warn', 'ok'),
+      P('Finance Transformation', 'Petronas Chemicals', 'PRJ-2188', 'On track', '81%', 'Deploy', '02 Mar 26 – 30 Apr 27', '31', '24.9 m', '29.4%', 'ok', 'ok'),
+      P('SuccessFactors Rollout', 'Malayan Banking', 'PRJ-2304', 'On track', '34%', 'Explore', '01 Jun 26 – 15 Sep 27', '18', '11.2 m', '31.0%', 'ok', 'ok'),
+      P('Utilities Billing Upgrade', 'Perak Water Board', 'PRJ-2140', 'Late', '48%', 'Realize', '14 Oct 25 – 28 Feb 27', '26', '19.4 m', '21.8%', 'late', 'bad'),
+      P('Group Reporting', 'Sime Darby Plantation', 'PRJ-2331', 'On track', '12%', 'Prepare', '20 Jul 26 – 31 Mar 28', '9', '7.8 m', '28.6%', 'ok', 'ok'),
+      P('Warehouse Management', 'Northport Malaysia', 'PRJ-2276', 'Not started', '0%', 'Prepare', '01 Oct 26 – 30 Jun 28', '4', '9.1 m', '26.2%', 'none', 'ok')
+    ];
+
+    const dashNotes = [
+      { k: 'Scanability', v: 'Health, progress and margin sit in fixed columns so six programmes can be read in one pass; nothing is behind a hover or a click.' },
+      { k: 'Sorting', v: 'Default order is attention-first — late, then at risk, then everything else by window start. A portfolio sorted alphabetically hides the one row that matters.' },
+      { k: 'Redaction', v: 'Value and margin obey cost visibility per programme, not per user: a lead with level 3 on one programme and level 1 on another sees a real figure beside a mask, each with its own reason.' },
+      { k: 'Tiles', v: 'Four, never more. Each one is a number a delivery lead is accountable for, and each states the exception behind it rather than only the aggregate.' }
+    ];
+
+    const skeletonRows = [{ a: '52%', b: '30%' }, { a: '44%', b: '26%' }, { a: '58%', b: '34%' }];
+
+    const rail = [
+      { g: '▤', label: 'Timeline', bg: '#E8F0FE', fg: '#0B57D0', bd: '#BBD0F6' },
+      { g: '◑', label: 'Resources', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { g: '≡', label: 'Cost', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { g: '⌗', label: 'Org chart', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { g: '◇', label: 'Architecture', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' },
+      { g: '◔', label: 'Insights', bg: '#FFFFFF', fg: '#4B5563', bd: 'transparent' }
+    ];
+
+    const treeRows = [
+      { name: 'Prepare · PMO', indent: '10px', chev: '▶', fw: 600, fg: '#101720', bg: '#F6F7F9', bar: 'none' },
+      { name: 'Explore · Finance', indent: '10px', chev: '▶', fw: 600, fg: '#101720', bg: '#F6F7F9', bar: 'none' },
+      { name: 'Realize · Finance', indent: '10px', chev: '▼', fw: 600, fg: '#101720', bg: '#F6F7F9', bar: 'none' },
+      { name: 'Chart of accounts workshop', indent: '30px', chev: '', fw: 400, fg: '#101720', bg: '#E8F0FE', bar: 'inset 2px 0 0 #0B57D0' },
+      { name: 'Fit-gap — Finance 2', indent: '30px', chev: '', fw: 400, fg: '#4B5563', bg: '#FFFFFF', bar: 'none' },
+      { name: 'Build — Finance 3', indent: '30px', chev: '', fw: 400, fg: '#4B5563', bg: '#FFFFFF', bar: 'none' },
+      { name: 'Realize · Data Migration', indent: '10px', chev: '▶', fw: 600, fg: '#101720', bg: '#F6F7F9', bar: 'none' },
+      { name: 'Deploy · Cutover', indent: '10px', chev: '▶', fw: 600, fg: '#101720', bg: '#F6F7F9', bar: 'none' }
+    ];
+
+    const ganttBars = [
+      { top: '10px', left: '4%', w: '18%', h: '10px', bg: '#4B5563', border: '1px solid #101720' },
+      { top: '40px', left: '14%', w: '26%', h: '10px', bg: '#4B5563', border: '1px solid #101720' },
+      { top: '70px', left: '30%', w: '44%', h: '10px', bg: '#4B5563', border: '1px solid #101720' },
+      { top: '98px', left: '32%', w: '12%', h: '14px', bg: '#0B57D0', border: '1.5px solid #0B57D0' },
+      { top: '128px', left: '38%', w: '9%', h: '14px', bg: '#E8F0FE', border: '1px solid #0B57D0' },
+      { top: '158px', left: '44%', w: '14%', h: '14px', bg: '#E8F0FE', border: '1.5px solid #B3261E' },
+      { top: '188px', left: '46%', w: '30%', h: '10px', bg: '#4B5563', border: '1px solid #101720' },
+      { top: '218px', left: '68%', w: '22%', h: '10px', bg: '#4B5563', border: '1px solid #101720' }
+    ];
+
+    const inspector = [
+      { k: 'Dates', v: '07 – 18 Sep 2026' },
+      { k: 'Effort', v: '8 working days' },
+      { k: 'Assigned', v: 'Aisyah Rahman 80%' },
+      { k: 'Predecessor', v: 'Sign-off — Finance 8' },
+      { k: 'Cost', v: 'MYR 15,360' }
+    ];
+
+    const workspaceNotes = [
+      { k: 'Four regions', v: 'A 50px icon rail for destinations, a 44px project bar, the split Gantt, and a 230px inspector. Nothing else is chrome — the canvas gets every remaining pixel.' },
+      { k: 'Inspector', v: 'Docked at ≥1440px, an overlay drawer below that. It follows selection and never blocks the selected row, which stays visible with its accent bar.' },
+      { k: 'Status bar', v: '30px, always present: object counts, critical-path length and the sync state in words. It is the one place a user can confirm the size of what they are looking at.' },
+      { k: 'Viewer mode', v: 'A VIEWER sees the identical layout with commit actions replaced by one “Request edit access” button — never a screen of disabled controls.' },
+      { k: 'Density', v: 'Compact mode drops rows from 32 to 28 and the project bar from 44 to 40. Type never shrinks below 12px, and no padding is removed from a hit target.' }
+    ];
+
+    const modals = [
+      { title: 'Add / edit task', size: 'md 640', body: 'Name, phase, dates against the region calendar, effort, dependencies and assignment. Shows working days and the holidays excluded before commit.', parts: 'Input · Date-range picker · Combobox · Number input · Modal footer' },
+      { title: 'Add / edit phase', size: 'md 640', body: 'Name, stage, window, region calendar and workstream. Warns when the window falls outside its stage’s bounds instead of blocking it.', parts: 'Input · Select · Date-range picker · Inline alert' },
+      { title: 'Delete phase', size: 'sm 420', body: 'Destructive confirm. Names the phase, its 24 tasks, 9 assignments and 3 milestones, and requires the phase name typed to enable Delete.', parts: 'Modal/destructive · Input · Button/danger' },
+      { title: 'Assign resource', size: 'md 640', body: 'Async combobox over the roster with rate and region, an allocation slider clamped 0–150, and a live over-allocation warning naming the affected weeks.', parts: 'Combobox · Slider · Number input · Inline alert' },
+      { title: 'Edit dependency', size: 'sm 420', body: 'Link type (FS, SS, FF, SF), lag in working days, and a plain-language sentence of the result: “Cutover rehearsal starts 2 working days after Mock conversion 3 finishes.”', parts: 'Radio group · Number input · Inline alert' },
+      { title: 'Set baseline', size: 'sm 420', body: 'Names the version being replaced and how many tasks are captured. Baselines are never overwritten silently — the previous one is retained and listed.', parts: 'Modal · Inline alert · Button/primary' },
+      { title: 'Share project', size: 'md 640', body: 'Invite by email, role EDITOR or VIEWER, cost-visibility level, and expiry. Existing collaborators are listed with presence and last-seen.', parts: 'Combobox · Radio group · Select · Data table · Avatar' },
+      { title: 'Generate proposal', size: 'lg 880', body: 'Stepper: sections, branding, cost visibility for the export, then format. Shows a page-count estimate and warns when a chosen section contains masked figures.', parts: 'Stepper · Checkbox group · Radio group · Progress bar' },
+      { title: 'Resolve conflict', size: 'lg 880', body: 'Two versions side by side with field-level choice, as specified in layer 4e. Opens automatically only when the user was the last editor of the conflicted record.', parts: 'Modal/lg · Radio pair per field · Inline alert' }
+    ];
+
+    const palette = [
+      { label: 'SAP S/4HANA', bg: '#E8F0FE', bd: '#0B57D0' },
+      { label: 'SAP BTP', bg: '#E3F5EB', bd: '#0A7A47' },
+      { label: 'Integration', bg: '#FBF0DC', bd: '#8A5200' },
+      { label: 'Legacy system', bg: '#F1F3F7', bd: '#7D8799' },
+      { label: 'Data store', bg: '#FFFFFF', bd: '#7D8799' },
+      { label: 'External party', bg: '#FDE9E7', bd: '#B3261E' }
+    ];
+
+    // One geometry source: node width and column x-positions drive both cards and links.
+    const NW = 112, COL = [16, 168, 320];
+    const N = (col, y, label, sub, border) => ({ x: COL[col] + 'px', y: y + 'px', w: NW + 'px', label, sub, border, col, yv: y });
+    const archNodes = [
+      N(0, 24, 'S/4HANA', 'Private cloud, KL', '1.5px solid #0B57D0'),
+      N(0, 148, 'ECC 6.0', 'Legacy, retiring', '1px solid #7D8799'),
+      N(1, 86, 'SAP BTP', 'Integration Suite', '1px solid #0A7A47'),
+      N(2, 24, 'SuccessFactors', 'SaaS', '1px solid #0A7A47'),
+      N(2, 148, 'Bank host-to-host', 'External party', '1px solid #B3261E')
+    ];
+    const NHh = 46;
+    const link = (a, b) => {
+      const ax = COL[a.col] + NW, ay = a.yv + NHh / 2;
+      const bx = COL[b.col], by = b.yv + NHh / 2;
+      const mid = (ax + bx) / 2;
+      return [
+        { left: ax + 'px', top: ay + 'px', w: (mid - ax) + 'px', h: '1.5px' },
+        { left: mid + 'px', top: Math.min(ay, by) + 'px', w: '1.5px', h: (Math.abs(by - ay) || 1) + 'px' },
+        { left: mid + 'px', top: by + 'px', w: (bx - mid) + 'px', h: '1.5px' }
+      ];
+    };
+    const archLinks = []
+      .concat(link(archNodes[0], archNodes[2]))
+      .concat(link(archNodes[1], archNodes[2]))
+      .concat(link(archNodes[2], archNodes[3]))
+      .concat(link(archNodes[2], archNodes[4]));
+
+    const archProps = [
+      { k: 'Name', v: 'SAP BTP' }, { k: 'Type', v: 'Integration Suite' },
+      { k: 'Environment', v: 'Production' }, { k: 'Owner', v: 'Goh Mei Yee' },
+      { k: 'Go-live', v: '18 Jan 2027' }
+    ];
+
+    const statesTable = [
+      { k: '/dashboard', v: 'Loading — six 52px skeleton rows plus four tile skeletons, announced as “Loading your programmes”. Empty — the first-run state above. No results after filtering — stays in the table body with the filter count and a one-click removal. Error — “Your programmes could not be loaded. The list you last saw is shown from this device, dated 14:02.”' },
+      { k: '/gantt-tool', v: 'Loading — the tree renders first from the local copy, the canvas fills in behind it; the status bar reads “Loading 1,200 tasks”. Empty — a phase-less project offers the Activate starter inline in the tree. Error — the canvas is replaced, the tree stays, so navigation and undo survive.' },
+      { k: 'Inspector', v: 'Loading — field skeletons at exact field heights. Empty — “Select a task or phase to see its detail.” Error — the drawer keeps its header and shows a retry inline rather than closing.' },
+      { k: '/architecture', v: 'Loading — the palette and properties render immediately, the canvas shows a centred spinner with “Opening diagram v7”. Empty — “Drag a component from the palette to start.” Error — offers the last exported SVG for download so a client meeting is not lost.' },
+      { k: 'Modals', v: 'Loading — the primary button enters its loading state and the form stays interactive. Error — a role="alert" inline banner at the top of the modal body, never a nested modal, and focus moves to it.' }
+    ];
+
+    const responsive = [
+      { k: '1920+', v: 'Dashboard table gains the native-currency and utilisation columns. Gantt shows the inspector docked plus a 320px critical-path panel at the bottom without overlap.' },
+      { k: '1440', v: 'Reference width. Dashboard as drawn; Gantt with docked inspector; architecture with both side panels.' },
+      { k: '1024', v: 'Dashboard drops Window and People into a second line under the name. Gantt inspector becomes an overlay drawer; the icon rail stays. Architecture properties panel becomes a bottom drawer.' },
+      { k: '768', v: 'Dashboard becomes a card list, one programme per card, health and margin on the same line. Gantt switches to the stage-summary list from layer 4a — read plus percent-complete editing only. Architecture is read-only with pan and zoom.' },
+      { k: '320', v: 'Dashboard cards stack with 44px targets. Gantt is the stage list; tapping a stage opens its phases, tapping a phase opens a read-only task list. Architecture offers the exported image with pinch-zoom and an “Open on desktop to edit” link.' }
+    ];
+
+    return { tiles, projCols, projects, dashNotes, skeletonRows, rail, treeRows, ganttBars, inspector, workspaceNotes, modals, palette, archNodes, archLinks, archProps, statesTable, responsive };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/sync.html
+++ b/docs/design/sync.html
@@ -1,0 +1,430 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#F6F7F9; font-family:'IBM Plex Sans',system-ui,sans-serif; -webkit-font-smoothing:antialiased; color:#101720; }
+  a { color:#0B57D0; } a:hover { color:#08429E; }
+  button { font-family:inherit; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { animation-duration:1ms !important; transition-duration:1ms !important; } }
+</style>
+</helmet>
+
+<header style="max-width:1500px;margin:0 auto;padding:56px 32px 24px">
+  <div style="font-size:13px;line-height:18px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#667085">Cockpit — layer 4e of 5</div>
+  <h1 style="margin:14px 0 0;font-size:40px;line-height:46px;font-weight:600;letter-spacing:-0.025em">Sync state machine &amp; conflict resolution</h1>
+  <p style="margin:16px 0 0;max-width:80ch;font-size:15px;line-height:24px;color:#4B5563;text-wrap:pretty">Six states, thirteen transitions, one chip. Click a state to see its chip and its exact announcement, or run the scripted journey to watch a full round trip from a local edit through a conflict to resolution.</p>
+</header>
+
+<section style="max-width:1500px;margin:0 auto;padding:0 32px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="display:flex;align-items:center;gap:12px;padding:12px 14px;border-bottom:1px solid #CBD2DC;flex-wrap:wrap">
+      <span style="font-size:12px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#4B5563">Current state</span>
+      <span style="display:inline-flex;align-items:center;gap:8px;height:30px;padding:0 11px;border-radius:999px;background:{{ chipBg }};border:1px solid {{ chipBd }}">
+        <sc-if value="{{ chipSpin }}" hint-placeholder-val="{{ false }}"><span style="width:12px;height:12px;border-radius:999px;border:2px solid #BBD0F6;border-top-color:{{ chipFg }};animation:spin 700ms linear infinite"></span></sc-if>
+        <sc-if value="{{ chipGlyphShown }}" hint-placeholder-val="{{ true }}"><span aria-hidden="true" style="font-size:11px;color:{{ chipFg }}">{{ chipGlyph }}</span></sc-if>
+        <span style="font-size:12.5px;font-weight:600;color:{{ chipFg }}">{{ chipLabel }}</span>
+        <span style="font-size:11.5px;color:{{ chipMetaFg }};font-variant-numeric:tabular-nums">{{ chipMeta }}</span>
+      </span>
+      <span style="font-size:12.5px;line-height:19px;color:#4B5563;max-width:50ch;text-wrap:pretty">{{ stateSummary }}</span>
+      <span style="margin-left:auto;display:flex;gap:8px">
+        <button onClick="{{ runJourney }}" style="height:30px;padding:0 12px;border-radius:6px;border:1px solid #0B57D0;background:#0B57D0;color:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">{{ journeyLabel }}</button>
+        <button onClick="{{ reset }}" style="height:30px;padding:0 12px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Reset</button>
+      </span>
+    </div>
+
+    <div style="position:relative;height:410px;background:#F6F7F9;overflow-x:auto;overflow-y:hidden">
+      <div style="position:relative;width:1120px;height:410px">
+      <div aria-hidden="true" style="position:absolute;inset:0;background-image:radial-gradient(#E4E7EC 1px,transparent 1px);background-size:24px 24px;opacity:.7"></div>
+      <sc-for list="{{ edges }}" as="e" hint-placeholder-count="18">
+        <div aria-hidden="true" style="position:absolute;left:{{ e.left }};top:{{ e.top }};width:{{ e.w }};height:{{ e.h }};background:{{ e.color }};opacity:{{ e.op }}"></div>
+      </sc-for>
+      <sc-for list="{{ edgeLabels }}" as="e" hint-placeholder-count="9">
+        <div aria-hidden="true" style="position:absolute;left:{{ e.left }};top:{{ e.top }};transform:translate(-50%,-50%);background:#F6F7F9;padding:1px 5px;border-radius:3px;font-size:10.5px;font-weight:500;color:{{ e.color }};white-space:nowrap">{{ e.label }}</div>
+      </sc-for>
+      <sc-for list="{{ stateNodes }}" as="s" hint-placeholder-count="6">
+        <button onClick="{{ s.on }}" aria-pressed="{{ s.pressed }}" style="position:absolute;left:{{ s.x }};top:{{ s.y }};width:212px;text-align:left;background:{{ s.bg }};border:{{ s.border }};border-radius:8px;padding:11px 13px;box-shadow:{{ s.shadow }};cursor:pointer">
+          <span style="display:flex;align-items:center;gap:8px">
+            <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;flex:none;border-radius:999px;background:{{ s.glyphBg }};color:{{ s.glyphFg }};font-size:11px;font-weight:700">{{ s.glyph }}</span>
+            <span style="font-size:13px;font-weight:600;color:#101720">{{ s.label }}</span>
+          </span>
+          <span style="display:block;font-size:11.5px;line-height:17px;color:#4B5563;margin-top:5px;text-wrap:pretty">{{ s.blurb }}</span>
+        </button>
+      </sc-for>
+      </div>
+    </div>
+
+    <div id="sync-status" role="{{ liveRole }}" aria-live="{{ livePoliteness }}" aria-atomic="true" style="display:flex;align-items:flex-start;gap:10px;padding:9px 14px;border-top:1px solid #CBD2DC;background:{{ statusBg }}">
+      <span style="font-size:11px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#667085;flex:none;padding-top:2px">{{ liveLabel }}</span>
+      <span style="font-size:12.5px;line-height:19px;color:#101720">{{ announce }}</span>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 0">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="padding:13px 16px;border-bottom:1px solid #CBD2DC"><h2 style="margin:0;font-size:18px;line-height:24px;font-weight:600;letter-spacing:-0.01em">Every transition</h2></div>
+    <div style="display:grid;grid-template-columns:1fr 1fr 1.3fr 1.6fr 2.1fr;gap:14px;padding:9px 16px;background:#F1F3F7;border-bottom:1px solid #CBD2DC;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">
+      <div>From</div><div>To</div><div>Trigger</div><div>Visual treatment</div><div>Announcement</div>
+    </div>
+    <sc-for list="{{ transitions }}" as="t" hint-placeholder-count="13">
+      <div style="display:grid;grid-template-columns:1fr 1fr 1.3fr 1.6fr 2.1fr;gap:14px;padding:11px 16px;border-bottom:1px solid #E4E7EC;align-items:start">
+        <div style="font-size:12.5px;font-weight:500;color:#101720">{{ t.from }}</div>
+        <div style="display:flex;align-items:center;gap:6px;font-size:12.5px;font-weight:500;color:#101720"><span aria-hidden="true" style="color:#7D8799">→</span>{{ t.to }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ t.trigger }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ t.visual }}</div>
+        <div style="font-size:12.5px;line-height:19px;color:#101720;text-wrap:pretty">{{ t.say }}<span style="display:inline-flex;align-items:center;height:17px;padding:0 5px;margin-left:6px;border-radius:3px;background:{{ t.polBg }};border:1px solid {{ t.polBd }};font-family:'IBM Plex Mono',monospace;font-size:10px;color:{{ t.polFg }}">{{ t.pol }}</span></div>
+      </div>
+    </sc-for>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 0">
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600">The chip in all six states</h3>
+      <div style="display:flex;flex-direction:column;gap:10px">
+        <sc-for list="{{ chipGallery }}" as="c" hint-placeholder-count="6">
+          <div style="display:flex;align-items:flex-start;gap:12px">
+            <span style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;flex:none;border-radius:999px;background:{{ c.bg }};border:1px solid {{ c.bd }}"><span aria-hidden="true" style="font-size:11px;color:{{ c.fg }}">{{ c.glyph }}</span><span style="font-size:12px;font-weight:600;color:{{ c.fg }}">{{ c.label }}</span><span style="font-size:11px;color:{{ c.metaFg }};font-variant-numeric:tabular-nums">{{ c.meta }}</span></span>
+            <span style="font-size:12px;line-height:18px;color:#4B5563;text-wrap:pretty">{{ c.note }}</span>
+          </div>
+        </sc-for>
+      </div>
+      <div style="margin-top:16px;padding-top:14px;border-top:1px solid #E4E7EC;font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">The chip is a button whose accessible name is the whole state sentence; activating it opens the sync popover with pending changes, last successful sync, queue size and Retry. It appears in the top bar of every authenticated screen at every breakpoint — at 320px it keeps the glyph and one word and drops the timestamp.</div>
+    </div>
+
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 14px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Dark chips, with ratios</h3>
+      <div style="display:flex;flex-direction:column;gap:10px">
+        <sc-for list="{{ darkChips }}" as="c" hint-placeholder-count="6">
+          <div style="display:flex;align-items:center;gap:12px">
+            <span style="display:inline-flex;align-items:center;gap:7px;height:28px;padding:0 10px;flex:none;border-radius:999px;background:{{ c.bg }};border:1px solid {{ c.bd }}"><span aria-hidden="true" style="font-size:11px;color:{{ c.fg }}">{{ c.glyph }}</span><span style="font-size:12px;font-weight:600;color:{{ c.fg }}">{{ c.label }}</span></span>
+            <span style="font-size:11.5px;line-height:17px;color:#AFBACA;font-variant-numeric:tabular-nums">{{ c.ratio }}</span>
+          </div>
+        </sc-for>
+      </div>
+      <div style="margin-top:14px;font-size:12px;line-height:18px;color:#8592A6;text-wrap:pretty">Each dark chip pairs a status hue with its own subtle fill and a border at or above 3:1, so the chip stays a distinct object on surface/raised rather than a coloured word floating on the bar.</div>
+    </div>
+
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Rules</h3>
+      <sc-for list="{{ rules }}" as="r" hint-placeholder-count="8">
+        <div style="display:grid;grid-template-columns:16px 1fr;gap:8px;padding:6px 0"><span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#0B57D0;line-height:19px">§</span><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r }}</div></div>
+      </sc-for>
+    </div>
+  </div>
+</section>
+
+<section style="max-width:1500px;margin:0 auto;padding:16px 32px 96px">
+  <div style="border:1px solid #CBD2DC;border-radius:8px;background:#FFFFFF;overflow:hidden">
+    <div style="display:flex;align-items:flex-start;gap:12px;padding:14px 16px;border-bottom:1px solid #CBD2DC;background:#FDE9E7">
+      <span aria-hidden="true" style="font-size:13px;color:#B3261E;padding-top:2px">⚠</span>
+      <div style="flex:1;min-width:0">
+        <div style="font-size:15px;font-weight:600;color:#B3261E">Resolve conflict — “Data cleansing sign-off”</div>
+        <div style="font-size:12.5px;line-height:19px;color:#4B5563;margin-top:3px;text-wrap:pretty">You and <span style="font-weight:600;color:#101720">Rajesh Menon</span> edited this task while you were offline. Rajesh’s version reached the server at 13:58; yours has been queued locally since 13:41. Sync is paused for the whole project until this is resolved.</div>
+      </div>
+      <div style="display:flex;gap:8px;flex:none">
+        <button onClick="{{ takeAllMine }}" style="height:30px;padding:0 11px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Take all mine</button>
+        <button onClick="{{ takeAllTheirs }}" style="height:30px;padding:0 11px;border-radius:6px;border:1px solid #7D8799;background:#FFFFFF;font-size:12.5px;font-weight:500;cursor:pointer">Take all Rajesh’s</button>
+      </div>
+    </div>
+
+    <div style="display:grid;grid-template-columns:170px 1fr 1fr;gap:0;background:#F1F3F7;border-bottom:1px solid #CBD2DC">
+      <div style="padding:9px 14px;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563">Field</div>
+      <div style="padding:9px 14px;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563;border-left:1px solid #E4E7EC">Your version <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#667085">· queued locally 13:41</span></div>
+      <div style="padding:9px 14px;font-size:11.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#4B5563;border-left:1px solid #E4E7EC">Rajesh Menon <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#667085">· on server 13:58</span></div>
+    </div>
+
+    <sc-for list="{{ fields }}" as="f" hint-placeholder-count="4">
+      <div style="display:grid;grid-template-columns:170px 1fr 1fr;border-bottom:1px solid #E4E7EC">
+        <div style="padding:12px 14px">
+          <div style="font-size:13px;font-weight:500;color:#101720">{{ f.label }}</div>
+          <div style="font-size:11.5px;line-height:17px;color:#667085;margin-top:3px;text-wrap:pretty">{{ f.note }}</div>
+        </div>
+        <sc-if value="{{ f.same }}" hint-placeholder-val="{{ false }}">
+          <div style="grid-column:2 / span 2;padding:12px 14px;border-left:1px solid #E4E7EC;background:#F6F7F9;display:flex;align-items:center;gap:10px">
+            <span style="font-size:13px;color:#4B5563">{{ f.mine }}</span>
+            <span style="display:inline-flex;align-items:center;height:20px;padding:0 7px;border-radius:3px;background:#FFFFFF;border:1px solid #CBD2DC;font-size:11px;font-weight:500;color:#4B5563">Unchanged on both sides — no decision needed</span>
+          </div>
+        </sc-if>
+        <sc-if value="{{ f.isConflict }}" hint-placeholder-val="{{ true }}">
+          <div style="padding:10px 14px;border-left:1px solid #E4E7EC">
+            <button onClick="{{ f.pickMine }}" style="width:100%;text-align:left;background:{{ f.mineBg }};border:{{ f.mineBd }};border-radius:6px;padding:9px 11px;cursor:pointer">
+              <span style="display:block;font-size:13px;color:#101720">{{ f.mine }}</span>
+              <span style="display:block;font-size:11.5px;font-weight:600;color:{{ f.mineFg }};margin-top:5px">{{ f.mineMark }}</span>
+            </button>
+          </div>
+        </sc-if>
+        <sc-if value="{{ f.isConflict }}" hint-placeholder-val="{{ true }}">
+          <div style="padding:10px 14px;border-left:1px solid #E4E7EC">
+            <button onClick="{{ f.pickTheirs }}" style="width:100%;text-align:left;background:{{ f.theirsBg }};border:{{ f.theirsBd }};border-radius:6px;padding:9px 11px;cursor:pointer">
+              <span style="display:block;font-size:13px;color:#101720">{{ f.theirs }}</span>
+              <span style="display:block;font-size:11.5px;font-weight:600;color:{{ f.theirsFg }};margin-top:5px">{{ f.theirsMark }}</span>
+            </button>
+          </div>
+        </sc-if>
+      </div>
+    </sc-for>
+
+    <div style="display:flex;align-items:center;gap:14px;padding:12px 16px;background:#F6F7F9;flex-wrap:wrap">
+      <span style="font-size:12.5px;color:#4B5563;font-variant-numeric:tabular-nums">{{ resolvedCount }} of {{ conflictCount }} conflicted fields resolved · 1 field unchanged and carried through</span>
+      <span style="font-size:12px;color:#667085">↑↓ field · ← yours · → theirs · Enter merge</span>
+      <span style="margin-left:auto;display:flex;gap:8px">
+        <button style="height:34px;padding:0 13px;border-radius:6px;border:none;background:transparent;font-size:13px;font-weight:500;color:#0B57D0;cursor:pointer">Keep both as separate tasks</button>
+        <button style="height:34px;padding:0 14px;border-radius:6px;background:{{ resolveBg }};color:{{ resolveFg }};border:1px solid {{ resolveBd }};font-size:13px;font-weight:500;cursor:pointer">{{ resolveLabel }}</button>
+      </span>
+    </div>
+  </div>
+
+  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:16px;margin-top:16px">
+    <div style="background:#FFFFFF;border:1px solid #E4E7EC;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600">Conflict-resolution rules</h3>
+      <sc-for list="{{ conflictRules }}" as="r" hint-placeholder-count="7">
+        <div style="display:grid;grid-template-columns:126px 1fr;gap:12px;padding:7px 0;border-top:1px solid #E4E7EC"><div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:#101720">{{ r.k }}</div><div style="font-size:12.5px;line-height:19px;color:#4B5563;text-wrap:pretty">{{ r.v }}</div></div>
+      </sc-for>
+    </div>
+    <div style="background:#0E1116;border:1px solid #333C4A;border-radius:8px;padding:22px">
+      <h3 style="margin:0 0 12px;font-size:16px;line-height:22px;font-weight:600;color:#E9EEF6">Conflict rows — dark</h3>
+      <div style="border:1px solid #333C4A;border-radius:6px;overflow:hidden">
+        <div style="display:grid;grid-template-columns:110px 1fr 1fr;background:#0A0D12;border-bottom:1px solid #333C4A;font-size:10.5px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#AFBACA"><div style="padding:7px 10px">Field</div><div style="padding:7px 10px">Yours</div><div style="padding:7px 10px">Rajesh</div></div>
+        <div style="display:grid;grid-template-columns:110px 1fr 1fr;border-bottom:1px solid #232A35">
+          <div style="padding:9px 10px;font-size:12px;color:#E9EEF6">Dates</div>
+          <div style="padding:7px 10px"><div style="border:1px solid #3D4757;border-radius:5px;padding:7px 9px;font-size:12px;color:#E9EEF6;background:#171C24">12 – 16 Jan 2027</div></div>
+          <div style="padding:7px 10px"><div style="border:1.5px solid #7FB0FF;border-radius:5px;padding:7px 9px;font-size:12px;color:#E9EEF6;background:#16294A">19 – 23 Jan 2027<span style="display:block;font-size:11px;font-weight:600;color:#7FB0FF;margin-top:4px">✓ Keeping Rajesh’s</span></div></div>
+        </div>
+        <div style="display:grid;grid-template-columns:110px 1fr 1fr">
+          <div style="padding:9px 10px;font-size:12px;color:#E9EEF6">Owner</div>
+          <div style="grid-column:2 / span 2;padding:9px 10px;background:#0A0D12;font-size:12px;color:#AFBACA">Daniel Okafor — unchanged on both sides</div>
+        </div>
+      </div>
+      <div style="font-size:12px;line-height:18px;color:#8592A6;margin-top:10px">The chosen side is accent/subtle with a 1.5px accent border and the word “Keeping” — three signals, so the choice is not carried by fill alone at a glance or on a projector.</div>
+    </div>
+  </div>
+</section></x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1500,&quot;height&quot;:960}}">
+const STATES = {
+  local: { label: 'Saved locally', glyph: '●', meta: '3 pending', blurb: 'Edits are on this device and not yet sent. The resting state while working.',
+    bg: '#F1F3F7', bd: '#7D8799', fg: '#4B5563', metaFg: '#667085', glyphBg: '#E4E7EC', glyphFg: '#4B5563',
+    say: 'Saved locally. 3 changes pending sync.', pol: 'polite' },
+  syncing: { label: 'Syncing', glyph: '◐', meta: '148 changes', blurb: 'Changes are in flight; the count falls as batches are acknowledged.',
+    bg: '#E8F0FE', bd: '#BBD0F6', fg: '#0B57D0', metaFg: '#0B57D0', glyphBg: '#D6E4FD', glyphFg: '#0B57D0',
+    say: 'Syncing 148 changes.', pol: 'polite' },
+  synced: { label: 'Synced', glyph: '✓', meta: '14:32', blurb: 'Local and server agree. The timestamp is the last acknowledgement.',
+    bg: '#E3F5EB', bd: '#9AD9BB', fg: '#0A7A47', metaFg: '#0A7A47', glyphBg: '#CDEBDB', glyphFg: '#0A7A47',
+    say: 'Synced. All 148 changes saved to the server at 14:32.', pol: 'polite' },
+  offline: { label: 'Offline', glyph: '⌁', meta: '148 queued', blurb: 'No connection. Editing continues; everything queues locally and nothing is lost.',
+    bg: '#FBF0DC', bd: '#E0C089', fg: '#8A5200', metaFg: '#8A5200', glyphBg: '#F5E2BE', glyphFg: '#8A5200',
+    say: 'Offline. Editing continues; 148 changes are queued locally.', pol: 'polite' },
+  conflict: { label: 'Conflict', glyph: '⚠', meta: '1 to resolve', blurb: 'Someone else changed the same fields. Sync pauses until a version is chosen.',
+    bg: '#FDE9E7', bd: '#F0B5AF', fg: '#B3261E', metaFg: '#B3261E', glyphBg: '#F9D4D0', glyphFg: '#B3261E',
+    say: 'Sync stopped. Two people edited “Data cleansing sign-off”. Choose a version to keep. Press G then R to open conflict resolution.', pol: 'assertive' },
+  error: { label: 'Sync failed', glyph: '✕', meta: 'PRJ-2291', blurb: 'The server rejected the batch. Retrying has stopped; the local copy is intact.',
+    bg: '#FDE9E7', bd: '#B3261E', fg: '#B3261E', metaFg: '#B3261E', glyphBg: '#B3261E', glyphFg: '#FFFFFF',
+    say: 'Sync failed permanently. The server rejected 148 changes. Your local copy is intact. Reference PRJ-2291 / 14:32.', pol: 'assertive' }
+};
+const POS = { synced: { x: 40, y: 34 }, local: { x: 320, y: 34 }, syncing: { x: 600, y: 34 }, offline: { x: 320, y: 186 }, conflict: { x: 600, y: 292 }, error: { x: 880, y: 186 } };
+const EDGES = [
+  ['synced', 'local', 'edit'], ['local', 'syncing', 'autosync 3s'], ['syncing', 'synced', 'ack'],
+  ['local', 'offline', 'connection lost'], ['offline', 'syncing', 'reconnect'], ['syncing', 'conflict', 'version clash'],
+  ['conflict', 'local', 'resolved'], ['syncing', 'error', '5 retries failed'], ['error', 'local', 'manual retry']
+];
+const JOURNEY = [
+  ['local', 'You drag “Cutover rehearsal” one week later.'],
+  ['syncing', 'Autosync fires 3 seconds after the last edit.'],
+  ['conflict', 'The server returns a version clash on two fields.'],
+  ['local', 'You resolve the conflict; the merged version is queued.'],
+  ['syncing', 'The merged batch is sent.'],
+  ['synced', 'The server acknowledges every change.']
+];
+
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.state = { current: 'local', announce: STATES.local.say, urgent: false, playing: false, picks: { owner: 'mine' } };
+  }
+  componentWillUnmount() { clearInterval(this._t); }
+  go(k, note) { this.setState({ current: k, announce: (note ? note + ' ' : '') + STATES[k].say, urgent: STATES[k].pol === 'assertive' }); }
+  sayPolite(m) { this.setState({ announce: m, urgent: false }); }
+  play() {
+    if (this.state.playing) { clearInterval(this._t); this.setState({ playing: false }); return; }
+    this.setState({ playing: true });
+    let i = 0;
+    const tick = () => {
+      if (i >= JOURNEY.length) { clearInterval(this._t); this.setState({ playing: false }); return; }
+      this.go(JOURNEY[i][0], JOURNEY[i][1]);
+      i++;
+    };
+    tick();
+    this._t = setInterval(tick, 1900);
+  }
+
+  renderVals() {
+    const cur = this.state.current;
+    const s = STATES[cur];
+    const NW = 212, NH = 74;
+    const c = (k) => ({ x: POS[k].x + NW / 2, y: POS[k].y + NH / 2 });
+    const edges = [], edgeLabels = [];
+    EDGES.forEach(([a, b, label]) => {
+      const A = c(a), B = c(b);
+      const active = cur === a || cur === b;
+      const color = active ? '#0B57D0' : '#98A2B3';
+      const op = active ? '1' : '0.5';
+      edges.push({ left: Math.min(A.x, B.x) + 'px', top: A.y + 'px', w: Math.abs(B.x - A.x) + 'px', h: '1.5px', color, op });
+      edges.push({ left: B.x + 'px', top: Math.min(A.y, B.y) + 'px', w: '1.5px', h: Math.abs(B.y - A.y) + 'px', color, op });
+      edgeLabels.push({ left: ((A.x + B.x) / 2) + 'px', top: (A.y === B.y ? A.y : (A.y + B.y) / 2) + 'px', label, color: active ? '#0B57D0' : '#4B5563' });
+    });
+
+    const stateNodes = Object.keys(STATES).map(k => {
+      const st = STATES[k], sel = cur === k;
+      return {
+        x: POS[k].x + 'px', y: POS[k].y + 'px', label: st.label, blurb: st.blurb,
+        glyph: st.glyph, glyphBg: st.glyphBg, glyphFg: st.glyphFg,
+        bg: sel ? st.bg : '#FFFFFF',
+        border: sel ? '1.5px solid ' + st.bd : '1px solid #7D8799',
+        shadow: sel ? '0 4px 12px rgba(16,23,32,.10)' : '0 1px 2px rgba(16,23,32,.06)',
+        pressed: sel ? 'true' : 'false',
+        on: () => this.go(k, '')
+      };
+    });
+
+    const T = (from, to, trigger, visual, say, pol) => ({
+      from, to, trigger, visual, say, pol,
+      polBg: pol === 'assertive' ? '#FDE9E7' : '#F1F3F7',
+      polBd: pol === 'assertive' ? '#F0B5AF' : '#CBD2DC',
+      polFg: pol === 'assertive' ? '#B3261E' : '#4B5563'
+    });
+
+    const FIELDS = [
+      { id: 'dates', label: 'Dates', mine: '12 – 16 Jan 2027', theirs: '19 – 23 Jan 2027', base: '12 – 16 Jan 2027', note: 'Rajesh moved it a week to clear the integration freeze.' },
+      { id: 'pct', label: 'Percent complete', mine: '65%', theirs: '40%', base: '40%', note: 'You updated this after yesterday’s stand-up.' },
+      { id: 'owner', label: 'Owner', mine: 'Daniel Okafor', theirs: 'Daniel Okafor', base: 'Daniel Okafor', note: 'Unchanged on both sides — shown for context, not a decision.' },
+      { id: 'note', label: 'Assumption', mine: 'Client provides cleansed vendor master by 30 Sep.', theirs: 'Client provides cleansed vendor master by 15 Oct.', base: 'Client provides cleansed vendor master by 30 Sep.', note: 'Both edited the same sentence; there is no safe automatic merge.' }
+    ];
+    const picks = this.state.picks;
+    const conflicted = FIELDS.filter(f => f.mine !== f.theirs);
+    const chosen = conflicted.filter(f => picks[f.id]).length;
+
+    return {
+      stateNodes, edges, edgeLabels,
+      chipBg: s.bg, chipBd: s.bd, chipFg: s.fg, chipMetaFg: s.metaFg,
+      chipGlyph: s.glyph, chipLabel: s.label, chipMeta: s.meta,
+      chipSpin: cur === 'syncing', chipGlyphShown: cur !== 'syncing',
+      stateSummary: s.blurb,
+      announce: this.state.announce,
+      statusBg: this.state.urgent ? '#FDE9E7' : '#FFFFFF',
+      liveRole: this.state.urgent ? 'alert' : 'status',
+      livePoliteness: this.state.urgent ? 'assertive' : 'polite',
+      liveLabel: this.state.urgent ? 'Announced — assertive' : 'Announced — polite',
+      journeyLabel: this.state.playing ? 'Stop journey' : 'Run scripted journey',
+      runJourney: () => this.play(),
+      reset: () => { clearInterval(this._t); this.setState({ playing: false }); this.go('local', ''); },
+
+      transitions: [
+        T('Synced', 'Saved locally', 'Any edit — a drag, a cell commit, a rename.', 'Chip flips to neutral within 120ms; the pending counter appears and increments.', 'Saved locally. 3 changes pending sync. Coalesced to at most one announcement every 5s.', 'polite'),
+        T('Saved locally', 'Syncing', 'Autosync 3s after the last edit, ⌘S, or Retry.', 'Glyph becomes a 12px spinner; label “Syncing”; the counter shows the batch size.', 'Syncing 148 changes. Suppressed entirely if the round trip finishes inside 400ms.', 'polite'),
+        T('Syncing', 'Synced', 'Server acknowledges the whole batch.', 'Spinner replaced by ✓, fill becomes success/subtle, timestamp replaces the counter. No toast.', 'Synced. All 148 changes saved to the server at 14:32.', 'polite'),
+        T('Syncing', 'Saved locally', 'A later edit lands mid-flight; the batch completes but new work is pending.', 'Chip returns to neutral with the new count, with no success flash in between.', 'Saved locally. 2 changes pending sync.', 'polite'),
+        T('Saved locally', 'Offline', 'Connection lost and still absent after a 2s confirmation window.', 'Fill becomes warning/subtle with ⌁; queue count replaces pending count; an offline banner pins above the workspace.', 'Offline. Editing continues; 148 changes are queued locally.', 'polite'),
+        T('Offline', 'Syncing', 'Connection returns.', 'Chip goes straight to the spinner; the offline banner is replaced by a progress bar in the same slot, so nothing moves.', 'Back online. Sending 148 queued changes.', 'polite'),
+        T('Syncing', 'Conflict', 'Server rejects one or more changes with a version clash.', 'Fill becomes danger/subtle with ⚠; a conflict banner pins above the workspace; affected rows take a 1.5px danger left edge.', 'Sync stopped. Two people edited “Data cleansing sign-off”. Choose a version to keep. Press G then R to open conflict resolution.', 'assertive'),
+        T('Conflict', 'Conflict', 'A second conflict arrives within 10s.', 'The banner count increments; no second banner appears and no row markers re-animate.', '3 conflicts need resolution.', 'assertive'),
+        T('Conflict', 'Saved locally', 'Every field is resolved and the merge confirmed.', 'Chip returns to neutral; row markers clear; resolved rows carry a 2px accent left edge for 240ms.', 'Conflict resolved. Merged version of “Data cleansing sign-off” queued. 1 change pending sync.', 'polite'),
+        T('Syncing', 'Sync failed', 'Five retries fail, or the server returns a non-retryable error.', 'Fill stays danger/subtle, border goes full-strength danger, glyph becomes ✕, reference code replaces the counter.', 'Sync failed permanently. The server rejected 148 changes. Your local copy is intact. Reference PRJ-2291 / 14:32.', 'assertive'),
+        T('Sync failed', 'Syncing', 'The user presses Retry in the sync popover.', 'Spinner returns; the failure stays in the popover history rather than vanishing.', 'Retrying 148 changes.', 'polite'),
+        T('Sync failed', 'Saved locally', 'The user exports a local backup and dismisses the failure.', 'Chip returns to neutral; the popover keeps a “Last failure 14:32” entry.', 'Failure dismissed. 148 changes are still held locally and unsent.', 'polite'),
+        T('Any', 'Synced', 'A background refresh finds nothing pending and nothing changed.', 'Chip settles to ✓ with a new timestamp. No motion, no flash.', 'Nothing is announced — the user perceived no change, so the region is not written.', 'polite')
+      ],
+
+      chipGallery: Object.keys(STATES).map(k => ({
+        label: STATES[k].label, glyph: STATES[k].glyph, meta: STATES[k].meta,
+        bg: STATES[k].bg, bd: STATES[k].bd, fg: STATES[k].fg, metaFg: STATES[k].metaFg,
+        note: k === 'local' ? 'Neutral, not warning — unsent work is normal in a local-first product and must not read as an error.'
+          : k === 'syncing' ? 'The only animated chip. Under reduced motion the spinner becomes a static ◐ and the count carries progress.'
+          : k === 'synced' ? 'Success is quiet: no toast, no flash, just the state and the time it happened.'
+          : k === 'offline' ? 'Warning, because the user should know — but the copy states that nothing is lost, because nothing is.'
+          : k === 'conflict' ? 'Danger with a soft border: the work is safe, but it cannot proceed without a decision.'
+          : 'Danger with a full-strength border and a reference code — the only chip that asks the user to contact someone.'
+      })),
+
+      darkChips: [
+        { label: 'Saved locally', glyph: '●', bg: '#1B222C', bd: '#748196', fg: '#AFBACA', ratio: 'text 8.35:1 · border 4.03:1 on surface/raised' },
+        { label: 'Syncing', glyph: '◐', bg: '#16294A', bd: '#2F4E82', fg: '#7FB0FF', ratio: 'text 6.59:1 · border 3.16:1' },
+        { label: 'Synced', glyph: '✓', bg: '#0F2E22', bd: '#2C6B4E', fg: '#56D69A', ratio: 'text 8.01:1 · border 3.24:1' },
+        { label: 'Offline', glyph: '⌁', bg: '#33240B', bd: '#7A5A22', fg: '#E9B45A', ratio: 'text 7.97:1 · border 3.09:1' },
+        { label: 'Conflict', glyph: '⚠', bg: '#3A1512', bd: '#8A3A33', fg: '#FF8A80', ratio: 'text 7.10:1 · border 3.05:1' },
+        { label: 'Sync failed', glyph: '✕', bg: '#3A1512', bd: '#FF8A80', fg: '#FF8A80', ratio: 'text 7.10:1 · border 8.28:1 (full strength)' }
+      ],
+
+      rules: [
+        'One owner: the chip owns every sync statement. A toast that mirrors it renders its text aria-hidden and announces nothing, so a state change is never read twice.',
+        'The chip never disappears, never becomes a bare dot, and never moves — its position in the top bar is fixed at every breakpoint so the eye can return to it without searching.',
+        'Editing is never blocked. Offline, conflict and permanent failure all keep the workspace fully editable; only the act of sending is paused.',
+        'Retry is exponential — 1s, 2s, 4s, 8s, 16s — and stops after five attempts. The chip states which attempt it is on in the popover, never in the chip itself.',
+        'A conflict pauses the whole queue, not just the conflicted record: shipping half a batch would leave the plan in a state neither person authored.',
+        'Nothing auto-merges. Two edits to the same field are a decision, and the product’s job is to make the decision cheap, not to guess.',
+        'Assertive is rationed: conflict, permanent failure and completed destructive actions only. Everything else is polite, including all six routine transitions.',
+        'The queue survives reload, crash and browser restart. The popover states the queue’s age — “oldest change 41 minutes old” — because a stale queue is the real risk in a local-first product.'
+      ],
+
+      fields: FIELDS.map(f => {
+        const isConflict = f.mine !== f.theirs;
+        const pick = picks[f.id];
+        return {
+          label: f.label, mine: f.mine, theirs: f.theirs, note: f.note,
+          isConflict, same: !isConflict,
+          mineBg: pick === 'mine' ? '#E8F0FE' : '#FFFFFF',
+          mineBd: pick === 'mine' ? '1.5px solid #0B57D0' : '1px solid #CBD2DC',
+          mineMark: pick === 'mine' ? '✓ Keeping yours' : 'Keep yours',
+          mineFg: pick === 'mine' ? '#0B57D0' : '#4B5563',
+          theirsBg: pick === 'theirs' ? '#E8F0FE' : '#FFFFFF',
+          theirsBd: pick === 'theirs' ? '1.5px solid #0B57D0' : '1px solid #CBD2DC',
+          theirsMark: pick === 'theirs' ? '✓ Keeping Rajesh’s' : 'Keep Rajesh’s',
+          theirsFg: pick === 'theirs' ? '#0B57D0' : '#4B5563',
+          pickMine: () => {
+            const p = Object.assign({}, this.state.picks); p[f.id] = 'mine';
+            const n = conflicted.filter(x => p[x.id]).length;
+            this.setState({ picks: p, urgent: false, announce: f.label + ': keeping your version, ' + f.mine + '. ' + n + ' of ' + conflicted.length + ' fields resolved.' });
+          },
+          pickTheirs: () => {
+            const p = Object.assign({}, this.state.picks); p[f.id] = 'theirs';
+            const n = conflicted.filter(x => p[x.id]).length;
+            this.setState({ picks: p, urgent: false, announce: f.label + ': keeping Rajesh Menon’s version, ' + f.theirs + '. ' + n + ' of ' + conflicted.length + ' fields resolved.' });
+          }
+        };
+      }),
+      conflictCount: conflicted.length,
+      resolvedCount: chosen,
+      resolveReady: chosen === conflicted.length,
+      resolveLabel: chosen === conflicted.length ? 'Merge and sync' : 'Choose ' + (conflicted.length - chosen) + ' more field' + ((conflicted.length - chosen) === 1 ? '' : 's'),
+      resolveBg: chosen === conflicted.length ? '#0B57D0' : '#F1F3F7',
+      resolveFg: chosen === conflicted.length ? '#FFFFFF' : '#98A2B3',
+      resolveBd: chosen === conflicted.length ? '#0B57D0' : '#E4E7EC',
+      takeAllMine: () => { const p = {}; FIELDS.forEach(f => { p[f.id] = 'mine'; }); this.setState({ picks: p, urgent: false, announce: 'All ' + conflicted.length + ' conflicted fields set to your version.' }); },
+      takeAllTheirs: () => { const p = {}; FIELDS.forEach(f => { p[f.id] = 'theirs'; }); this.setState({ picks: p, urgent: false, announce: 'All ' + conflicted.length + ' conflicted fields set to Rajesh Menon’s version.' }); },
+
+      conflictRules: [
+        { k: 'Scope', v: 'Field-level, never record-level. “Keep mine / keep theirs” on a whole task would silently discard someone’s unrelated edit to a different field.' },
+        { k: 'Unchanged fields', v: 'Shown greyed with a single value and no choice, so the user can see the record whole and confirm that nothing else moved.' },
+        { k: 'Base version', v: 'Each row can expand to show the common ancestor, which is what makes “who changed what” answerable rather than a guess.' },
+        { k: 'No auto-merge', v: 'Even non-overlapping text edits are presented as a choice. A merged sentence neither person wrote is worse than a decision.' },
+        { k: 'Keyboard', v: '↑↓ moves between fields, ← chooses yours, → chooses theirs, Enter merges when every field is resolved. The merge button states how many remain rather than sitting silently disabled.' },
+        { k: 'Announcement', v: 'Every pick is announced with the field, the chosen value and the running count; the merge announces the record name and the resulting queue size.' },
+        { k: 'Audit', v: 'A resolution writes an audit entry naming both authors, the fields taken from each and the timestamp — recoverable later from the task’s History tab.' }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,12 @@
 @import "./tokens.css";
+/* Design-system foundation tokens (layer 1). Every name is `--ds-` prefixed
+ * and additive: this import cannot alter the legacy UI. See the header of
+ * foundations.css for why the prefix is mandatory rather than stylistic.
+ *
+ * Deliberately second: tokens.css must stay the first @import because it
+ * bridges into apple-design-system.css, an ordering the visual suite guards.
+ * This layer shares no names with it, so its position is free. */
+@import "../styles/foundations.css";
 @import "../styles/motion.css";
 @import "../styles/button-normalize.css";
 @import "../styles/accessibility.css";

--- a/src/components/ds/Button.module.css
+++ b/src/components/ds/Button.module.css
@@ -1,0 +1,252 @@
+/* Design system — Button (layer 2, Primitives)
+ *
+ * Reads only `--ds-*` tokens, so both themes come for free and no hex appears
+ * below. Every colour here traces to a pair verified in
+ * src/styles/__tests__/foundations-contrast.test.ts. */
+
+.button {
+  /* The label stack (see .labels) needs the button to be a grid container. */
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: center;
+
+  border: var(--ds-border-hairline) solid transparent;
+  border-radius: var(--ds-radius-md);
+  font-family: var(--ds-font-sans);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  text-decoration: none;
+
+  transition:
+    background-color var(--ds-duration-fast) var(--ds-easing-standard),
+    border-color var(--ds-duration-fast) var(--ds-easing-standard),
+    color var(--ds-duration-fast) var(--ds-easing-standard);
+}
+
+.button:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+/* ---------------------------------------------------------------------------
+ * Sizes
+ *
+ * Rule 6 from the spec: a button never uses type/label. 12px on a 36px control
+ * reads as a disabled chip, so 13px is the floor — which is why `sm` is 13px
+ * and not the 12px label token.
+ * -------------------------------------------------------------------------*/
+.sm {
+  height: 28px;
+  padding: 0 10px;
+  gap: 6px;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.md {
+  height: 36px;
+  padding: 0 14px;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.lg {
+  height: 44px;
+  padding: 0 18px;
+  gap: 8px;
+  font-size: 15px;
+  line-height: 22px;
+}
+
+/* Icon-only: a square of the same height, no horizontal padding. The 44px
+ * variant is the touch target; `sm` is for table-row actions. */
+.iconOnly.sm {
+  width: 28px;
+  padding: 0;
+}
+.iconOnly.md {
+  width: 36px;
+  padding: 0;
+}
+.iconOnly.lg {
+  width: 44px;
+  padding: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Variants
+ * -------------------------------------------------------------------------*/
+.primary {
+  background: var(--ds-accent-default);
+  color: var(--ds-accent-on);
+  border-color: var(--ds-accent-default);
+}
+.primary:hover:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-accent-hover);
+  border-color: var(--ds-accent-hover);
+}
+.primary:active:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-accent-active);
+  border-color: var(--ds-accent-active);
+}
+
+.secondary {
+  background: var(--ds-surface-raised);
+  color: var(--ds-content-primary);
+  border-color: var(--ds-border-strong);
+}
+.secondary:hover:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-surface-hover);
+  border-color: var(--ds-border-strong-hover);
+}
+.secondary:active:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-surface-active);
+  border-color: var(--ds-border-strong-hover);
+}
+
+.tertiary {
+  background: transparent;
+  color: var(--ds-accent-default);
+  border-color: transparent;
+}
+.tertiary:hover:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-accent-subtle-hover);
+  color: var(--ds-accent-hover);
+}
+.tertiary:active:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-accent-subtle-active);
+  color: var(--ds-accent-active);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--ds-content-secondary);
+  border-color: transparent;
+}
+.ghost:hover:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-surface-hover);
+  color: var(--ds-content-primary);
+}
+.ghost:active:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-surface-active);
+  color: var(--ds-content-primary);
+}
+
+.danger {
+  background: var(--ds-danger-default);
+  color: var(--ds-danger-on);
+  border-color: var(--ds-danger-default);
+}
+.danger:hover:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-danger-hover);
+  border-color: var(--ds-danger-hover);
+}
+.danger:active:not([aria-disabled="true"]):not([aria-busy="true"]) {
+  background: var(--ds-danger-active);
+  border-color: var(--ds-danger-active);
+}
+
+/* ---------------------------------------------------------------------------
+ * Disabled
+ *
+ * Driven by `aria-disabled`, not the `disabled` attribute — a disabled element
+ * is removed from the tab order and cannot hold a tooltip or be explained, so
+ * the component keeps it focusable and blocks activation in the handler.
+ * -------------------------------------------------------------------------*/
+.button[aria-disabled="true"] {
+  cursor: not-allowed;
+  background: var(--ds-surface-disabled);
+  color: var(--ds-content-disabled);
+  border-color: var(--ds-border-disabled);
+}
+
+/* Filled variants read as "switched off" rather than "a different button". */
+.primary[aria-disabled="true"],
+.danger[aria-disabled="true"] {
+  background: var(--ds-fill-disabled);
+}
+
+.tertiary[aria-disabled="true"],
+.ghost[aria-disabled="true"] {
+  background: transparent;
+  border-color: transparent;
+}
+
+/* ---------------------------------------------------------------------------
+ * Loading
+ *
+ * cursor:progress rather than not-allowed — the action was accepted, it is
+ * running. The button stays focusable; activation is blocked in the handler.
+ * -------------------------------------------------------------------------*/
+.button[aria-busy="true"] {
+  cursor: progress;
+}
+
+/* Both labels occupy the same grid cell, so the button is always as wide as
+ * the wider of "Save plan" and "Saving…" in every state. That is what stops
+ * the row reflowing when loading starts — reserving width only while loading
+ * would move the layout at the exact moment the user is watching it. */
+.labels {
+  display: grid;
+  align-items: center;
+  justify-items: center;
+}
+
+.labels > * {
+  grid-area: 1 / 1;
+}
+
+.hiddenLabel {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border-radius: var(--ds-radius-full);
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  opacity: 0.9;
+  animation: ds-button-spin 700ms linear infinite;
+}
+
+@keyframes ds-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Reduced motion: the spinner must not simply freeze mid-rotation, which reads
+ * as a hung control. It slows to a step so progress is still legible. */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: ds-button-spin 3s steps(8, end) infinite !important;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Menu chevron
+ * -------------------------------------------------------------------------*/
+.chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  transition: transform var(--ds-duration-fast) var(--ds-easing-standard);
+}
+
+.button[aria-expanded="true"] .chevron {
+  transform: rotate(180deg);
+}
+
+.icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/ds/Button.tsx
+++ b/src/components/ds/Button.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Design system — Button (layer 2, Primitives)
+ *
+ * Implements the five variants, three sizes and six states in
+ * `docs/design/primitives.html`, plus the six rules stated there. Three of
+ * those rules are enforced by this file rather than left to the caller:
+ *
+ *  - **Loading locks the width.** Both labels share one grid cell, so the
+ *    control is always as wide as the wider of them and the row cannot reflow
+ *    at the moment the action starts.
+ *  - **Disabled stays focusable.** `aria-disabled` rather than `disabled`, so
+ *    the control can still be reached, explained and tooltipped. Activation is
+ *    blocked here instead.
+ *  - **An icon-only button must have a name.** The type signature makes
+ *    `label` mandatory when `iconOnly` is set, so a nameless icon button will
+ *    not compile.
+ *
+ * The remaining rules are placement decisions this component cannot see:
+ * danger must never be the default focus target in a confirm dialog, and
+ * disabled is only for a state fixable in the current view — if the reason
+ * lies elsewhere (no permission, no cost visibility), keep the button enabled
+ * and explain on activation.
+ */
+
+import { cn } from "@/lib/utils";
+// Explicit import: tsconfig uses `jsx: "preserve"` with no automatic runtime,
+// which is the convention across this codebase.
+import React, { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import styles from "./Button.module.css";
+
+export type ButtonVariant = "primary" | "secondary" | "tertiary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md" | "lg";
+
+type NativeButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "disabled">;
+
+interface CommonProps extends NativeButtonProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /** Leading icon. Replaced by the spinner while loading. */
+  icon?: ReactNode;
+  /**
+   * Blocks activation and greys the control. Use only for a state the user can
+   * fix in this view; otherwise leave it enabled and explain on activation.
+   */
+  disabled?: boolean;
+  /** Marks the action in flight: spinner, `aria-busy`, activation blocked. */
+  loading?: boolean;
+  /**
+   * The progressive form of the label — "Save plan" becomes "Saving…". The
+   * resting label stays in the layout (hidden) so the width never changes.
+   */
+  loadingLabel?: string;
+  /** Renders the chevron and the menu ARIA pair. */
+  menu?: boolean;
+  /** Chevron direction and `aria-expanded`. Only meaningful with `menu`. */
+  expanded?: boolean;
+}
+
+interface TextButtonProps extends CommonProps {
+  iconOnly?: false;
+  children: ReactNode;
+}
+
+interface IconOnlyButtonProps extends CommonProps {
+  iconOnly: true;
+  /** Required: an icon-only control has no visible text to name it. */
+  label: string;
+  children?: never;
+}
+
+export type ButtonProps = TextButtonProps | IconOnlyButtonProps;
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  props,
+  ref
+) {
+  const {
+    variant = "secondary",
+    size = "md",
+    icon,
+    disabled = false,
+    loading = false,
+    loadingLabel,
+    menu = false,
+    expanded,
+    className,
+    onClick,
+    type = "button",
+    // Pulled out of `rest` so they are never spread onto the DOM node — React
+    // warns on unknown attributes, and `iconOnly="true"` in the markup would
+    // be meaningless to a browser.
+    iconOnly: iconOnlyProp,
+    label: labelProp,
+    children: childrenProp,
+    ...rest
+  } = props as CommonProps & {
+    iconOnly?: boolean;
+    label?: string;
+    children?: ReactNode;
+  };
+
+  const iconOnly = iconOnlyProp === true;
+  const label = iconOnly ? labelProp : undefined;
+  const children = iconOnly ? null : childrenProp;
+
+  // Both states block activation, for different reasons: disabled means "not
+  // available", busy means "already running". Neither is the `disabled`
+  // attribute, so both remain focusable and explainable.
+  //
+  // They are announced separately on purpose. Setting aria-disabled while
+  // merely loading would be wrong twice over: a busy control is not
+  // unavailable, and the disabled styling would paint over the loading state
+  // that the spec keeps on the filled variant.
+  const inactive = disabled || loading;
+
+  return (
+    <button
+      {...rest}
+      ref={ref}
+      type={type}
+      className={cn(
+        styles.button,
+        styles[variant],
+        styles[size],
+        iconOnly && styles.iconOnly,
+        className
+      )}
+      aria-disabled={disabled || undefined}
+      aria-busy={loading || undefined}
+      aria-label={label}
+      aria-haspopup={menu ? "menu" : undefined}
+      aria-expanded={menu ? Boolean(expanded) : undefined}
+      onClick={(event) => {
+        if (inactive) {
+          // Prevent default too: without it, a form-submitting button still
+          // submits, because aria-disabled carries no behaviour of its own.
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+        onClick?.(event);
+      }}
+    >
+      {loading ? (
+        <span className={styles.spinner} aria-hidden="true" />
+      ) : icon ? (
+        <span className={styles.icon} aria-hidden="true">
+          {icon}
+        </span>
+      ) : null}
+
+      {!iconOnly && (
+        <span className={styles.labels}>
+          {/* The resting label always occupies the cell, so the width is
+           * identical in every state. Hidden rather than removed while
+           * loading. */}
+          <span className={loading ? styles.hiddenLabel : undefined}>{children}</span>
+          {loading && loadingLabel ? <span>{loadingLabel}</span> : null}
+        </span>
+      )}
+
+      {menu && (
+        <svg
+          className={styles.chevron}
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 4.5 6 7.5 9 4.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+});

--- a/src/components/ds/__tests__/Button.test.tsx
+++ b/src/components/ds/__tests__/Button.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Button — behaviour, not markup.
+ *
+ * The existing a11y suite asserts HTML strings, which is why `BaseModal` could
+ * ship with no `role="dialog"` and no focus trap while its evidence file
+ * claimed both were present. These tests render the real component and drive
+ * it the way a user does.
+ */
+
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Button } from "../Button";
+
+describe("activation", () => {
+  test("a resting button fires its handler", async () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Save plan</Button>);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save plan" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("a disabled button does not fire", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Save plan
+      </Button>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save plan" }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test("a loading button does not fire again", async () => {
+    // The double-submit this prevents is the whole reason the state exists.
+    const onClick = vi.fn();
+    render(
+      <Button loading loadingLabel="Saving…" onClick={onClick}>
+        Save plan
+      </Button>
+    );
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test("a disabled submit button does not submit its form", async () => {
+    // aria-disabled carries no behaviour of its own, so without an explicit
+    // preventDefault the form would still submit.
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <Button type="submit" disabled>
+          Save plan
+        </Button>
+      </form>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save plan" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe("focusability", () => {
+  test("a disabled button is still reachable by keyboard", async () => {
+    // The point of aria-disabled over the disabled attribute: a control the
+    // user cannot reach is a control that can never explain why it is off.
+    render(<Button disabled>Save plan</Button>);
+
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: "Save plan" })).toHaveFocus();
+  });
+
+  test("keyboard activation is blocked while disabled", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Save plan
+      </Button>
+    );
+
+    await userEvent.tab();
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard(" ");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("state is announced", () => {
+  test("disabled sets aria-disabled and never the disabled attribute", () => {
+    render(<Button disabled>Save plan</Button>);
+    const button = screen.getByRole("button", { name: "Save plan" });
+
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).not.toBeDisabled();
+  });
+
+  test("loading sets aria-busy but not aria-disabled", () => {
+    // A busy control is not an unavailable one, and marking it disabled would
+    // also paint the disabled grey over the loading state.
+    render(
+      <Button loading loadingLabel="Saving…">
+        Save plan
+      </Button>
+    );
+    const button = screen.getByRole("button");
+
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).not.toHaveAttribute("aria-disabled");
+  });
+
+  test("a resting button announces neither", () => {
+    render(<Button>Save plan</Button>);
+    const button = screen.getByRole("button", { name: "Save plan" });
+
+    expect(button).not.toHaveAttribute("aria-busy");
+    expect(button).not.toHaveAttribute("aria-disabled");
+  });
+});
+
+describe("loading", () => {
+  test("the progressive label replaces the resting one visually", () => {
+    render(
+      <Button loading loadingLabel="Saving…">
+        Save plan
+      </Button>
+    );
+
+    expect(screen.getByText("Saving…")).toBeInTheDocument();
+    // The resting label stays in the DOM to hold the width open.
+    expect(screen.getByText("Save plan")).toBeInTheDocument();
+  });
+
+  test("the resting label is kept in the layout so the row cannot reflow", () => {
+    render(
+      <Button loading loadingLabel="Saving…">
+        Save plan
+      </Button>
+    );
+
+    // visibility:hidden reserves space; display:none would not. This is the
+    // difference between a stable row and one that jumps when the user clicks.
+    const resting = screen.getByText("Save plan");
+    expect(resting.className).not.toBe("");
+    expect(screen.getByRole("button")).toContainElement(resting);
+  });
+});
+
+describe("icon-only buttons", () => {
+  test("the label becomes the accessible name", () => {
+    render(<Button iconOnly label="Add task" icon={<svg />} />);
+    expect(screen.getByRole("button", { name: "Add task" })).toBeInTheDocument();
+  });
+
+  test("an icon-only button cannot be built without a name", () => {
+    // Enforced by the type signature: `label` is required when `iconOnly` is
+    // set, so the nameless case fails to compile rather than shipping.
+    // @ts-expect-error - iconOnly requires label
+    const invalid = <Button iconOnly icon={<svg />} />;
+    expect(invalid).toBeTruthy();
+  });
+});
+
+describe("menu buttons", () => {
+  test("a menu button announces its popup and collapsed state", () => {
+    render(<Button menu>Filters</Button>);
+    const button = screen.getByRole("button", { name: "Filters" });
+
+    expect(button).toHaveAttribute("aria-haspopup", "menu");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("expanded is reflected", () => {
+    render(
+      <Button menu expanded>
+        Filters
+      </Button>
+    );
+    expect(screen.getByRole("button", { name: "Filters" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  test("a plain button claims no popup", () => {
+    render(<Button>Filters</Button>);
+    const button = screen.getByRole("button", { name: "Filters" });
+
+    expect(button).not.toHaveAttribute("aria-haspopup");
+    expect(button).not.toHaveAttribute("aria-expanded");
+  });
+});
+
+describe("defaults", () => {
+  test("type defaults to button, so it cannot submit a form by accident", () => {
+    render(<Button>Add phase</Button>);
+    expect(screen.getByRole("button", { name: "Add phase" })).toHaveAttribute(
+      "type",
+      "button"
+    );
+  });
+
+  test("an explicit type is respected", () => {
+    render(<Button type="submit">Save plan</Button>);
+    expect(screen.getByRole("button", { name: "Save plan" })).toHaveAttribute(
+      "type",
+      "submit"
+    );
+  });
+});

--- a/src/styles/__tests__/foundations-contrast.test.ts
+++ b/src/styles/__tests__/foundations-contrast.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Contrast enforcement for the design-system foundation tokens.
+ *
+ * This test exists because the previous design system shipped a primary blue
+ * at 4.02:1 — failing WCAG AA on the background of every primary button —
+ * while the accessibility evidence file claimed it passed, and two visual
+ * tests asserted the failing value as correct. Documentation does not stop
+ * that; a computation does.
+ *
+ * It reads the REAL stylesheet rather than a copy of the values. A test that
+ * restates the palette would pass happily while the shipped CSS drifted.
+ */
+
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const CSS = readFileSync(join(process.cwd(), "src/styles/foundations.css"), "utf8");
+
+/* -------------------------------------------------------------------------
+ * WCAG 2.2 relative luminance and contrast ratio.
+ * -----------------------------------------------------------------------*/
+
+function channel(value8Bit: number): number {
+  const c = value8Bit / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const full =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+export function contrast(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Reads a token's value out of a specific block of the stylesheet.
+ *
+ * Scoped by selector because most colour tokens are defined more than once —
+ * light on `:root`, dark on `:root.dark`, and dark again inside the
+ * prefers-color-scheme query. A naive whole-file match would silently read
+ * whichever came first.
+ */
+function tokenIn(selectorStart: string, name: string): string {
+  const start = CSS.indexOf(selectorStart);
+  expect(start, `selector not found: ${selectorStart}`).toBeGreaterThan(-1);
+  const block = CSS.slice(start, CSS.indexOf("\n}", start));
+  const match = block.match(new RegExp(`--ds-${name}\\s*:\\s*([^;]+);`));
+  expect(match, `token --ds-${name} not found in ${selectorStart}`).not.toBeNull();
+  return match![1].trim();
+}
+
+const light = (name: string) => tokenIn(":root,\n:root.light,", name);
+const dark = (name: string) => tokenIn(":root.dark,\n:root[data-theme=\"dark\"] {", name);
+
+/* -------------------------------------------------------------------------
+ * The surfaces each foreground token can legitimately land on.
+ *
+ * This is the part the spec got wrong: it computed every ratio against
+ * `surface/base` alone. A token used on a sunken well or a raised card has to
+ * clear its floor there too, and those surfaces are always the harder ones.
+ * -----------------------------------------------------------------------*/
+const LIGHT_SURFACES = ["surface-base", "surface-app", "surface-sunken"] as const;
+const DARK_SURFACES = ["surface-base", "surface-raised", "surface-sunken"] as const;
+
+/** WCAG 2.2: 4.5:1 for body text, 3:1 for non-text UI (1.4.11). */
+const TEXT_FLOOR = 4.5;
+const UI_FLOOR = 3;
+
+const FOREGROUNDS: Array<{ token: string; floor: number }> = [
+  { token: "content-primary", floor: TEXT_FLOOR },
+  { token: "content-secondary", floor: TEXT_FLOOR },
+  { token: "content-tertiary", floor: TEXT_FLOOR },
+  { token: "accent-default", floor: TEXT_FLOOR },
+  { token: "accent-hover", floor: TEXT_FLOOR },
+  { token: "accent-active", floor: TEXT_FLOOR },
+  { token: "success-default", floor: TEXT_FLOOR },
+  { token: "warning-default", floor: TEXT_FLOOR },
+  { token: "danger-default", floor: TEXT_FLOOR },
+  { token: "info-default", floor: TEXT_FLOOR },
+  // Non-text: input edges, checkbox borders, Gantt bar outlines, focus ring.
+  { token: "border-strong", floor: UI_FLOOR },
+  { token: "border-focus", floor: UI_FLOOR },
+];
+
+describe("foundation tokens — foreground on every surface it can appear on", () => {
+  describe.each([
+    { theme: "light", read: light, surfaces: LIGHT_SURFACES },
+    { theme: "dark", read: dark, surfaces: DARK_SURFACES },
+  ])("$theme", ({ read, surfaces }) => {
+    test.each(FOREGROUNDS)("$token clears $floor:1 on all surfaces", ({ token, floor }) => {
+      const fg = read(token);
+      for (const surface of surfaces) {
+        const ratio = contrast(fg, read(surface));
+        expect(
+          ratio,
+          `--ds-${token} (${fg}) on --ds-${surface} (${read(surface)}) = ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(floor);
+      }
+    });
+  });
+});
+
+describe("status pills — text on its own subtle fill", () => {
+  // A pill puts its own text on its own tinted background, so the pair has to
+  // be checked directly; neither half is ever seen against a plain surface.
+  const FAMILIES = ["success", "warning", "danger", "info", "accent"];
+
+  test.each([
+    { theme: "light", read: light },
+    { theme: "dark", read: dark },
+  ])("$theme", ({ read }) => {
+    for (const family of FAMILIES) {
+      const ratio = contrast(read(`${family}-default`), read(`${family}-subtle`));
+      expect(
+        ratio,
+        `${family}: default on subtle = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(TEXT_FLOOR);
+    }
+  });
+});
+
+describe("filled surfaces — label on a solid accent or status fill", () => {
+  test.each([
+    { theme: "light", read: light },
+    { theme: "dark", read: dark },
+  ])("$theme", ({ read }) => {
+    for (const family of ["accent", "success", "warning", "danger", "info"]) {
+      const ratio = contrast(read(`${family}-on`), read(`${family}-default`));
+      expect(
+        ratio,
+        `${family}: on-colour over default fill = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(TEXT_FLOOR);
+    }
+  });
+});
+
+describe("documented exemption", () => {
+  // WCAG 1.4.3 exempts disabled controls. Asserted rather than ignored so the
+  // exemption stays a deliberate decision: if someone later uses this token
+  // for enabled text, this test is where the reason is recorded.
+  test("content/disabled is below the floor, and that is intentional", () => {
+    const lightRatio = contrast(light("content-disabled"), light("surface-base"));
+    const darkRatio = contrast(dark("content-disabled"), dark("surface-base"));
+
+    expect(lightRatio).toBeLessThan(TEXT_FLOOR);
+    expect(darkRatio).toBeLessThan(TEXT_FLOOR);
+
+    // It must still be perceivable — an exemption is not a licence for
+    // invisible text.
+    expect(lightRatio).toBeGreaterThan(2);
+    expect(darkRatio).toBeGreaterThan(2);
+  });
+});
+
+describe("interaction states", () => {
+  // Hover/active are where a palette usually breaks: the base colour is
+  // checked, the state it changes to is not, and a hover reads fine to the
+  // person who picked it and fails for everyone else.
+  const FILLED = [
+    { fill: "accent-hover", on: "accent-on" },
+    { fill: "accent-active", on: "accent-on" },
+    { fill: "danger-hover", on: "danger-on" },
+    { fill: "danger-active", on: "danger-on" },
+  ];
+
+  test.each([
+    { theme: "light", read: light },
+    { theme: "dark", read: dark },
+  ])("$theme: label stays legible on every filled state", ({ read }) => {
+    for (const { fill, on } of FILLED) {
+      const ratio = contrast(read(on), read(fill));
+      expect(ratio, `${on} on ${fill} = ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(
+        TEXT_FLOOR
+      );
+    }
+  });
+
+  test.each([
+    { theme: "light", read: light },
+    { theme: "dark", read: dark },
+  ])("$theme: neutral controls stay legible when hovered and pressed", ({ read }) => {
+    for (const surface of ["surface-hover", "surface-active"]) {
+      const ratio = contrast(read("content-primary"), read(surface));
+      expect(
+        ratio,
+        `content-primary on ${surface} = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(TEXT_FLOOR);
+    }
+  });
+
+  test.each([
+    { theme: "light", read: light },
+    { theme: "dark", read: dark },
+  ])("$theme: the hovered border still reads as an edge", ({ read }) => {
+    const ratio = contrast(read("border-strong-hover"), read("surface-hover"));
+    expect(ratio, `border-strong-hover on surface-hover = ${ratio.toFixed(2)}:1`)
+      .toBeGreaterThanOrEqual(UI_FLOOR);
+  });
+});
+
+describe("the dark palette is declared identically in both of its blocks", () => {
+  // Dark is declared twice — once for an explicit choice (.dark /
+  // [data-theme="dark"]) and once for the OS preference, because a colour
+  // whose only definition sits inside a media query leaves the explicit
+  // toggle with nothing to apply. Two copies drift. This makes drift a test
+  // failure rather than a bug someone finds in dark mode months later.
+  /**
+   * Slices exactly one rule by counting braces from its opening one.
+   *
+   * An earlier version looked for a literal "\n  }" to find the end. The two
+   * blocks close at different indents — the explicit rule at column 0, the
+   * one nested in the media query at column 2 — so from the explicit rule the
+   * search ran past its own closing brace and swallowed the media-query rule
+   * as well. Both sides then read the same text and the test could never fail.
+   * Token values contain no braces, so counting is exact.
+   */
+  function blockTokens(startMarker: string): Map<string, string> {
+    const start = CSS.indexOf(startMarker);
+    expect(start, `block not found: ${startMarker}`).toBeGreaterThan(-1);
+
+    const open = CSS.indexOf("{", start);
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < CSS.length; i++) {
+      if (CSS[i] === "{") depth++;
+      else if (CSS[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    expect(depth, `unbalanced braces after: ${startMarker}`).toBe(0);
+
+    const out = new Map<string, string>();
+    for (const m of CSS.slice(open, end).matchAll(/--ds-([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+      out.set(m[1], m[2].trim());
+    }
+    return out;
+  }
+
+  test("same tokens, same values", () => {
+    const explicit = blockTokens(':root.dark,\n:root[data-theme="dark"] {');
+    const preference = blockTokens(
+      ':root:not(.light):not([data-theme="light"]) {'
+    );
+
+    expect(explicit.size).toBeGreaterThan(30);
+    expect([...preference.keys()].sort()).toEqual([...explicit.keys()].sort());
+    for (const [token, value] of explicit) {
+      expect(preference.get(token), `--ds-${token} differs between dark blocks`).toBe(
+        value
+      );
+    }
+  });
+});
+
+describe("the specific defect this file was created to prevent", () => {
+  test("content/tertiary does not regress to the spec's #667085", () => {
+    // #667085 measures 4.48:1 on --ds-surface-sunken (#F1F3F7): under the
+    // floor, and reachable — the spec puts placeholders in inset wells.
+    expect(contrast("#667085", "#F1F3F7")).toBeLessThan(TEXT_FLOOR);
+    expect(light("content-tertiary").toLowerCase()).not.toBe("#667085");
+  });
+
+  test("the old primary blue never comes back", () => {
+    // #007AFF on white is 4.02:1. It shipped, and the evidence file said it
+    // passed.
+    expect(contrast("#007AFF", "#FFFFFF")).toBeLessThan(TEXT_FLOOR);
+    expect(light("accent-default").toLowerCase()).not.toBe("#007aff");
+  });
+
+  test("the light content ramp stays ordered", () => {
+    // Hierarchy is the point of three content levels. If a change inverts
+    // them, the design reads as noise even while every ratio passes.
+    const sunken = light("surface-sunken");
+    const primary = contrast(light("content-primary"), sunken);
+    const secondary = contrast(light("content-secondary"), sunken);
+    const tertiary = contrast(light("content-tertiary"), sunken);
+
+    expect(primary).toBeGreaterThan(secondary);
+    expect(secondary).toBeGreaterThan(tertiary);
+  });
+});

--- a/src/styles/foundations.css
+++ b/src/styles/foundations.css
@@ -1,0 +1,410 @@
+/* ============================================================================
+ * Design system — Layer 1: Foundations
+ *
+ * The token substrate for the UI rebuild. Every primitive and composite in
+ * `src/components/ds/` references only the names defined here.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY EVERY NAME IS PREFIXED `--ds-`
+ *
+ * The design spec ships a "paste-ready" block using bare names (`--space-4`,
+ * `--radius-md`, `--z-modal`). Pasting it here would have been silently
+ * destructive, because this codebase already owns those exact names with
+ * different meanings:
+ *
+ *     --space-4    existing 0.25rem (4px, keyed by pixel value)
+ *                  spec     16px    (keyed by step index)      -> 4x jump
+ *     --space-16   existing 1rem (16px)   spec 64px            -> 4x jump
+ *     --radius-md  existing 8px           spec 6px
+ *     --z-modal    existing 1050          spec 400             -> modals would
+ *                                                                 fall behind
+ *                                                                 current overlays
+ *
+ * The old UI is still the live product until every route is migrated, so the
+ * two systems have to coexist without touching each other. The prefix is what
+ * makes that true. It stays after the migration as well — a namespace costs
+ * nothing and prevents the next collision.
+ *
+ * ---------------------------------------------------------------------------
+ * THEMING
+ *
+ * The spec assumes `data-theme` on the root element. This app's pre-hydration
+ * script (src/app/layout.tsx) sets a `dark`/`light` *class* instead. Both are
+ * honoured, and `prefers-color-scheme` covers the case where neither is set.
+ *
+ * Light is defined on bare `:root` so no colour has its only definition inside
+ * a media query — a page that never matches one still gets a complete palette.
+ * ==========================================================================*/
+
+/* ---------------------------------------------------------------------------
+ * Semantic colour — light
+ * -------------------------------------------------------------------------*/
+:root,
+:root.light,
+:root[data-theme="light"] {
+  /* Surfaces. `raised` equals `base` in light; only dark separates them. */
+  --ds-surface-base: #ffffff;
+  --ds-surface-raised: #ffffff;
+  --ds-surface-app: #f6f7f9;
+  --ds-surface-sunken: #f1f3f7;
+  --ds-surface-overlay: rgba(16, 23, 32, 0.48);
+  /* Second stacked modal only; max stack depth is 2. */
+  --ds-surface-overlay-stacked: rgba(16, 23, 32, 0.24);
+
+  --ds-content-primary: #101720;
+  --ds-content-secondary: #4b5563;
+  /* Corrected from the spec's #667085. See the contrast note at the foot of
+   * this file — #667085 fails AA on --ds-surface-sunken, which is exactly
+   * where placeholders and table-header metadata live. */
+  --ds-content-tertiary: #5f6b7f;
+  /* Exempt from the 4.5 floor: disabled text is always paired with
+   * aria-disabled, so the state is conveyed non-visually. */
+  --ds-content-disabled: #98a2b3;
+  --ds-content-inverse: #ffffff;
+
+  --ds-border-subtle: #e4e7ec;
+  --ds-border-default: #cbd2dc;
+  --ds-border-strong: #7d8799;
+  --ds-border-focus: #0b57d0;
+
+  --ds-accent-default: #0b57d0;
+  --ds-accent-hover: #08429e;
+  --ds-accent-active: #06337a;
+  --ds-accent-subtle: #e8f0fe;
+  --ds-accent-border: #bbd0f6;
+  --ds-accent-on: #ffffff;
+
+  --ds-success-default: #0a7a47;
+  --ds-success-subtle: #e3f5eb;
+  --ds-success-border: #9ad9bb;
+  --ds-success-on: #ffffff;
+
+  --ds-warning-default: #8a5200;
+  --ds-warning-subtle: #fbf0dc;
+  --ds-warning-border: #e0c089;
+  --ds-warning-on: #ffffff;
+
+  --ds-danger-default: #b3261e;
+  --ds-danger-subtle: #fde9e7;
+  --ds-danger-border: #f0b5af;
+  --ds-danger-on: #ffffff;
+
+  --ds-info-default: #0b57d0;
+  --ds-info-subtle: #e8f0fe;
+  --ds-info-border: #bbd0f6;
+  --ds-info-on: #ffffff;
+
+  /* Interaction states. In light these darken; in dark they lighten. Derived
+   * from the per-state colours the Primitives spec draws for every control,
+   * hoisted into tokens so a control never hard-codes a hex. */
+  --ds-surface-hover: #f1f3f7;
+  --ds-surface-active: #e4e7ec;
+  --ds-surface-disabled: #f6f7f9;
+  /* A filled control (primary, danger) when disabled — flatter than a
+   * neutral control's disabled surface so it reads as "switched off", not
+   * "a different button". */
+  --ds-fill-disabled: #f1f3f7;
+  --ds-border-strong-hover: #6e7a8c;
+  --ds-border-disabled: #e4e7ec;
+  --ds-accent-subtle-hover: #e8f0fe;
+  --ds-accent-subtle-active: #d6e4fd;
+  --ds-danger-hover: #8f1d17;
+  --ds-danger-active: #711511;
+
+  --ds-elevation-0: none;
+  --ds-elevation-1: 0 1px 2px rgba(16, 23, 32, 0.06);
+  --ds-elevation-2: 0 4px 12px rgba(16, 23, 32, 0.1);
+  --ds-elevation-3: 0 8px 28px rgba(16, 23, 32, 0.14);
+  --ds-elevation-4: 0 16px 48px rgba(16, 23, 32, 0.2);
+}
+
+/* ---------------------------------------------------------------------------
+ * Semantic colour — dark
+ *
+ * Declared three times on purpose: an explicit class, the spec's attribute,
+ * and the OS preference when the app has set neither. The media query is
+ * guarded so an explicit light choice always wins over a dark OS setting.
+ * -------------------------------------------------------------------------*/
+:root.dark,
+:root[data-theme="dark"] {
+  --ds-surface-base: #0e1116;
+  --ds-surface-raised: #171c24;
+  --ds-surface-app: #0e1116;
+  --ds-surface-sunken: #0a0d12;
+  --ds-surface-overlay: rgba(4, 6, 10, 0.64);
+  --ds-surface-overlay-stacked: rgba(4, 6, 10, 0.32);
+
+  --ds-content-primary: #e9eef6;
+  --ds-content-secondary: #afbaca;
+  --ds-content-tertiary: #8592a6;
+  --ds-content-disabled: #5c6779;
+  --ds-content-inverse: #0b1220;
+
+  --ds-border-subtle: #232a35;
+  --ds-border-default: #333c4a;
+  --ds-border-strong: #748196;
+  --ds-border-focus: #8fc0ff;
+
+  --ds-accent-default: #7fb0ff;
+  --ds-accent-hover: #a6c8ff;
+  --ds-accent-active: #5c97f5;
+  --ds-accent-subtle: #16294a;
+  --ds-accent-border: #2f4e82;
+  --ds-accent-on: #0b1220;
+
+  --ds-success-default: #56d69a;
+  --ds-success-subtle: #0f2e22;
+  --ds-success-border: #2c6b4e;
+  --ds-success-on: #06170f;
+
+  --ds-warning-default: #e9b45a;
+  --ds-warning-subtle: #33240b;
+  --ds-warning-border: #7a5a22;
+  --ds-warning-on: #1c1305;
+
+  --ds-danger-default: #ff8a80;
+  --ds-danger-subtle: #3a1512;
+  --ds-danger-border: #8a3a33;
+  --ds-danger-on: #2a0a07;
+
+  --ds-info-default: #7fb0ff;
+  --ds-info-subtle: #16294a;
+  --ds-info-border: #2f4e82;
+  --ds-info-on: #0b1220;
+
+  --ds-surface-hover: #1d242e;
+  --ds-surface-active: #222a35;
+  --ds-surface-disabled: #12161c;
+  --ds-fill-disabled: #1b222c;
+  --ds-border-strong-hover: #8894a8;
+  --ds-border-disabled: #232a35;
+  --ds-accent-subtle-hover: #16294a;
+  --ds-accent-subtle-active: #1d3357;
+  --ds-danger-hover: #ffa9a1;
+  --ds-danger-active: #e8756b;
+
+  --ds-elevation-0: none;
+  --ds-elevation-1: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --ds-elevation-2: 0 4px 12px rgba(0, 0, 0, 0.6);
+  --ds-elevation-3: 0 8px 28px rgba(0, 0, 0, 0.68);
+  --ds-elevation-4: 0 16px 48px rgba(0, 0, 0, 0.76);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not([data-theme="light"]) {
+    --ds-surface-base: #0e1116;
+    --ds-surface-raised: #171c24;
+    --ds-surface-app: #0e1116;
+    --ds-surface-sunken: #0a0d12;
+    --ds-surface-overlay: rgba(4, 6, 10, 0.64);
+    --ds-surface-overlay-stacked: rgba(4, 6, 10, 0.32);
+
+    --ds-content-primary: #e9eef6;
+    --ds-content-secondary: #afbaca;
+    --ds-content-tertiary: #8592a6;
+    --ds-content-disabled: #5c6779;
+    --ds-content-inverse: #0b1220;
+
+    --ds-border-subtle: #232a35;
+    --ds-border-default: #333c4a;
+    --ds-border-strong: #748196;
+    --ds-border-focus: #8fc0ff;
+
+    --ds-accent-default: #7fb0ff;
+    --ds-accent-hover: #a6c8ff;
+    --ds-accent-active: #5c97f5;
+    --ds-accent-subtle: #16294a;
+    --ds-accent-border: #2f4e82;
+    --ds-accent-on: #0b1220;
+
+    --ds-success-default: #56d69a;
+    --ds-success-subtle: #0f2e22;
+    --ds-success-border: #2c6b4e;
+    --ds-success-on: #06170f;
+
+    --ds-warning-default: #e9b45a;
+    --ds-warning-subtle: #33240b;
+    --ds-warning-border: #7a5a22;
+    --ds-warning-on: #1c1305;
+
+    --ds-danger-default: #ff8a80;
+    --ds-danger-subtle: #3a1512;
+    --ds-danger-border: #8a3a33;
+    --ds-danger-on: #2a0a07;
+
+    --ds-info-default: #7fb0ff;
+    --ds-info-subtle: #16294a;
+    --ds-info-border: #2f4e82;
+    --ds-info-on: #0b1220;
+
+    --ds-surface-hover: #1d242e;
+    --ds-surface-active: #222a35;
+    --ds-surface-disabled: #12161c;
+    --ds-fill-disabled: #1b222c;
+    --ds-border-strong-hover: #8894a8;
+    --ds-border-disabled: #232a35;
+    --ds-accent-subtle-hover: #16294a;
+    --ds-accent-subtle-active: #1d3357;
+    --ds-danger-hover: #ffa9a1;
+    --ds-danger-active: #e8756b;
+
+    --ds-elevation-0: none;
+    --ds-elevation-1: 0 1px 2px rgba(0, 0, 0, 0.5);
+    --ds-elevation-2: 0 4px 12px rgba(0, 0, 0, 0.6);
+    --ds-elevation-3: 0 8px 28px rgba(0, 0, 0, 0.68);
+    --ds-elevation-4: 0 16px 48px rgba(0, 0, 0, 0.76);
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Scales — identical in both themes
+ * -------------------------------------------------------------------------*/
+:root {
+  /* Spacing: 4px base, keyed by STEP not by pixels. --ds-space-4 is the fourth
+   * step (16px), not 4px. Steps 7, 9, 11 and 13-15 are deliberately absent —
+   * an incomplete ramp is what stops arbitrary values creeping back in. */
+  --ds-space-0: 0px;
+  --ds-space-1: 4px;
+  --ds-space-2: 8px;
+  --ds-space-3: 12px;
+  --ds-space-4: 16px;
+  --ds-space-5: 20px;
+  --ds-space-6: 24px;
+  --ds-space-8: 32px;
+  --ds-space-10: 40px;
+  --ds-space-12: 48px;
+  --ds-space-16: 64px;
+
+  --ds-radius-none: 0px; /* Gantt bars, table cells */
+  --ds-radius-xs: 2px; /* Checkbox, tag */
+  --ds-radius-sm: 4px; /* Status pill, badge */
+  --ds-radius-md: 6px; /* Button, input, menu item */
+  --ds-radius-lg: 8px; /* Card, panel, modal */
+  --ds-radius-full: 999px; /* Avatar, toggle, chip */
+
+  --ds-border-hairline: 1px;
+  --ds-border-emphasis: 1.5px;
+  --ds-border-focus-width: 2px;
+  --ds-focus-offset: 2px;
+
+  /* IBM Plex is the spec's choice. It is not loaded yet — the fallback chain
+   * carries the app until the font is added, and the metrics below assume
+   * Plex's proportions. */
+  --ds-font-sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --ds-font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", monospace;
+
+  --ds-type-display: 600 28px/34px var(--ds-font-sans);
+  --ds-ls-display: -0.02em;
+  --ds-type-heading-lg: 600 20px/28px var(--ds-font-sans);
+  --ds-ls-heading-lg: -0.015em;
+  --ds-type-heading-md: 600 16px/22px var(--ds-font-sans);
+  --ds-ls-heading-md: -0.01em;
+  --ds-type-heading-sm: 600 12px/16px var(--ds-font-sans);
+  --ds-ls-heading-sm: 0.06em;
+  --ds-type-body: 400 14px/20px var(--ds-font-sans);
+  --ds-type-body-sm: 400 13px/18px var(--ds-font-sans);
+  --ds-type-label: 500 12px/16px var(--ds-font-sans);
+  --ds-ls-label: 0.005em;
+  --ds-type-numeric: 500 14px/20px var(--ds-font-sans);
+  --ds-numeric-feature: tabular-nums;
+  --ds-type-mono: 400 13px/18px var(--ds-font-mono);
+
+  --ds-duration-instant: 0ms;
+  --ds-duration-fast: 120ms; /* hover, focus ring, checkbox, tooltip */
+  --ds-duration-base: 180ms; /* dropdown, popover, toast, tab change */
+  --ds-duration-slow: 240ms; /* drawer, modal, panel expand */
+  --ds-duration-emphasized: 300ms; /* Gantt zoom re-scale — the ceiling */
+  --ds-easing-standard: cubic-bezier(0.2, 0, 0, 1); /* entering or moving */
+  --ds-easing-exit: cubic-bezier(0.4, 0, 1, 1); /* leaving; always faster */
+
+  /* Deliberately an order of magnitude below the legacy scale (--z-modal:1050)
+   * so that during migration a new-system surface never covers a legacy one by
+   * accident. Stacked modals add 10 each, max depth 2. */
+  --ds-z-base: 0;
+  --ds-z-sticky: 100;
+  --ds-z-dropdown: 200;
+  --ds-z-overlay: 300;
+  --ds-z-modal: 400;
+  --ds-z-toast: 500;
+  --ds-z-tooltip: 600;
+}
+
+/* ---------------------------------------------------------------------------
+ * The two rules the spec applies globally.
+ *
+ * Both are scoped to `.ds` so they cannot alter the legacy UI mid-migration.
+ * Wrap a new-system subtree in `<div className="ds">` (or put it on <body>
+ * once every route has moved).
+ * -------------------------------------------------------------------------*/
+.ds {
+  font: var(--ds-type-body);
+  color: var(--ds-content-primary);
+  background: var(--ds-surface-app);
+}
+
+/* P1: "The figure is the interface." Figures line up vertically and never
+ * reflow between rows — tabular figures, right aligned, fixed decimals. */
+.ds .ds-numeric,
+.ds-numeric {
+  font: var(--ds-type-numeric);
+  font-variant-numeric: var(--ds-numeric-feature);
+  text-align: right;
+}
+
+/* P5: "The keyboard is the primary input." Every focusable target shows the
+ * ring — :focus-visible, so pointer users do not see it on click. */
+.ds :where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ds-duration-fast: 0ms;
+    --ds-duration-base: 0ms;
+    --ds-duration-slow: 0ms;
+    --ds-duration-emphasized: 0ms;
+  }
+
+  .ds *,
+  .ds *::before,
+  .ds *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}
+
+/* ============================================================================
+ * CONTRAST — what was verified, and the one value that was changed
+ *
+ * Every ratio in the spec was computed against `surface/base` alone (#FFFFFF
+ * light, #0E1116 dark). These tokens are also used on `surface/sunken` and, in
+ * dark, on `surface/raised`, where every ratio is lower. Recomputing each pair
+ * against the worst surface it can legitimately land on found exactly one
+ * genuine failure:
+ *
+ *     content/tertiary  #667085 on surface/sunken #F1F3F7  =  4.48:1   FAIL
+ *
+ * The spec assigns content/tertiary to "metadata, timestamps, placeholder" and
+ * surface/sunken to "table headers, inset wells, disabled fields" — a
+ * placeholder inside an inset well is that pairing, so it is reachable rather
+ * than theoretical. Corrected to #5F6B7F (same hue, 220.6deg):
+ *
+ *     #5F6B7F on #FFFFFF 5.53 · on #F6F7F9 5.16 · on #F1F3F7 4.85   PASS
+ *
+ * The three-step hierarchy is preserved: primary 16.22 > secondary 6.80 >
+ * tertiary 4.85 against the worst light surface.
+ *
+ * Everything else clears its floor against every surface it can appear on
+ * (4.5:1 for text, 3:1 for borders and other non-text UI). The status pill
+ * pairs reproduce the spec's stated ratios exactly.
+ *
+ * `content/disabled` is the one documented exemption in both themes: 2.58:1
+ * light, 3.31:1 dark. WCAG exempts disabled controls, and the spec requires it
+ * to be paired with aria-disabled so the state is never colour-only.
+ *
+ * These floors are enforced, not just documented — see
+ * src/styles/__tests__/foundations-contrast.test.ts. Changing a colour here
+ * without checking it fails the build.
+ * ==========================================================================*/

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -427,15 +427,46 @@ beforeEach(() => {
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as any;
 
-// Mock window.getComputedStyle for AntD components
+// window.getComputedStyle
+//
+// This was previously replaced wholesale with a stub that reported
+// `display: 'none'` for EVERY element. Testing Library consults
+// getComputedStyle to decide whether a node is in the accessibility tree, so
+// the stub made every element in the entire suite invisible: `getByRole`,
+// `getByLabelText` and every other accessible query could never match
+// anything, in any test, and only `{ hidden: true }` worked.
+//
+// That is very likely why the accessibility suite asserts HTML strings rather
+// than querying rendered components — the accessible queries were broken, so
+// they were worked around instead of fixed. Asserting strings is what allowed
+// BaseModal to ship with no role="dialog" and no focus trap while its evidence
+// file claimed otherwise.
+//
+// jsdom's real implementation is used instead. The two properties AntD reads
+// off the result are layout values jsdom always reports as empty strings, so
+// they are filled in with harmless defaults rather than by faking the whole
+// object.
 if (typeof window !== 'undefined') {
+  const realGetComputedStyle = window.getComputedStyle.bind(window);
+
   Object.defineProperty(window, 'getComputedStyle', {
-    value: () => ({
-      getPropertyValue: () => '',
-      display: 'none',
-      width: '0px',
-      height: '0px',
-    }),
+    configurable: true,
+    value: (element: Element, pseudoElement?: string | null) => {
+      const style = realGetComputedStyle(element, pseudoElement ?? undefined);
+
+      // jsdom performs no layout, so these come back as "". AntD reads them
+      // during measurement and treats "" as NaN.
+      return new Proxy(style, {
+        get(target, prop, receiver) {
+          if (prop === 'width' || prop === 'height') {
+            const value = Reflect.get(target, prop, receiver);
+            return value === '' ? '0px' : value;
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+    },
   });
 
   // Mock matchMedia for responsive components


### PR DESCRIPTION
The design system existed only as HTML specification documents in a scratch directory. **Nothing was implemented**, which is why the deployed app still shows the old UI. This lands the substrate the rebuild is built from.

**This change is deliberately invisible.** Layer 1 is a token layer plus one primitive that no route uses yet. The app still ships 19 pages, 3 layouts and 58 components on the legacy UI, and will look identical after this merges. The visible change starts at layer 3 and lands at layer 5.

## Why every token is prefixed `--ds-`

Mandatory, not stylistic. The spec ships a "paste-ready" block using bare names this codebase already owns with **different meanings**:

| Name | Existing meaning | Spec meaning |
|---|---|---|
| `--space-4` | `0.25rem` (4px) — keyed by pixel value | `16px` — keyed by step index |
| `--space-16` | `1rem` (16px) | `64px` |
| `--radius-md` | `8px` | `6px` |
| `--z-modal` | `1050` | `400` |

Pasting it would have jumped every existing component 4× on spacing and dropped new modals behind current overlays. The legacy UI is the live product until migration finishes, so the two systems must not touch. The spec was authored standalone and had no way to know.

## One real contrast defect, caught before shipping

Every ratio in the spec was computed against `surface/base` alone (`#FFFFFF` light, `#0E1116` dark). These tokens also land on `surface/sunken` and, in dark, on `surface/raised`, where every ratio is lower. Recomputing each pair against the worst surface it can legitimately appear on found exactly one genuine failure:

```
content/tertiary  #667085 on surface/sunken #F1F3F7  =  4.48:1     (floor 4.5)
```

Reachable rather than theoretical — the spec assigns `content/tertiary` to *"metadata, timestamps, placeholder"* and `surface/sunken` to *"table headers, inset wells, disabled fields"*. Corrected to `#5F6B7F`: same hue (220.6°), 4.85:1 worst-case, and the three-step hierarchy is preserved (primary 16.22 > secondary 6.80 > tertiary 4.85).

Nothing else failed. The status-pill pairs reproduce the spec's stated ratios exactly.

**The floors are enforced, not documented.** `src/styles/__tests__/foundations-contrast.test.ts` parses the real stylesheet rather than restating the palette — a test that restated it would pass while the shipped CSS drifted. Verified to fail when `#667085` is reintroduced:

```
--ds-content-tertiary (#667085) on --ds-surface-sunken (#f1f3f7) = 4.48:1
```

This matters because the previous design system shipped `#007AFF` at 4.02:1 on the background of every primary button while `A11Y_EVIDENCE.md` claimed it passed, and two visual tests asserted the failing value as correct.

## The fix that unblocked accessibility testing

`tests/setup.ts` replaced `window.getComputedStyle` with a stub reporting `display: 'none'` for **every** element:

```js
Object.defineProperty(window, 'getComputedStyle', {
  value: () => ({ getPropertyValue: () => '', display: 'none', ... }),
});
```

Testing Library consults `getComputedStyle` to decide whether a node is in the accessibility tree. With that stub, every element in the entire suite was invisible to accessible queries — `getByRole`, `getByLabelText` and every sibling query could never match anything, in any test. Only `{ hidden: true }` worked. A bare `<button>Hello</button>` was unreachable by role.

So the a11y suite's hand-written HTML string assertions were a **workaround for a broken environment**, and they are what let `BaseModal` ship to 28 dialogs with no `role="dialog"`, no `aria-modal` and `initialFocus: false` while its evidence file claimed all of it was present. A test that reads source as text cannot notice that the rendered component has no accessible role.

Replaced with jsdom's real implementation, filling in `width`/`height` for AntD's measurement code (jsdom performs no layout, so those come back as empty strings). **Full suite before and after: 1772 → 1773 passing, zero regressions.** The stub was never load-bearing.

## Button — the first primitive

Five variants, three sizes, six states, reading only `--ds-` tokens so both themes come free and no hex appears in the component. Three of the spec's rules are enforced here rather than left to the caller:

- **Loading locks the width.** Both labels share one grid cell, so the control is always as wide as the wider of "Save plan" and "Saving…" and the row cannot reflow at the moment the action starts.
- **Disabled stays focusable.** `aria-disabled` rather than the `disabled` attribute, so the control can still be reached and explained; activation is blocked in the handler, including `preventDefault` so a submit button cannot slip through.
- **An icon-only button will not compile without a name.** The type signature makes `label` required when `iconOnly` is set.

`aria-disabled` and `aria-busy` are announced separately on purpose: a busy control is not an unavailable one, and marking it disabled would also paint the disabled grey over the loading state the spec keeps on the filled variant.

Its tests drive the rendered component the way a user does — now possible for the first time.

## Two defects of my own, corrected

**The drift test passed on deliberately broken input.** It checks that the two dark-theme blocks stay identical (dark is declared twice — once for an explicit choice, once for the OS preference — because a colour whose only definition sits inside a media query leaves the explicit toggle with nothing to apply). The first version searched for a literal `"\n  }"` to find a block's end; the two blocks close at different indents, so from the explicit rule it ran past its own closing brace and compared the media-query block with itself. Caught by testing it against a deliberate drift, fixed by counting braces. It now fails on both a changed value and a missing token.

**`iconOnly` leaked onto the DOM node**, caught by React's unknown-attribute warning.

## Also in this change

The 14 design specification documents are committed to `docs/design/`, with a README recording the layer map, the implementation status of each, and both deliberate divergences. They previously existed only as downloads.

## Verified

| Gate | Result |
|---|---|
| `lint:strict` | PASS |
| `typecheck:strict` | PASS |
| `test` | PASS — 69 files, 1773 tests, 201 skipped |
| `test:coverage` | PASS — thresholds met |
| `build` | PASS — 76/76 pages |
| bundle budgets | PASS |

The full `ci:strict` gate also ran via the `pre-push` hook before this branch was pushed.

## What is not in this change

~14 remaining primitives, 8 composite systems, the domain surfaces (Gantt, allocation matrix, org chart, cost, sync), and the migration of all 19 routes. Layer 1 is additive and changes nothing visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_