### PR TITLE
UI rebuild layers 2 and 3: the primitive and composite sets

### DIFF
--- a/src/components/ds/AppShell.module.css
+++ b/src/components/ds/AppShell.module.css
@@ -1,0 +1,348 @@
+/* Design system — AppShell (layer 3, Composites) */
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--ds-surface-app);
+  color: var(--ds-content-primary);
+  font: var(--ds-type-body);
+}
+
+/* ---------------------------------------------------------------------------
+ * Top bar — the only global surface.
+ *
+ * Project switcher, global search, sync chip, presence, account. Nothing
+ * project-specific ever moves in here; that is what the sub-nav is for.
+ * -------------------------------------------------------------------------*/
+.topBar {
+  position: sticky;
+  top: 0;
+  z-index: var(--ds-z-sticky);
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  height: 52px;
+  padding: 0 var(--ds-space-4);
+  background: var(--ds-surface-raised);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-default);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  font: var(--ds-type-heading-md);
+  letter-spacing: var(--ds-ls-heading-md);
+  color: var(--ds-content-primary);
+  text-decoration: none;
+  flex: none;
+}
+
+.projectName {
+  font: var(--ds-type-body);
+  font-weight: 500;
+  color: var(--ds-content-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+
+/* Below 480 the full name is replaced by the project code, which is short
+ * enough to stay legible and unique enough to identify. */
+.projectCode {
+  display: none;
+  font: var(--ds-type-mono);
+  color: var(--ds-content-secondary);
+}
+
+.topBarSpacer {
+  flex: 1 1 auto;
+}
+
+.topBarSearch {
+  flex: 0 1 320px;
+  min-width: 0;
+}
+
+.topBarEnd {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  flex: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * Primary nav — destinations
+ * -------------------------------------------------------------------------*/
+.primaryNav {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-1);
+  flex: none;
+}
+
+.navLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  height: 32px;
+  padding: 0 var(--ds-space-3);
+  border-radius: var(--ds-radius-md);
+  font: var(--ds-type-body-sm);
+  font-weight: 500;
+  color: var(--ds-content-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.navLink:hover {
+  background: var(--ds-surface-hover);
+  color: var(--ds-content-primary);
+}
+
+.navLink:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+/* The active destination is filled *and* carries aria-current, so it is not
+ * signalled by colour alone. */
+.navLinkActive {
+  background: var(--ds-accent-subtle);
+  color: var(--ds-accent-default);
+}
+
+.menuButton {
+  display: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * Sub-nav — views of the current destination, plus the two facts that change
+ * what everything below means: role and cost visibility.
+ * -------------------------------------------------------------------------*/
+.subBar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  min-height: 40px;
+  padding: 0 var(--ds-space-4);
+  background: var(--ds-surface-raised);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  overflow-x: auto;
+}
+
+.subNav {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-1);
+}
+
+.subLink {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 var(--ds-space-2);
+  border-radius: var(--ds-radius-sm);
+  font: var(--ds-type-body-sm);
+  color: var(--ds-content-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+}
+
+.subLink:hover {
+  color: var(--ds-content-primary);
+}
+
+.subLink:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: -2px;
+}
+
+.subLinkActive {
+  color: var(--ds-accent-default);
+  border-bottom-color: var(--ds-accent-default);
+  font-weight: 500;
+}
+
+.subBarEnd {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  flex: none;
+}
+
+.meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-1);
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+  white-space: nowrap;
+}
+
+.metaValue {
+  color: var(--ds-content-secondary);
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------------
+ * Sync chip — present on every authenticated screen (principle P3)
+ * -------------------------------------------------------------------------*/
+.syncChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 var(--ds-space-2);
+  border-radius: var(--ds-radius-full);
+  border: var(--ds-border-hairline) solid;
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  white-space: nowrap;
+}
+
+.syncSynced {
+  color: var(--ds-success-default);
+  background: var(--ds-success-subtle);
+  border-color: var(--ds-success-border);
+}
+
+.syncPending {
+  color: var(--ds-warning-default);
+  background: var(--ds-warning-subtle);
+  border-color: var(--ds-warning-border);
+}
+
+.syncOffline {
+  color: var(--ds-content-secondary);
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-default);
+}
+
+.syncError {
+  color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+  border-color: var(--ds-danger-border);
+}
+
+.syncGlyph {
+  flex: none;
+  width: 10px;
+  height: 10px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Main
+ * -------------------------------------------------------------------------*/
+.main {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: var(--ds-space-6) var(--ds-space-4);
+}
+
+.mainInner {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.pageHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ds-space-4);
+  margin-bottom: var(--ds-space-5);
+  flex-wrap: wrap;
+}
+
+.pageTitleWrap {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pageTitle {
+  font: var(--ds-type-display);
+  letter-spacing: var(--ds-ls-display);
+  color: var(--ds-content-primary);
+  margin: 0;
+}
+
+.pageDescription {
+  font: var(--ds-type-body);
+  color: var(--ds-content-secondary);
+  margin: var(--ds-space-1) 0 0;
+}
+
+.pageActions {
+  display: flex;
+  gap: var(--ds-space-2);
+  flex: none;
+}
+
+/* A card is the default panel: raised surface, hairline edge, 8px radius. */
+.card {
+  background: var(--ds-surface-raised);
+  border: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  border-radius: var(--ds-radius-lg);
+  box-shadow: var(--ds-elevation-1);
+}
+
+.cardPadded {
+  padding: var(--ds-space-5);
+}
+
+/* ---------------------------------------------------------------------------
+ * Responsive
+ * -------------------------------------------------------------------------*/
+@media (max-width: 900px) {
+  .topBarSearch {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  /* Primary nav collapses into a menu button. It moves into the sub-bar
+   * rather than into an off-canvas drawer, so destinations stay one tap away. */
+  .primaryNav {
+    display: none;
+  }
+
+  .menuButton {
+    display: inline-flex;
+  }
+
+  .primaryNavOpen {
+    display: flex;
+    position: absolute;
+    top: 52px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    padding: var(--ds-space-2);
+    background: var(--ds-surface-raised);
+    border-bottom: var(--ds-border-hairline) solid var(--ds-border-default);
+    box-shadow: var(--ds-elevation-2);
+    z-index: var(--ds-z-dropdown);
+  }
+}
+
+@media (max-width: 480px) {
+  .projectName {
+    display: none;
+  }
+
+  .projectCode {
+    display: inline;
+  }
+
+  /* The chip keeps its glyph and one word — the state must never disappear. */
+  .syncLabelLong {
+    display: none;
+  }
+}

--- a/src/components/ds/AppShell.tsx
+++ b/src/components/ds/AppShell.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+/**
+ * Design system — AppShell (layer 3, Composites)
+ *
+ * Top bar, primary nav, contextual sub-nav, page header and card.
+ *
+ * The shell encodes three of the spec's rules, because they are decisions
+ * about meaning rather than layout:
+ *
+ *  - **Primary nav is destinations; sub-nav is views of the current
+ *    destination.** If an item changes what data you see rather than where you
+ *    are, it is a filter, not navigation.
+ *
+ *  - **Role and cost-visibility are always on screen** (principle P3, "nothing
+ *    important is implied"). Permission changes what every control below it
+ *    does, and a masked figure has to be explainable from the same screen —
+ *    so neither is allowed to live in a tooltip or a settings page.
+ *
+ *  - **A VIEWER gets one "Request edit access" button, never a screen of
+ *    disabled buttons.** `SyncChip` and `RoleBadge` are exported so a page can
+ *    make that decision; the shell only guarantees the facts are visible.
+ */
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import React, { useState, type ReactNode } from "react";
+import styles from "./AppShell.module.css";
+import { StatusPill } from "./Display";
+
+/* ==========================================================================
+ * Sync chip
+ * ========================================================================*/
+
+export type SyncState = "synced" | "pending" | "offline" | "error";
+
+const SYNC_COPY: Record<SyncState, { short: string; long: string }> = {
+  synced: { short: "Synced", long: "All changes saved" },
+  pending: { short: "Saving", long: "Saving changes" },
+  offline: { short: "Offline", long: "Offline — changes queued" },
+  error: { short: "Failed", long: "Sync failed" },
+};
+
+const SYNC_CLASS: Record<SyncState, string> = {
+  synced: styles.syncSynced,
+  pending: styles.syncPending,
+  offline: styles.syncOffline,
+  error: styles.syncError,
+};
+
+export interface SyncChipProps {
+  state: SyncState;
+  /** Number of queued local changes. Shown when there are any. */
+  queued?: number;
+}
+
+/**
+ * Present on every authenticated screen, and announced on every transition.
+ *
+ * Local-first sync changes what the user is looking at without changing the
+ * layout, and silence about that is a correctness bug rather than a polish
+ * issue — hence the live region rather than a passive badge.
+ */
+export function SyncChip({ state, queued }: SyncChipProps) {
+  const copy = SYNC_COPY[state];
+  const detail = queued && queued > 0 ? `${copy.long}, ${queued} queued` : copy.long;
+
+  return (
+    <span
+      className={cn(styles.syncChip, SYNC_CLASS[state])}
+      role="status"
+      aria-live="polite"
+      // The visible text is abbreviated at narrow widths, so the full state is
+      // carried in the accessible name where it cannot be truncated away.
+      aria-label={detail}
+    >
+      <svg className={styles.syncGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+        {state === "synced" ? (
+          <path
+            d="M2 5.2 4 7.2l4-4.4"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : state === "error" ? (
+          <path
+            d="M2.6 2.6l4.8 4.8M7.4 2.6l-4.8 4.8"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+          />
+        ) : (
+          <circle cx="5" cy="5" r="2.6" fill="currentColor" />
+        )}
+      </svg>
+      <span aria-hidden="true">{copy.short}</span>
+      {queued && queued > 0 ? (
+        <span aria-hidden="true" className={styles.syncLabelLong}>
+          · {queued}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/* ==========================================================================
+ * Role badge
+ * ========================================================================*/
+
+export type ProjectRole = "EDITOR" | "VIEWER" | "OWNER";
+
+/** Sits beside the project name: permission changes what every control does. */
+export function RoleBadge({ role }: { role: ProjectRole }) {
+  return (
+    <StatusPill tone={role === "VIEWER" ? "neutral" : "info"}>{role}</StatusPill>
+  );
+}
+
+/* ==========================================================================
+ * Shell
+ * ========================================================================*/
+
+export interface NavItem {
+  label: string;
+  href: string;
+  /** Marks the destination the user is currently in. */
+  current?: boolean;
+}
+
+export interface AppShellProps {
+  children: ReactNode;
+
+  /** Product name shown at the far left. */
+  brand?: ReactNode;
+  /** Full project name; replaced by `projectCode` on narrow screens. */
+  projectName?: string;
+  projectCode?: string;
+  role?: ProjectRole;
+
+  primaryNav?: NavItem[];
+  subNav?: NavItem[];
+
+  /** Global search, rendered in the top bar. */
+  search?: ReactNode;
+  sync?: SyncChipProps;
+  /** Presence, account menu. */
+  topBarEnd?: ReactNode;
+
+  /**
+   * Cost-visibility level, e.g. "2 of 3". Shown at all times so a masked
+   * figure is always explainable from the same screen.
+   */
+  costVisibility?: string;
+
+  className?: string;
+}
+
+export function AppShell({
+  children,
+  brand = "Cockpit",
+  projectName,
+  projectCode,
+  role,
+  primaryNav,
+  subNav,
+  search,
+  sync,
+  topBarEnd,
+  costVisibility,
+  className,
+}: AppShellProps) {
+  const [navOpen, setNavOpen] = useState(false);
+
+  return (
+    <div className={cn("ds", styles.shell, className)}>
+      <header className={styles.topBar}>
+        <Link href="/dashboard" className={styles.brand}>
+          {brand}
+        </Link>
+
+        {projectName && (
+          <>
+            <span className={styles.projectName} title={projectName}>
+              {projectName}
+            </span>
+            {projectCode && <span className={styles.projectCode}>{projectCode}</span>}
+          </>
+        )}
+        {role && <RoleBadge role={role} />}
+
+        {primaryNav && primaryNav.length > 0 && (
+          <>
+            <button
+              type="button"
+              className={cn(styles.navLink, styles.menuButton)}
+              aria-expanded={navOpen}
+              aria-controls="ds-primary-nav"
+              onClick={() => setNavOpen((open) => !open)}
+            >
+              Menu
+            </button>
+            <nav
+              id="ds-primary-nav"
+              aria-label="Primary"
+              className={cn(styles.primaryNav, navOpen && styles.primaryNavOpen)}
+            >
+              {primaryNav.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(styles.navLink, item.current && styles.navLinkActive)}
+                  // The fill is the sighted signal; this is the other one.
+                  aria-current={item.current ? "page" : undefined}
+                  onClick={() => setNavOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </>
+        )}
+
+        <span className={styles.topBarSpacer} />
+        {search && <div className={styles.topBarSearch}>{search}</div>}
+
+        <div className={styles.topBarEnd}>
+          {sync && <SyncChip {...sync} />}
+          {topBarEnd}
+        </div>
+      </header>
+
+      {(subNav?.length || costVisibility) && (
+        <div className={styles.subBar}>
+          {subNav && subNav.length > 0 && (
+            <nav aria-label="Views" className={styles.subNav}>
+              {subNav.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(styles.subLink, item.current && styles.subLinkActive)}
+                  aria-current={item.current ? "page" : undefined}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          )}
+          {costVisibility && (
+            <div className={styles.subBarEnd}>
+              <span className={styles.meta}>
+                Cost visibility
+                <span className={styles.metaValue}>{costVisibility}</span>
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <main className={styles.main} id="main-content">
+        <div className={styles.mainInner}>{children}</div>
+      </main>
+    </div>
+  );
+}
+
+/* ==========================================================================
+ * Page header and card
+ * ========================================================================*/
+
+export interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn(styles.pageHeader, className)}>
+      <div className={styles.pageTitleWrap}>
+        {/* One h1 per screen, and it is the page title — never a panel heading. */}
+        <h1 className={styles.pageTitle}>{title}</h1>
+        {description && <p className={styles.pageDescription}>{description}</p>}
+      </div>
+      {actions && <div className={styles.pageActions}>{actions}</div>}
+    </div>
+  );
+}
+
+export interface CardProps {
+  children: ReactNode;
+  /** Set false when the child manages its own padding, e.g. a data table. */
+  padded?: boolean;
+  className?: string;
+  /** Renders as a <section> with this accessible name. */
+  label?: string;
+}
+
+export function Card({ children, padded = true, className, label }: CardProps) {
+  const Tag = label ? "section" : "div";
+  return (
+    <Tag
+      className={cn(styles.card, padded && styles.cardPadded, className)}
+      aria-label={label}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/ds/Choice.module.css
+++ b/src/components/ds/Choice.module.css
@@ -1,0 +1,238 @@
+/* Design system — choice controls (layer 2, Primitives)
+ *
+ * Checkbox, Radio and Toggle. The native input stays in the DOM, focusable and
+ * operable; it is visually replaced, not hidden from assistive technology. */
+
+.row {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--ds-space-2);
+  cursor: pointer;
+}
+
+.row.disabled {
+  cursor: not-allowed;
+}
+
+.row.readOnly {
+  cursor: default;
+}
+
+/* The real control. `opacity: 0` over the visual box rather than
+ * `display: none` — a hidden input is not focusable, and the focus ring below
+ * is driven by :focus-visible on this element. */
+.input {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: inherit;
+}
+
+.control {
+  position: relative;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ds-surface-raised);
+  border: var(--ds-border-hairline) solid var(--ds-border-strong);
+  color: var(--ds-accent-on);
+  transition:
+    background-color var(--ds-duration-fast) var(--ds-easing-standard),
+    border-color var(--ds-duration-fast) var(--ds-easing-standard);
+}
+
+/* 18px keeps the box on the 2px grid while staying visually level with 14px
+ * body text; the 8px gap plus the label makes the real hit area far larger. */
+.box {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--ds-radius-xs);
+  /* Nudge down so the box aligns with the first line of a wrapping label
+   * rather than the middle of the block. */
+  margin-top: 1px;
+}
+
+.circle {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--ds-radius-full);
+  margin-top: 1px;
+}
+
+.row:hover .control:not(.checkedControl):not(.disabledControl):not(.readOnlyControl) {
+  border-color: var(--ds-border-strong-hover);
+  background: var(--ds-surface-hover);
+}
+
+.input:focus-visible + .control {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+.checkedControl {
+  background: var(--ds-accent-default);
+  border-color: var(--ds-accent-default);
+}
+
+.row:hover .checkedControl:not(.disabledControl):not(.readOnlyControl) {
+  background: var(--ds-accent-hover);
+  border-color: var(--ds-accent-hover);
+}
+
+.errorControl {
+  border-color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+}
+
+/* Disabled-and-checked stays filled, just muted. A disabled checkbox that
+ * renders empty reads as unchecked, which is a different fact. */
+.disabledControl {
+  background: var(--ds-surface-active);
+  border-color: var(--ds-border-default);
+  color: var(--ds-content-disabled);
+}
+
+.readOnlyControl {
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-default);
+  color: var(--ds-content-secondary);
+}
+
+.glyph {
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+}
+
+/* The radio's inner dot. Sized in the same ramp as the check glyph. */
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--ds-radius-full);
+  background: currentColor;
+  pointer-events: none;
+}
+
+.labelWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.label {
+  font: var(--ds-type-body);
+  color: var(--ds-content-primary);
+}
+
+.labelError {
+  color: var(--ds-danger-default);
+}
+
+.labelDisabled {
+  color: var(--ds-content-disabled);
+}
+
+.description {
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+}
+
+/* ---------------------------------------------------------------------------
+ * Toggle
+ *
+ * A switch, not a checkbox: it commits immediately, so it is used only where
+ * there is no Save button to press.
+ * -------------------------------------------------------------------------*/
+.track {
+  position: relative;
+  flex: none;
+  width: 40px;
+  height: 22px;
+  margin-top: 0;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-border-default);
+  border: var(--ds-border-hairline) solid var(--ds-border-strong);
+  transition: background-color var(--ds-duration-base) var(--ds-easing-standard);
+}
+
+.trackOn {
+  background: var(--ds-accent-default);
+  border-color: var(--ds-accent-default);
+}
+
+.trackDisabled {
+  background: var(--ds-surface-active);
+  border-color: var(--ds-border-default);
+}
+
+/* Pending is its own colour, distinct from both on and disabled: the user's
+ * intent is recorded but the server has not confirmed it, and showing it as
+ * already-on would be a lie the next refresh corrects. */
+.trackPending {
+  background: var(--ds-content-disabled);
+  border-color: var(--ds-border-strong);
+}
+
+.knob {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-surface-raised);
+  box-shadow: var(--ds-elevation-1);
+  transform: translate(0, -50%);
+  transition: transform var(--ds-duration-base) var(--ds-easing-standard);
+}
+
+.knobOn {
+  transform: translate(18px, -50%);
+}
+
+.knobDisabled {
+  background: var(--ds-surface-disabled);
+}
+
+/* ---------------------------------------------------------------------------
+ * Group
+ * -------------------------------------------------------------------------*/
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-2);
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.groupHorizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--ds-space-4);
+}
+
+.legend {
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-secondary);
+  padding: 0;
+  margin-bottom: var(--ds-space-1);
+}
+
+.groupHelper {
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+  margin-top: var(--ds-space-1);
+}
+
+.groupError {
+  color: var(--ds-danger-default);
+}

--- a/src/components/ds/Choice.tsx
+++ b/src/components/ds/Choice.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+/**
+ * Design system — choice controls (layer 2, Primitives)
+ *
+ * Checkbox, Radio, Toggle and the group wrappers.
+ *
+ * All three keep a real `<input>` in the DOM at `opacity: 0` over the visual
+ * control, rather than replacing it with a `<div role="checkbox">`. That gets
+ * the platform's own semantics, keyboard handling, form participation and
+ * name/value pairing for free — and those are exactly the parts hand-rolled
+ * versions get wrong.
+ *
+ * Indeterminate is set through the DOM property, because it has no HTML
+ * attribute and cannot be expressed in JSX.
+ */
+
+import { cn } from "@/lib/utils";
+import React, {
+  forwardRef,
+  useEffect,
+  useId,
+  useRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import styles from "./Choice.module.css";
+
+interface ChoiceBase extends Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "size"> {
+  label: ReactNode;
+  /** Secondary line under the label. */
+  description?: string;
+  /** Marks the control invalid and colours the label. */
+  error?: boolean;
+  /**
+   * Shows the value without allowing change. Native inputs have no read-only
+   * state for checkboxes or radios, so this is enforced by blocking the
+   * interaction and announcing `aria-readonly`.
+   */
+  readOnly?: boolean;
+}
+
+/* ==========================================================================
+ * Checkbox
+ * ========================================================================*/
+
+export interface CheckboxProps extends ChoiceBase {
+  /** Renders the dash glyph and sets the DOM property. */
+  indeterminate?: boolean;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    label,
+    description,
+    error,
+    readOnly,
+    indeterminate,
+    disabled,
+    checked,
+    defaultChecked,
+    className,
+    onClick,
+    ...rest
+  },
+  ref
+) {
+  const id = useId();
+  const descriptionId = description ? `${id}-desc` : undefined;
+  const inner = useRef<HTMLInputElement | null>(null);
+
+  // `indeterminate` exists only as a DOM property — there is no attribute for
+  // it, so it cannot be passed through JSX and must be assigned after render.
+  useEffect(() => {
+    if (inner.current) inner.current.indeterminate = Boolean(indeterminate);
+  }, [indeterminate]);
+
+  const isOn = Boolean(checked ?? defaultChecked) || Boolean(indeterminate);
+
+  return (
+    <label
+      className={cn(
+        styles.row,
+        disabled && styles.disabled,
+        readOnly && styles.readOnly,
+        className
+      )}
+    >
+      <span style={{ position: "relative", display: "flex" }}>
+        <input
+          {...rest}
+          ref={(node) => {
+            inner.current = node;
+            if (typeof ref === "function") ref(node);
+            else if (ref) ref.current = node;
+          }}
+          type="checkbox"
+          className={styles.input}
+          disabled={disabled}
+          checked={checked}
+          defaultChecked={defaultChecked}
+          aria-describedby={descriptionId}
+          aria-invalid={error || undefined}
+          aria-readonly={readOnly || undefined}
+          onClick={(event) => {
+            // A read-only checkbox must still be focusable and announced, so
+            // it cannot use `disabled`; the change is blocked here instead.
+            if (readOnly) {
+              event.preventDefault();
+              return;
+            }
+            onClick?.(event);
+          }}
+        />
+        <span
+          className={cn(
+            styles.control,
+            styles.box,
+            isOn && styles.checkedControl,
+            error && styles.errorControl,
+            readOnly && styles.readOnlyControl,
+            disabled && styles.disabledControl
+          )}
+        >
+          {indeterminate ? (
+            <svg className={styles.glyph} viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path d="M3 6h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          ) : isOn ? (
+            <svg className={styles.glyph} viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M2.5 6.5 5 9l4.5-5.5"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : null}
+        </span>
+      </span>
+      <span className={styles.labelWrap}>
+        <span
+          className={cn(
+            styles.label,
+            error && styles.labelError,
+            disabled && styles.labelDisabled
+          )}
+        >
+          {label}
+        </span>
+        {description && (
+          <span className={styles.description} id={descriptionId}>
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+});
+
+/* ==========================================================================
+ * Radio
+ * ========================================================================*/
+
+export type RadioProps = ChoiceBase;
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
+  {
+    label,
+    description,
+    error,
+    readOnly,
+    disabled,
+    checked,
+    defaultChecked,
+    className,
+    onClick,
+    ...rest
+  },
+  ref
+) {
+  const id = useId();
+  const descriptionId = description ? `${id}-desc` : undefined;
+  const isOn = Boolean(checked ?? defaultChecked);
+
+  return (
+    <label
+      className={cn(
+        styles.row,
+        disabled && styles.disabled,
+        readOnly && styles.readOnly,
+        className
+      )}
+    >
+      <span style={{ position: "relative", display: "flex" }}>
+        <input
+          {...rest}
+          ref={ref}
+          type="radio"
+          className={styles.input}
+          disabled={disabled}
+          checked={checked}
+          defaultChecked={defaultChecked}
+          aria-describedby={descriptionId}
+          // No aria-invalid or aria-readonly here: the `radio` role supports
+          // neither. Validity belongs on the enclosing radiogroup, which
+          // ChoiceGroup carries. ARIA offers no read-only state for a radio,
+          // so an unchangeable one is announced as disabled — which is what
+          // it is from the user's point of view — while the visual treatment
+          // stays the lighter read-only one.
+          aria-disabled={readOnly || undefined}
+          onClick={(event) => {
+            if (readOnly) {
+              event.preventDefault();
+              return;
+            }
+            onClick?.(event);
+          }}
+        />
+        <span
+          className={cn(
+            styles.control,
+            styles.circle,
+            isOn && styles.checkedControl,
+            error && styles.errorControl,
+            readOnly && styles.readOnlyControl,
+            disabled && styles.disabledControl
+          )}
+        >
+          {isOn && <span className={styles.dot} />}
+        </span>
+      </span>
+      <span className={styles.labelWrap}>
+        <span
+          className={cn(
+            styles.label,
+            error && styles.labelError,
+            disabled && styles.labelDisabled
+          )}
+        >
+          {label}
+        </span>
+        {description && (
+          <span className={styles.description} id={descriptionId}>
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+});
+
+/* ==========================================================================
+ * Toggle
+ * ========================================================================*/
+
+export interface ToggleProps extends Omit<ChoiceBase, "error"> {
+  /**
+   * The change has been sent but not confirmed. Shown in its own colour
+   * rather than as "on", because presenting an unconfirmed change as done is
+   * a claim the next refresh may contradict.
+   */
+  pending?: boolean;
+  /** Hides the visible label, keeping it as the accessible name. */
+  hideLabel?: boolean;
+}
+
+export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(function Toggle(
+  {
+    label,
+    description,
+    pending,
+    hideLabel,
+    readOnly,
+    disabled,
+    checked,
+    defaultChecked,
+    className,
+    onClick,
+    ...rest
+  },
+  ref
+) {
+  const id = useId();
+  const descriptionId = description ? `${id}-desc` : undefined;
+  const isOn = Boolean(checked ?? defaultChecked);
+
+  return (
+    <label
+      className={cn(
+        styles.row,
+        disabled && styles.disabled,
+        readOnly && styles.readOnly,
+        className
+      )}
+    >
+      <span style={{ position: "relative", display: "flex" }}>
+        {/* role="switch" rather than a plain checkbox: it commits immediately,
+         * with no Save to press, and screen readers announce on/off instead
+         * of checked/unchecked. */}
+        <input
+          {...rest}
+          ref={ref}
+          type="checkbox"
+          role="switch"
+          className={styles.input}
+          disabled={disabled}
+          checked={checked}
+          defaultChecked={defaultChecked}
+          aria-describedby={descriptionId}
+          aria-readonly={readOnly || undefined}
+          aria-busy={pending || undefined}
+          onClick={(event) => {
+            if (readOnly) {
+              event.preventDefault();
+              return;
+            }
+            onClick?.(event);
+          }}
+        />
+        <span
+          className={cn(
+            styles.track,
+            isOn && styles.trackOn,
+            pending && styles.trackPending,
+            disabled && styles.trackDisabled
+          )}
+        >
+          <span
+            className={cn(
+              styles.knob,
+              isOn && styles.knobOn,
+              disabled && styles.knobDisabled
+            )}
+          />
+        </span>
+      </span>
+      <span className={styles.labelWrap}>
+        <span
+          className={cn(styles.label, disabled && styles.labelDisabled)}
+          style={hideLabel ? srOnly : undefined}
+        >
+          {label}
+        </span>
+        {description && (
+          <span className={styles.description} id={descriptionId}>
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+});
+
+/** Visually hidden but still in the accessibility tree. */
+const srOnly: React.CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0 0 0 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
+
+/* ==========================================================================
+ * Groups
+ * ========================================================================*/
+
+export interface ChoiceGroupProps {
+  legend: string;
+  children: ReactNode;
+  /** Guidance under the group. Replaced by `error` when present. */
+  helper?: string;
+  error?: string;
+  orientation?: "vertical" | "horizontal";
+  className?: string;
+}
+
+/**
+ * A fieldset with a legend.
+ *
+ * Radios especially need this: without a grouping label, a screen reader
+ * announces "Fixed price, radio button, 1 of 3" with no indication of what
+ * question is being answered.
+ */
+export function ChoiceGroup({
+  legend,
+  children,
+  helper,
+  error,
+  orientation = "vertical",
+  className,
+}: ChoiceGroupProps) {
+  const id = useId();
+  const descriptionId = error || helper ? `${id}-desc` : undefined;
+
+  return (
+    <fieldset
+      className={cn(styles.group, className)}
+      aria-describedby={descriptionId}
+      aria-invalid={Boolean(error) || undefined}
+    >
+      <legend className={styles.legend}>{legend}</legend>
+      <div
+        className={cn(styles.group, orientation === "horizontal" && styles.groupHorizontal)}
+      >
+        {children}
+      </div>
+      {descriptionId && (
+        <span
+          className={cn(styles.groupHelper, error && styles.groupError)}
+          id={descriptionId}
+        >
+          {error ?? helper}
+        </span>
+      )}
+    </fieldset>
+  );
+}

--- a/src/components/ds/Choice.tsx
+++ b/src/components/ds/Choice.tsx
@@ -47,6 +47,12 @@ interface ChoiceBase extends Omit<InputHTMLAttributes<HTMLInputElement>, "type" 
 export interface CheckboxProps extends ChoiceBase {
   /** Renders the dash glyph and sets the DOM property. */
   indeterminate?: boolean;
+  /**
+   * Hides the visible label while keeping it as the accessible name. For
+   * table selection cells, where a visible label per row would be noise but
+   * an unnamed checkbox is unusable by screen reader.
+   */
+  hideLabel?: boolean;
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
@@ -56,6 +62,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
     error,
     readOnly,
     indeterminate,
+    hideLabel,
     disabled,
     checked,
     defaultChecked,
@@ -146,6 +153,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
             error && styles.labelError,
             disabled && styles.labelDisabled
           )}
+          style={hideLabel ? srOnly : undefined}
         >
           {label}
         </span>

--- a/src/components/ds/DataTable.module.css
+++ b/src/components/ds/DataTable.module.css
@@ -1,0 +1,178 @@
+/* Design system — DataTable (layer 3, Composites)
+ *
+ * Density without noise (principle P2): no zebra striping, no vertical
+ * gridlines. Separation comes from alignment and space. At most two border
+ * weights are visible at once. */
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* The toolbar stays operational in every state, including empty and error, so
+ * the user can undo the filter that emptied the table. */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  min-height: 52px;
+  flex-wrap: wrap;
+}
+
+/* The bulk bar REPLACES the toolbar rather than stacking beneath it, so the
+ * table never loses vertical space when a row is selected. */
+.bulkBar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  min-height: 52px;
+  background: var(--ds-accent-subtle);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-accent-border);
+}
+
+.bulkCount {
+  font: var(--ds-type-body-sm);
+  font-weight: 500;
+  color: var(--ds-accent-default);
+}
+
+.toolbarSpacer {
+  flex: 1 1 auto;
+}
+
+.scroll {
+  overflow-x: auto;
+  min-width: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font: var(--ds-type-body-sm);
+}
+
+.headerCell {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--ds-surface-sunken);
+  color: var(--ds-content-secondary);
+  font: var(--ds-type-heading-sm);
+  letter-spacing: var(--ds-ls-heading-sm);
+  text-transform: uppercase;
+  text-align: left;
+  padding: var(--ds-space-2) var(--ds-space-3);
+  white-space: nowrap;
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-default);
+}
+
+.headerCellNumeric {
+  text-align: right;
+}
+
+.sortButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-1);
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sortButton:hover {
+  color: var(--ds-content-primary);
+}
+
+.sortButton:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+/* The active sort column turns accent AND shows an arrow — not colour alone. */
+.sortActive {
+  color: var(--ds-accent-default);
+}
+
+.sortArrow {
+  width: 10px;
+  height: 10px;
+  flex: none;
+}
+
+.row {
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+}
+
+.row:hover {
+  background: var(--ds-surface-hover);
+}
+
+.rowSelected {
+  background: var(--ds-accent-subtle);
+}
+
+.rowSelected:hover {
+  background: var(--ds-accent-subtle-active);
+}
+
+.cell {
+  padding: var(--ds-space-2) var(--ds-space-3);
+  color: var(--ds-content-primary);
+  vertical-align: middle;
+}
+
+/* Figures line up vertically and never reflow between rows (principle P1). */
+.cellNumeric {
+  font-variant-numeric: var(--ds-numeric-feature);
+  text-align: right;
+}
+
+.checkboxCell {
+  width: 40px;
+  padding-left: var(--ds-space-4);
+}
+
+/* Empty and error states render INSIDE the table body, so the header and
+ * toolbar stay operational. */
+.stateCell {
+  padding: 0;
+}
+
+.caption {
+  /* Visually hidden, but present: a table with no caption is announced only
+   * as "table" with a column count. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  border-top: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+  flex-wrap: wrap;
+}
+
+.footerSpacer {
+  flex: 1 1 auto;
+}

--- a/src/components/ds/DataTable.tsx
+++ b/src/components/ds/DataTable.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+/**
+ * Design system — DataTable (layer 3, Composites)
+ *
+ * A real `<table>` with real `<th scope>`, because that is what makes a screen
+ * reader able to say "Day rate, 1,240" instead of just "1,240" — and no
+ * div-grid reproduces it without reimplementing the entire table model.
+ *
+ * The rules it encodes, each because it is a correctness decision rather than
+ * a styling one:
+ *
+ *  - **Sort is announced through `aria-sort`, and the active column shows an
+ *    arrow as well as accent colour** — never colour alone.
+ *  - **The header checkbox selects the loaded page only, and says so**, since
+ *    "select all" over a paginated set is a promise the table cannot keep.
+ *  - **The bulk bar replaces the toolbar** rather than stacking beneath it, so
+ *    selecting a row never shortens the table.
+ *  - **Empty and error states render inside the table body**, keeping header
+ *    and toolbar operational so the user can undo the filter that emptied it.
+ */
+
+import { cn } from "@/lib/utils";
+import React, { type ReactNode } from "react";
+import { Checkbox } from "./Choice";
+import styles from "./DataTable.module.css";
+
+export type SortDirection = "asc" | "desc";
+
+export interface Column<Row> {
+  /** Stable key; also the sort key reported to `onSort`. */
+  key: string;
+  header: string;
+  /** Right-aligns and applies tabular figures. Use for every figure. */
+  numeric?: boolean;
+  sortable?: boolean;
+  render: (row: Row) => ReactNode;
+  width?: string;
+}
+
+export interface DataTableProps<Row> {
+  /** Names the table for assistive technology. Required. */
+  caption: string;
+  columns: Column<Row>[];
+  rows: Row[];
+  rowKey: (row: Row) => string;
+
+  sortKey?: string;
+  sortDirection?: SortDirection;
+  onSort?: (key: string, direction: SortDirection) => void;
+
+  /** Enables the selection column. */
+  selectedKeys?: Set<string>;
+  onSelectionChange?: (keys: Set<string>) => void;
+
+  /** Filters and actions. Replaced by the bulk bar while rows are selected. */
+  toolbar?: ReactNode;
+  /** Actions shown when rows are selected. */
+  bulkActions?: ReactNode;
+
+  /** Rendered inside the body when `rows` is empty. */
+  emptyState?: ReactNode;
+  loading?: boolean;
+  footer?: ReactNode;
+  className?: string;
+}
+
+export function DataTable<Row>({
+  caption,
+  columns,
+  rows,
+  rowKey,
+  sortKey,
+  sortDirection = "asc",
+  onSort,
+  selectedKeys,
+  onSelectionChange,
+  toolbar,
+  bulkActions,
+  emptyState,
+  loading,
+  footer,
+  className,
+}: DataTableProps<Row>) {
+  const selectable = Boolean(selectedKeys && onSelectionChange);
+  const selectedCount = selectedKeys?.size ?? 0;
+
+  const pageKeys = rows.map(rowKey);
+  const allOnPageSelected =
+    pageKeys.length > 0 && pageKeys.every((key) => selectedKeys?.has(key));
+  const someOnPageSelected =
+    pageKeys.some((key) => selectedKeys?.has(key)) && !allOnPageSelected;
+
+  const toggleAllOnPage = () => {
+    if (!selectedKeys || !onSelectionChange) return;
+    const next = new Set(selectedKeys);
+    if (allOnPageSelected) pageKeys.forEach((key) => next.delete(key));
+    else pageKeys.forEach((key) => next.add(key));
+    onSelectionChange(next);
+  };
+
+  const toggleRow = (key: string) => {
+    if (!selectedKeys || !onSelectionChange) return;
+    const next = new Set(selectedKeys);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    onSelectionChange(next);
+  };
+
+  const handleSort = (column: Column<Row>) => {
+    if (!column.sortable || !onSort) return;
+    const nextDirection: SortDirection =
+      sortKey === column.key && sortDirection === "asc" ? "desc" : "asc";
+    onSort(column.key, nextDirection);
+  };
+
+  return (
+    <div className={cn(styles.wrap, className)}>
+      {/* The bulk bar replaces the toolbar; it never stacks on top of it. */}
+      {selectable && selectedCount > 0 ? (
+        <div className={styles.bulkBar}>
+          <span className={styles.bulkCount} role="status" aria-live="polite">
+            {selectedCount} selected
+          </span>
+          <span className={styles.toolbarSpacer} />
+          {bulkActions}
+        </div>
+      ) : (
+        toolbar && <div className={styles.toolbar}>{toolbar}</div>
+      )}
+
+      <div className={styles.scroll}>
+        <table className={styles.table}>
+          <caption className={styles.caption}>{caption}</caption>
+          <thead>
+            <tr>
+              {selectable && (
+                <th scope="col" className={cn(styles.headerCell, styles.checkboxCell)}>
+                  <Checkbox
+                    // "Select all" over a paginated set is a promise the table
+                    // cannot keep, so the label states the real scope.
+                    label={`Select all ${rows.length} rows on this page`}
+                    hideLabel
+                    checked={allOnPageSelected}
+                    indeterminate={someOnPageSelected}
+                    onChange={toggleAllOnPage}
+                  />
+                </th>
+              )}
+              {columns.map((column) => {
+                const active = sortKey === column.key;
+                return (
+                  <th
+                    key={column.key}
+                    scope="col"
+                    style={column.width ? { width: column.width } : undefined}
+                    className={cn(
+                      styles.headerCell,
+                      column.numeric && styles.headerCellNumeric
+                    )}
+                    // The machine-readable half of the sort signal. Without it
+                    // a screen-reader user cannot tell which column is sorted.
+                    aria-sort={
+                      active
+                        ? sortDirection === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : column.sortable
+                          ? "none"
+                          : undefined
+                    }
+                  >
+                    {column.sortable && onSort ? (
+                      <button
+                        type="button"
+                        className={cn(styles.sortButton, active && styles.sortActive)}
+                        onClick={() => handleSort(column)}
+                      >
+                        {column.header}
+                        {active && (
+                          <svg
+                            className={styles.sortArrow}
+                            viewBox="0 0 10 10"
+                            fill="none"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d={sortDirection === "asc" ? "M2.5 6.5 5 4l2.5 2.5" : "M2.5 4 5 6.5 7.5 4"}
+                              stroke="currentColor"
+                              strokeWidth="1.6"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </button>
+                    ) : (
+                      column.header
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody aria-busy={loading || undefined}>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  className={styles.stateCell}
+                >
+                  {emptyState}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => {
+                const key = rowKey(row);
+                const selected = selectedKeys?.has(key) ?? false;
+                return (
+                  <tr
+                    key={key}
+                    className={cn(styles.row, selected && styles.rowSelected)}
+                    aria-selected={selectable ? selected : undefined}
+                  >
+                    {selectable && (
+                      <td className={cn(styles.cell, styles.checkboxCell)}>
+                        <Checkbox
+                          label={`Select row ${key}`}
+                          hideLabel
+                          checked={selected}
+                          onChange={() => toggleRow(key)}
+                        />
+                      </td>
+                    )}
+                    {columns.map((column) => (
+                      <td
+                        key={column.key}
+                        className={cn(styles.cell, column.numeric && styles.cellNumeric)}
+                      >
+                        {column.render(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {footer && <div className={styles.footer}>{footer}</div>}
+    </div>
+  );
+}

--- a/src/components/ds/Display.module.css
+++ b/src/components/ds/Display.module.css
@@ -1,0 +1,286 @@
+/* Design system — display primitives (layer 2)
+ *
+ * StatusPill, Badge, Chip, Avatar, Progress, Skeleton. */
+
+/* ---------------------------------------------------------------------------
+ * StatusPill
+ *
+ * Principle P4: "Colour is the second channel." Every pill carries a glyph and
+ * a word, so it survives a projector, a monochrome print and any colour-vision
+ * deficiency. The glyph is not decoration.
+ * -------------------------------------------------------------------------*/
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px var(--ds-space-2);
+  border-radius: var(--ds-radius-sm);
+  border: var(--ds-border-hairline) solid transparent;
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  white-space: nowrap;
+}
+
+.pillGlyph {
+  flex: none;
+  width: 10px;
+  height: 10px;
+}
+
+.success {
+  color: var(--ds-success-default);
+  background: var(--ds-success-subtle);
+  border-color: var(--ds-success-border);
+}
+
+.warning {
+  color: var(--ds-warning-default);
+  background: var(--ds-warning-subtle);
+  border-color: var(--ds-warning-border);
+}
+
+.danger {
+  color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+  border-color: var(--ds-danger-border);
+}
+
+.info {
+  color: var(--ds-info-default);
+  background: var(--ds-info-subtle);
+  border-color: var(--ds-info-border);
+}
+
+/* Neutral is a real status, not an absence of one — "not started" must not be
+ * grey-on-grey or it reads as disabled. */
+.neutral {
+  color: var(--ds-content-secondary);
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-default);
+}
+
+/* ---------------------------------------------------------------------------
+ * Badge — a count, not a status
+ * -------------------------------------------------------------------------*/
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-accent-default);
+  color: var(--ds-accent-on);
+  font: var(--ds-type-label);
+  font-variant-numeric: var(--ds-numeric-feature);
+  letter-spacing: 0;
+}
+
+.badgeNeutral {
+  background: var(--ds-surface-active);
+  color: var(--ds-content-secondary);
+}
+
+.badgeDanger {
+  background: var(--ds-danger-default);
+  color: var(--ds-danger-on);
+}
+
+/* ---------------------------------------------------------------------------
+ * Chip — a removable filter token
+ * -------------------------------------------------------------------------*/
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-1);
+  height: 24px;
+  padding: 0 var(--ds-space-1) 0 var(--ds-space-2);
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-accent-subtle);
+  border: var(--ds-border-hairline) solid var(--ds-accent-border);
+  color: var(--ds-accent-default);
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  white-space: nowrap;
+}
+
+.chipStatic {
+  padding-right: var(--ds-space-2);
+}
+
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: var(--ds-radius-full);
+  color: inherit;
+  cursor: pointer;
+}
+
+.chipRemove:hover {
+  background: var(--ds-accent-subtle-active);
+}
+
+.chipRemove:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Avatar
+ * -------------------------------------------------------------------------*/
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-accent-subtle);
+  color: var(--ds-accent-default);
+  font: var(--ds-type-label);
+  letter-spacing: 0;
+  overflow: hidden;
+  user-select: none;
+}
+
+.avatarSm {
+  width: 24px;
+  height: 24px;
+  font-size: 10px;
+}
+
+.avatarMd {
+  width: 32px;
+  height: 32px;
+  font-size: 12px;
+}
+
+.avatarLg {
+  width: 40px;
+  height: 40px;
+  font-size: 14px;
+}
+
+.avatarImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ---------------------------------------------------------------------------
+ * Progress
+ *
+ * The figure is printed beside the bar, never encoded in width alone —
+ * a bar with no number cannot be read off a projector or a printout.
+ * -------------------------------------------------------------------------*/
+.progressWrap {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  min-width: 0;
+}
+
+.progressTrack {
+  position: relative;
+  flex: 1 1 auto;
+  height: 6px;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-surface-sunken);
+  border: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--ds-accent-default);
+  transition: width var(--ds-duration-base) var(--ds-easing-standard);
+}
+
+.progressFillSuccess {
+  background: var(--ds-success-default);
+}
+
+.progressFillWarning {
+  background: var(--ds-warning-default);
+}
+
+.progressFillDanger {
+  background: var(--ds-danger-default);
+}
+
+/* Over 100% is an exception, not a bigger bar: the hatch makes it legible
+ * without colour, per P4. */
+.progressOver {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 3px,
+    rgba(255, 255, 255, 0.45) 3px,
+    rgba(255, 255, 255, 0.45) 6px
+  );
+}
+
+.progressValue {
+  flex: none;
+  font: var(--ds-type-numeric);
+  font-variant-numeric: var(--ds-numeric-feature);
+  color: var(--ds-content-secondary);
+  font-size: 12px;
+  min-width: 40px;
+  text-align: right;
+}
+
+/* ---------------------------------------------------------------------------
+ * Skeleton
+ * -------------------------------------------------------------------------*/
+.skeleton {
+  display: block;
+  background: var(--ds-surface-sunken);
+  border-radius: var(--ds-radius-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ds-surface-hover),
+    transparent
+  );
+  animation: ds-skeleton-sweep 1.4s ease-in-out infinite;
+}
+
+@keyframes ds-skeleton-sweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* A sweeping highlight is exactly the kind of motion that triggers vestibular
+ * symptoms. Under reduced motion the block still reads as a placeholder. */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+    background: none;
+  }
+}
+
+.skeletonText {
+  height: 12px;
+  border-radius: var(--ds-radius-xs);
+}
+
+.skeletonCircle {
+  border-radius: var(--ds-radius-full);
+}

--- a/src/components/ds/Display.tsx
+++ b/src/components/ds/Display.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+/**
+ * Design system — display primitives (layer 2)
+ *
+ * StatusPill, Badge, Chip, Avatar, Progress, Skeleton.
+ *
+ * The through-line is principle P4: colour is the second channel, never the
+ * only one. A status pill carries a glyph and a word; a progress bar prints
+ * its figure; an over-allocated bar adds a hatch. Each of those survives a
+ * projector, a monochrome printout, and any colour-vision deficiency.
+ */
+
+import { cn } from "@/lib/utils";
+import React, { type ReactNode } from "react";
+import styles from "./Display.module.css";
+
+/* ==========================================================================
+ * StatusPill
+ * ========================================================================*/
+
+export type StatusTone = "success" | "warning" | "danger" | "info" | "neutral";
+
+const TONE_GLYPH: Record<StatusTone, ReactNode> = {
+  success: (
+    <svg className={styles.pillGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <path
+        d="M2 5.2 4 7.2l4-4.4"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  warning: (
+    <svg className={styles.pillGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <path
+        d="M5 1.2 9.2 8.6H0.8L5 1.2Z"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinejoin="round"
+      />
+      <path d="M5 4.2v1.8" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+      <circle cx="5" cy="7.1" r="0.6" fill="currentColor" />
+    </svg>
+  ),
+  danger: (
+    <svg className={styles.pillGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <path
+        d="M2.6 2.6l4.8 4.8M7.4 2.6l-4.8 4.8"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  ),
+  info: (
+    <svg className={styles.pillGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <circle cx="5" cy="5" r="4" stroke="currentColor" strokeWidth="1.1" />
+      <path d="M5 4.4v2.6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <circle cx="5" cy="2.9" r="0.65" fill="currentColor" />
+    </svg>
+  ),
+  neutral: (
+    <svg className={styles.pillGlyph} viewBox="0 0 10 10" fill="none" aria-hidden="true">
+      <circle cx="5" cy="5" r="2.6" fill="currentColor" />
+    </svg>
+  ),
+};
+
+export interface StatusPillProps {
+  tone: StatusTone;
+  /** The word. Required — a glyph and a colour are not a label. */
+  children: ReactNode;
+  className?: string;
+}
+
+export function StatusPill({ tone, children, className }: StatusPillProps) {
+  return (
+    <span className={cn(styles.pill, styles[tone], className)}>
+      {TONE_GLYPH[tone]}
+      {children}
+    </span>
+  );
+}
+
+/* ==========================================================================
+ * Badge — a count
+ * ========================================================================*/
+
+export interface BadgeProps {
+  count: number;
+  /** Values above this render as "N+". */
+  max?: number;
+  tone?: "accent" | "neutral" | "danger";
+  /**
+   * What the number counts. Becomes the accessible name, because "3" alone
+   * tells a screen-reader user nothing.
+   */
+  label: string;
+  className?: string;
+}
+
+export function Badge({ count, max = 99, tone = "accent", label, className }: BadgeProps) {
+  const display = count > max ? `${max}+` : String(count);
+  return (
+    <span
+      className={cn(
+        styles.badge,
+        tone === "neutral" && styles.badgeNeutral,
+        tone === "danger" && styles.badgeDanger,
+        className
+      )}
+      aria-label={`${count} ${label}`}
+    >
+      <span aria-hidden="true">{display}</span>
+    </span>
+  );
+}
+
+/* ==========================================================================
+ * Chip — a removable filter token
+ * ========================================================================*/
+
+export interface ChipProps {
+  children: ReactNode;
+  /** Omit for a static chip with no remove affordance. */
+  onRemove?: () => void;
+  /** Names what removal does, e.g. "EMEA". Required when removable. */
+  removeLabel?: string;
+  className?: string;
+}
+
+export function Chip({ children, onRemove, removeLabel, className }: ChipProps) {
+  return (
+    <span className={cn(styles.chip, !onRemove && styles.chipStatic, className)}>
+      {children}
+      {onRemove && (
+        <button
+          type="button"
+          className={styles.chipRemove}
+          onClick={onRemove}
+          aria-label={`Remove ${removeLabel ?? ""}`.trim()}
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+            <path
+              d="M2.5 2.5l5 5M7.5 2.5l-5 5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+}
+
+/* ==========================================================================
+ * Avatar
+ * ========================================================================*/
+
+export interface AvatarProps {
+  /** Full name. Used for initials and for the accessible name. */
+  name: string;
+  src?: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+/** First and last initial — "Ada Lovelace" gives AL, "Ada" gives A. */
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function Avatar({ name, src, size = "md", className }: AvatarProps) {
+  const sizeClass =
+    size === "sm" ? styles.avatarSm : size === "lg" ? styles.avatarLg : styles.avatarMd;
+
+  return (
+    <span
+      className={cn(styles.avatar, sizeClass, className)}
+      role="img"
+      aria-label={name}
+      title={name}
+    >
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt="" className={styles.avatarImage} />
+      ) : (
+        <span aria-hidden="true">{initials(name)}</span>
+      )}
+    </span>
+  );
+}
+
+/* ==========================================================================
+ * Progress
+ * ========================================================================*/
+
+export interface ProgressProps {
+  /** Percentage. May exceed 100 — over-allocation is a real state. */
+  value: number;
+  /** What is progressing. Becomes the accessible name. */
+  label: string;
+  tone?: "accent" | "success" | "warning" | "danger";
+  /** Hides the printed figure. Only for a bar already beside its number. */
+  hideValue?: boolean;
+  className?: string;
+}
+
+export function Progress({
+  value,
+  label,
+  tone = "accent",
+  hideValue,
+  className,
+}: ProgressProps) {
+  const over = value > 100;
+  const width = Math.max(0, Math.min(100, value));
+
+  return (
+    <div className={cn(styles.progressWrap, className)}>
+      <div
+        className={styles.progressTrack}
+        role="progressbar"
+        aria-label={label}
+        aria-valuenow={Math.round(value)}
+        aria-valuemin={0}
+        // The max stays 100 even when the value exceeds it, so assistive
+        // technology reports "120%" rather than silently rescaling.
+        aria-valuemax={100}
+        aria-valuetext={`${Math.round(value)}%`}
+      >
+        <div
+          className={cn(
+            styles.progressFill,
+            tone === "success" && styles.progressFillSuccess,
+            tone === "warning" && styles.progressFillWarning,
+            (tone === "danger" || over) && styles.progressFillDanger,
+            over && styles.progressOver
+          )}
+          style={{ width: `${width}%` }}
+        />
+      </div>
+      {!hideValue && (
+        <span className={styles.progressValue} aria-hidden="true">
+          {Math.round(value)}%
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ==========================================================================
+ * Skeleton
+ * ========================================================================*/
+
+export interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  variant?: "block" | "text" | "circle";
+  className?: string;
+}
+
+/**
+ * A loading placeholder.
+ *
+ * `aria-hidden` on purpose: the surrounding region carries `aria-busy`, and
+ * announcing a dozen empty boxes tells a screen-reader user nothing useful.
+ */
+export function Skeleton({ width, height, variant = "block", className }: SkeletonProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        styles.skeleton,
+        variant === "text" && styles.skeletonText,
+        variant === "circle" && styles.skeletonCircle,
+        className
+      )}
+      style={{ width, height }}
+    />
+  );
+}

--- a/src/components/ds/Feedback.module.css
+++ b/src/components/ds/Feedback.module.css
@@ -1,0 +1,255 @@
+/* Design system — feedback composites (layer 3)
+ *
+ * EmptyState, Banner, Toast. */
+
+/* ---------------------------------------------------------------------------
+ * EmptyState
+ *
+ * Four kinds, two alignments. First-run and no-results are centred because
+ * they own the whole region; error and no-permission are left-aligned because
+ * they are statements about the data, and centring a paragraph of explanation
+ * makes it harder to read.
+ * -------------------------------------------------------------------------*/
+.empty {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-8) var(--ds-space-6);
+  max-width: 520px;
+}
+
+.emptyCentered {
+  align-items: center;
+  text-align: center;
+  margin: 0 auto;
+}
+
+.emptyLeft {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.emptyGlyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--ds-radius-lg);
+  border: var(--ds-border-hairline) solid;
+}
+
+.emptyTitle {
+  font: var(--ds-type-heading-md);
+  letter-spacing: var(--ds-ls-heading-md);
+  color: var(--ds-content-primary);
+  margin: 0;
+}
+
+.emptyBody {
+  font: var(--ds-type-body);
+  color: var(--ds-content-secondary);
+  margin: 0;
+}
+
+.emptyActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-space-2);
+  margin-top: var(--ds-space-1);
+}
+
+/* Support reference — a project code and a timestamp, in mono so it can be
+ * read aloud over a phone without ambiguity. */
+.emptyReference {
+  font: var(--ds-type-mono);
+  color: var(--ds-content-tertiary);
+}
+
+.toneFirstRun {
+  color: var(--ds-accent-default);
+  background: var(--ds-accent-subtle);
+  border-color: var(--ds-accent-border);
+}
+
+.toneNeutral {
+  color: var(--ds-content-secondary);
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-default);
+}
+
+.toneError {
+  color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+  border-color: var(--ds-danger-border);
+}
+
+.toneLocked {
+  color: var(--ds-content-secondary);
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-strong);
+}
+
+/* ---------------------------------------------------------------------------
+ * Banner — inline, persistent, tied to the region it sits in
+ * -------------------------------------------------------------------------*/
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  border: var(--ds-border-hairline) solid;
+  border-radius: var(--ds-radius-md);
+  font: var(--ds-type-body-sm);
+}
+
+.bannerGlyph {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+}
+
+.bannerContent {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-1);
+}
+
+.bannerTitle {
+  font: var(--ds-type-heading-md);
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0;
+  margin: 0;
+  color: inherit;
+}
+
+.bannerBody {
+  margin: 0;
+  color: var(--ds-content-secondary);
+}
+
+.bannerActions {
+  display: flex;
+  gap: var(--ds-space-2);
+  margin-top: var(--ds-space-1);
+}
+
+.bannerInfo {
+  color: var(--ds-info-default);
+  background: var(--ds-info-subtle);
+  border-color: var(--ds-info-border);
+}
+
+.bannerSuccess {
+  color: var(--ds-success-default);
+  background: var(--ds-success-subtle);
+  border-color: var(--ds-success-border);
+}
+
+.bannerWarning {
+  color: var(--ds-warning-default);
+  background: var(--ds-warning-subtle);
+  border-color: var(--ds-warning-border);
+}
+
+.bannerDanger {
+  color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+  border-color: var(--ds-danger-border);
+}
+
+.bannerDismiss {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: var(--ds-radius-sm);
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.bannerDismiss:hover {
+  opacity: 1;
+}
+
+.bannerDismiss:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Toast — transient, bottom-right, max 3 visible
+ * -------------------------------------------------------------------------*/
+.toastRegion {
+  position: fixed;
+  right: var(--ds-space-4);
+  bottom: var(--ds-space-4);
+  z-index: var(--ds-z-toast);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-2);
+  width: min(380px, calc(100vw - var(--ds-space-8)));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  background: var(--ds-surface-raised);
+  border: var(--ds-border-hairline) solid var(--ds-border-default);
+  border-radius: var(--ds-radius-md);
+  box-shadow: var(--ds-elevation-4);
+  font: var(--ds-type-body-sm);
+  color: var(--ds-content-primary);
+  animation: ds-toast-in var(--ds-duration-base) var(--ds-easing-standard);
+}
+
+/* A 3px edge rather than a tinted fill: a toast sits over arbitrary content,
+ * and a full tint would fight whatever is behind it. */
+.toastSuccess {
+  border-left: 3px solid var(--ds-success-default);
+}
+.toastWarning {
+  border-left: 3px solid var(--ds-warning-default);
+}
+.toastDanger {
+  border-left: 3px solid var(--ds-danger-default);
+}
+.toastInfo {
+  border-left: 3px solid var(--ds-info-default);
+}
+
+.toastContent {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.toastAction {
+  flex: none;
+}
+
+@keyframes ds-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+  }
+}

--- a/src/components/ds/Feedback.tsx
+++ b/src/components/ds/Feedback.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+/**
+ * Design system — feedback composites (layer 3)
+ *
+ * EmptyState, Banner and the Toast system.
+ *
+ * The spec's four empty states are four different designs, not one component
+ * with a colour prop, because they say four different things:
+ *
+ *   first-run     nothing is wrong — teach the first step, never apologise
+ *   no-results    name the filters and quantify the fix
+ *   error         say what happened, what it means for their data, two ways out
+ *   no-permission deliberate, not broken — name the level held and required
+ *
+ * That distinction is enforced by the type: `kind` decides which fields are
+ * required, so an error state without a recovery action will not compile.
+ */
+
+import { cn } from "@/lib/utils";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import styles from "./Feedback.module.css";
+
+/* ==========================================================================
+ * EmptyState
+ * ========================================================================*/
+
+type EmptyKind = "first-run" | "no-results" | "error" | "no-permission";
+
+interface EmptyStateBase {
+  title: string;
+  /** The explanation. Concrete — name the filters, name the level, name the failure. */
+  body: string;
+  primaryAction?: ReactNode;
+  secondaryAction?: ReactNode;
+  className?: string;
+}
+
+interface ErrorEmptyState extends EmptyStateBase {
+  kind: "error";
+  /**
+   * Support reference, e.g. "PRJ-2291 / 14:32". Required for errors: without
+   * it a support conversation starts with "which one?".
+   */
+  reference: string;
+}
+
+interface OtherEmptyState extends EmptyStateBase {
+  kind: Exclude<EmptyKind, "error">;
+  reference?: never;
+}
+
+export type EmptyStateProps = ErrorEmptyState | OtherEmptyState;
+
+const EMPTY_TONE: Record<EmptyKind, string> = {
+  "first-run": styles.toneFirstRun,
+  "no-results": styles.toneNeutral,
+  error: styles.toneError,
+  "no-permission": styles.toneLocked,
+};
+
+const EMPTY_GLYPH: Record<EmptyKind, ReactNode> = {
+  "first-run": (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <rect x="2.5" y="3.5" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M2.5 7.5h13M6.5 7.5v7" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  ),
+  "no-results": (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M12 12l3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+  error: (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M5.5 5.5l7 7M12.5 5.5l-7 7" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  ),
+  "no-permission": (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <rect x="4" y="8" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M6.5 8V6a2.5 2.5 0 0 1 5 0v2" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  ),
+};
+
+export function EmptyState(props: EmptyStateProps) {
+  const { kind, title, body, primaryAction, secondaryAction, className } = props;
+  // Error and no-permission are left-aligned: they are paragraphs of
+  // explanation, and centred prose is measurably harder to read.
+  const centered = kind === "first-run" || kind === "no-results";
+
+  return (
+    <div
+      className={cn(
+        styles.empty,
+        centered ? styles.emptyCentered : styles.emptyLeft,
+        className
+      )}
+      // Errors are assertive because the user is blocked; the others describe
+      // a state they can already see.
+      role={kind === "error" ? "alert" : "status"}
+    >
+      <span className={cn(styles.emptyGlyph, EMPTY_TONE[kind])}>{EMPTY_GLYPH[kind]}</span>
+      <h3 className={styles.emptyTitle}>{title}</h3>
+      <p className={styles.emptyBody}>{body}</p>
+      {(primaryAction || secondaryAction) && (
+        <div className={styles.emptyActions}>
+          {primaryAction}
+          {secondaryAction}
+        </div>
+      )}
+      {props.kind === "error" && (
+        <span className={styles.emptyReference}>{props.reference}</span>
+      )}
+    </div>
+  );
+}
+
+/* ==========================================================================
+ * Banner
+ * ========================================================================*/
+
+export type BannerTone = "info" | "success" | "warning" | "danger";
+
+export interface BannerProps {
+  tone: BannerTone;
+  title: string;
+  children?: ReactNode;
+  actions?: ReactNode;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+const BANNER_TONE: Record<BannerTone, string> = {
+  info: styles.bannerInfo,
+  success: styles.bannerSuccess,
+  warning: styles.bannerWarning,
+  danger: styles.bannerDanger,
+};
+
+const BANNER_GLYPH: Record<BannerTone, ReactNode> = {
+  info: (
+    <svg className={styles.bannerGlyph} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M8 7.2v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="4.9" r="0.9" fill="currentColor" />
+    </svg>
+  ),
+  success: (
+    <svg className={styles.bannerGlyph} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M5.2 8.3 7 10.1l3.8-4.2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  warning: (
+    <svg className={styles.bannerGlyph} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M8 1.8 15 14H1L8 1.8Z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M8 6.4v3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="11.4" r="0.85" fill="currentColor" />
+    </svg>
+  ),
+  danger: (
+    <svg className={styles.bannerGlyph} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M5.6 5.6l4.8 4.8M10.4 5.6l-4.8 4.8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+};
+
+/**
+ * An inline, persistent message tied to the region it sits in.
+ *
+ * Not a toast: a banner stays until the condition clears, so it is right for
+ * "you are viewing a baseline" and wrong for "saved".
+ */
+export function Banner({
+  tone,
+  title,
+  children,
+  actions,
+  onDismiss,
+  className,
+}: BannerProps) {
+  return (
+    <div
+      className={cn(styles.banner, BANNER_TONE[tone], className)}
+      role={tone === "danger" ? "alert" : "status"}
+    >
+      {BANNER_GLYPH[tone]}
+      <div className={styles.bannerContent}>
+        <p className={styles.bannerTitle}>{title}</p>
+        {children && <div className={styles.bannerBody}>{children}</div>}
+        {actions && <div className={styles.bannerActions}>{actions}</div>}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          className={styles.bannerDismiss}
+          onClick={onDismiss}
+          aria-label={`Dismiss: ${title}`}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ==========================================================================
+ * Toast
+ * ========================================================================*/
+
+export interface ToastOptions {
+  tone?: BannerTone;
+  /** Milliseconds before auto-dismiss. Errors default to staying put. */
+  duration?: number;
+  action?: ReactNode;
+}
+
+interface ToastRecord extends ToastOptions {
+  id: number;
+  message: string;
+}
+
+interface ToastApi {
+  show: (message: string, options?: ToastOptions) => void;
+  dismiss: (id: number) => void;
+}
+
+const ToastContext = createContext<ToastApi | null>(null);
+
+/** Toasts are capped at three; a fourth pushes the oldest out. */
+const MAX_VISIBLE = 3;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const nextId = useRef(1);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const show = useCallback((message: string, options: ToastOptions = {}) => {
+    const id = nextId.current++;
+    setToasts((current) => [...current, { id, message, ...options }].slice(-MAX_VISIBLE));
+  }, []);
+
+  const api = useMemo(() => ({ show, dismiss }), [show, dismiss]);
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {mounted &&
+        createPortal(
+          // One live region that persists across toasts. Creating a region at
+          // the moment a message arrives is the classic reason announcements
+          // are silently dropped — the region has to exist first.
+          //
+          // Polite, not assertive: a toast reports something that already
+          // happened, and interrupting a screen-reader user mid-sentence to
+          // say "saved" is worse than waiting.
+          <div
+            className={styles.toastRegion}
+            role="status"
+            aria-live="polite"
+            aria-atomic="false"
+          >
+            {toasts.map((toast) => (
+              <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />
+            ))}
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastRecord;
+  onDismiss: (id: number) => void;
+}) {
+  const { id, tone = "info", duration } = toast;
+
+  // An error that vanishes on a timer is an error the user may never have
+  // read, so danger stays until dismissed unless a duration is given.
+  const effectiveDuration = duration ?? (tone === "danger" ? 0 : 5000);
+
+  useEffect(() => {
+    if (effectiveDuration <= 0) return;
+    const timer = setTimeout(() => onDismiss(id), effectiveDuration);
+    return () => clearTimeout(timer);
+  }, [effectiveDuration, id, onDismiss]);
+
+  const toneClass =
+    tone === "success"
+      ? styles.toastSuccess
+      : tone === "warning"
+        ? styles.toastWarning
+        : tone === "danger"
+          ? styles.toastDanger
+          : styles.toastInfo;
+
+  return (
+    <div className={cn(styles.toast, toneClass)}>
+      <div className={styles.toastContent}>{toast.message}</div>
+      {toast.action && <div className={styles.toastAction}>{toast.action}</div>}
+      <button
+        type="button"
+        className={styles.bannerDismiss}
+        onClick={() => onDismiss(id)}
+        aria-label={`Dismiss: ${toast.message}`}
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export function useToast(): ToastApi {
+  const api = useContext(ToastContext);
+  if (!api) {
+    throw new Error("useToast must be used inside a <ToastProvider>.");
+  }
+  return api;
+}

--- a/src/components/ds/Field.module.css
+++ b/src/components/ds/Field.module.css
@@ -1,0 +1,286 @@
+/* Design system — field family (layer 2, Primitives)
+ *
+ * Shared by Input, Textarea, NumberInput, SearchInput and Select so the five
+ * cannot drift apart. Reads only `--ds-*` tokens. */
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-1);
+  min-width: 0;
+}
+
+.label {
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-secondary);
+}
+
+/* The required marker is decorative; the input carries `required`, which is
+ * what assistive technology actually announces. */
+.required {
+  color: var(--ds-danger-default);
+  margin-left: 2px;
+}
+
+.optional {
+  color: var(--ds-content-tertiary);
+  font-weight: 400;
+}
+
+/* The bordered box. The control inside is borderless and transparent so a
+ * prefix, suffix or icon sits *within* the border rather than beside it —
+ * "a static adornment inside the border, never a separate control". */
+.box {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  background: var(--ds-surface-raised);
+  border: var(--ds-border-hairline) solid var(--ds-border-strong);
+  border-radius: var(--ds-radius-md);
+  color: var(--ds-content-primary);
+  transition:
+    border-color var(--ds-duration-fast) var(--ds-easing-standard),
+    background-color var(--ds-duration-fast) var(--ds-easing-standard);
+}
+
+.box:hover:not(.error):not(.readOnly):not(.disabled) {
+  border-color: var(--ds-border-strong-hover);
+}
+
+/* The ring sits outside the border (outline + offset) so focusing a field
+ * never changes its size and never nudges the row it lives in. */
+.box:focus-within:not(.disabled) {
+  border-color: var(--ds-border-focus);
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+.sm {
+  min-height: 32px;
+  padding: 0 10px;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.md {
+  min-height: 36px;
+  padding: 0 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.lg {
+  min-height: 44px;
+  padding: 0 14px;
+  font-size: 15px;
+  line-height: 22px;
+}
+
+/* The control itself: no border, no background, no ring. The box owns all
+ * three, so the two can never disagree. */
+.control {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  background: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  font-family: var(--ds-font-sans);
+  width: 100%;
+}
+
+.control::placeholder {
+  color: var(--ds-content-tertiary);
+  opacity: 1; /* Firefox dims placeholders by default. */
+}
+
+.control:disabled {
+  cursor: not-allowed;
+  color: var(--ds-content-disabled);
+  -webkit-text-fill-color: var(--ds-content-disabled); /* Safari */
+}
+
+.textarea {
+  resize: vertical;
+  padding: var(--ds-space-2) 0;
+  min-height: 72px;
+}
+
+/* Any figure in a field is a figure in a column somewhere: tabular, right
+ * aligned, so digits line up between rows (principle P1). */
+.numeric {
+  font-variant-numeric: var(--ds-numeric-feature);
+  text-align: right;
+}
+
+/* Native spinners are inconsistent across browsers and unreachable by
+ * keyboard in some; NumberInput supplies its own controls. */
+.numeric::-webkit-outer-spin-button,
+.numeric::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.numeric[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+/* ---------------------------------------------------------------------------
+ * States
+ * -------------------------------------------------------------------------*/
+
+.error {
+  border-color: var(--ds-danger-default);
+  background: var(--ds-danger-subtle);
+}
+
+/* Read-only keeps text at content/primary. The value is real — it is simply
+ * not editable here, and greying it would suggest it is absent. */
+.readOnly {
+  background: var(--ds-surface-sunken);
+  border-color: var(--ds-border-default);
+  cursor: default;
+}
+
+.disabled {
+  background: var(--ds-surface-disabled);
+  border-color: var(--ds-border-disabled);
+  color: var(--ds-content-disabled);
+  cursor: not-allowed;
+}
+
+/* ---------------------------------------------------------------------------
+ * Adornments
+ * -------------------------------------------------------------------------*/
+
+.adornment {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  color: var(--ds-content-tertiary);
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.errorIcon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  color: var(--ds-danger-default);
+}
+
+/* ---------------------------------------------------------------------------
+ * Helper and error text
+ *
+ * One element, not two: the helper slot becomes the error message when
+ * invalid, so the field never grows a second line and shifts the form.
+ * -------------------------------------------------------------------------*/
+.helper {
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+}
+
+.helperError {
+  color: var(--ds-danger-default);
+}
+
+/* ---------------------------------------------------------------------------
+ * NumberInput stepper
+ * -------------------------------------------------------------------------*/
+.steppers {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  margin-right: -4px;
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 12px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ds-content-tertiary);
+  cursor: pointer;
+  border-radius: var(--ds-radius-xs);
+}
+
+.stepper:hover:not(:disabled) {
+  color: var(--ds-content-primary);
+  background: var(--ds-surface-hover);
+}
+
+.stepper:disabled {
+  color: var(--ds-content-disabled);
+  cursor: not-allowed;
+}
+
+.stepper:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Select
+ * -------------------------------------------------------------------------*/
+.select {
+  appearance: none;
+  cursor: pointer;
+  /* Room for the chevron, which is absolutely positioned by the box's gap. */
+  padding-right: var(--ds-space-1);
+}
+
+.select:disabled {
+  cursor: not-allowed;
+}
+
+.chevron {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  color: var(--ds-content-tertiary);
+  pointer-events: none;
+}
+
+.searchIcon {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--ds-content-tertiary);
+}
+
+.clear {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: var(--ds-radius-full);
+  color: var(--ds-content-tertiary);
+  cursor: pointer;
+}
+
+.clear:hover {
+  color: var(--ds-content-primary);
+  background: var(--ds-surface-hover);
+}
+
+.clear:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: 1px;
+}

--- a/src/components/ds/Field.tsx
+++ b/src/components/ds/Field.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+/**
+ * Design system — field family (layer 2, Primitives)
+ *
+ * Input, Textarea, NumberInput, SearchInput and Select in one module so their
+ * accessibility contract cannot drift apart. Every one of them:
+ *
+ *  - associates its label through `htmlFor`/`id` rather than nesting, so the
+ *    label is clickable and the accessible name is unambiguous;
+ *  - links helper *and* error text through `aria-describedby`, so a screen
+ *    reader hears the explanation with the field rather than after it;
+ *  - sets `aria-invalid` when in error, which is what assistive technology
+ *    reports — the red border is only the sighted half of that signal;
+ *  - reuses one line for helper and error text, so validating a form never
+ *    grows the layout and pushes the next field down.
+ *
+ * Read-only deliberately keeps text at `content/primary`. The value is real;
+ * greying it would suggest it is missing.
+ */
+
+import { cn } from "@/lib/utils";
+import React, {
+  forwardRef,
+  useId,
+  useRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type SelectHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from "react";
+import styles from "./Field.module.css";
+
+export type FieldSize = "sm" | "md" | "lg";
+
+interface FieldShellProps {
+  /** Visible label. Omit only when an external `aria-label` names the field. */
+  label?: string;
+  size?: FieldSize;
+  /** Guidance shown under the field. Replaced by `error` when invalid. */
+  helper?: string;
+  /** Presence marks the field invalid; the text replaces `helper`. */
+  error?: string;
+  required?: boolean;
+  /** Renders "(optional)" beside the label. Use on forms where most fields are required. */
+  optionalHint?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
+  className?: string;
+}
+
+/** Ids for the control and its description, wired once for every field type. */
+function useFieldWiring(error?: string, helper?: string) {
+  const base = useId();
+  const controlId = `${base}-control`;
+  const describedById = error || helper ? `${base}-desc` : undefined;
+  return { controlId, describedById, invalid: Boolean(error) };
+}
+
+function Label({
+  htmlFor,
+  label,
+  required,
+  optionalHint,
+}: {
+  htmlFor: string;
+  label?: string;
+  required?: boolean;
+  optionalHint?: boolean;
+}) {
+  if (!label) return null;
+  return (
+    <label className={styles.label} htmlFor={htmlFor}>
+      {label}
+      {required && (
+        <span className={styles.required} aria-hidden="true">
+          *
+        </span>
+      )}
+      {optionalHint && !required && <span className={styles.optional}> (optional)</span>}
+    </label>
+  );
+}
+
+function Description({
+  id,
+  error,
+  helper,
+}: {
+  id?: string;
+  error?: string;
+  helper?: string;
+}) {
+  if (!id) return null;
+  return (
+    <span className={cn(styles.helper, error && styles.helperError)} id={id}>
+      {error ?? helper}
+    </span>
+  );
+}
+
+/** The ✕ shown inside an invalid field. Colour alone never carries the state. */
+function ErrorIcon() {
+  return (
+    <span className={styles.errorIcon} aria-hidden="true">
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <path
+          d="M4 4l6 6M10 4l-6 6"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  );
+}
+
+function boxClasses(
+  size: FieldSize,
+  { error, readOnly, disabled }: { error?: string; readOnly?: boolean; disabled?: boolean }
+) {
+  return cn(
+    styles.box,
+    styles[size],
+    error && styles.error,
+    readOnly && styles.readOnly,
+    disabled && styles.disabled
+  );
+}
+
+/* ==========================================================================
+ * Input
+ * ========================================================================*/
+
+export interface InputProps
+  // `prefix` is a global RDFa attribute typed as `string` in React's DOM
+  // types, so it has to be dropped before being redeclared as a node.
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "prefix">,
+    FieldShellProps {
+  /** Static adornment inside the border — a currency code, a unit. */
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    label,
+    size = "md",
+    helper,
+    error,
+    required,
+    optionalHint,
+    disabled,
+    readOnly,
+    className,
+    prefix,
+    suffix,
+    ...rest
+  },
+  ref
+) {
+  const { controlId, describedById, invalid } = useFieldWiring(error, helper);
+
+  return (
+    <div className={cn(styles.wrapper, className)}>
+      <Label
+        htmlFor={controlId}
+        label={label}
+        required={required}
+        optionalHint={optionalHint}
+      />
+      <div className={boxClasses(size, { error, readOnly, disabled })}>
+        {prefix && <span className={styles.adornment}>{prefix}</span>}
+        <input
+          {...rest}
+          ref={ref}
+          id={controlId}
+          className={styles.control}
+          disabled={disabled}
+          readOnly={readOnly}
+          required={required}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedById}
+        />
+        {invalid && <ErrorIcon />}
+        {suffix && <span className={styles.adornment}>{suffix}</span>}
+      </div>
+      <Description id={describedById} error={error} helper={helper} />
+    </div>
+  );
+});
+
+/* ==========================================================================
+ * Textarea
+ * ========================================================================*/
+
+export interface TextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement>,
+    FieldShellProps {}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  {
+    label,
+    size = "md",
+    helper,
+    error,
+    required,
+    optionalHint,
+    disabled,
+    readOnly,
+    className,
+    rows = 3,
+    ...rest
+  },
+  ref
+) {
+  const { controlId, describedById, invalid } = useFieldWiring(error, helper);
+
+  return (
+    <div className={cn(styles.wrapper, className)}>
+      <Label
+        htmlFor={controlId}
+        label={label}
+        required={required}
+        optionalHint={optionalHint}
+      />
+      <div className={boxClasses(size, { error, readOnly, disabled })}>
+        <textarea
+          {...rest}
+          ref={ref}
+          id={controlId}
+          rows={rows}
+          className={cn(styles.control, styles.textarea)}
+          disabled={disabled}
+          readOnly={readOnly}
+          required={required}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedById}
+        />
+      </div>
+      <Description id={describedById} error={error} helper={helper} />
+    </div>
+  );
+});
+
+/* ==========================================================================
+ * NumberInput
+ * ========================================================================*/
+
+export interface NumberInputProps extends Omit<InputProps, "type"> {
+  step?: number;
+  min?: number;
+  max?: number;
+}
+
+export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+  function NumberInput(
+    {
+      label,
+      size = "md",
+      helper,
+      error,
+      required,
+      optionalHint,
+      disabled,
+      readOnly,
+      className,
+      prefix,
+      suffix,
+      step = 1,
+      min,
+      max,
+      ...rest
+    },
+    ref
+  ) {
+    const { controlId, describedById, invalid } = useFieldWiring(error, helper);
+    const inner = useRef<HTMLInputElement | null>(null);
+
+    // Drives the real input so React's onChange fires and any controlled
+    // value stays in sync — setting `.value` directly would not notify React.
+    const nudge = (direction: 1 | -1) => {
+      const el = inner.current;
+      if (!el || disabled || readOnly) return;
+      if (direction === 1) el.stepUp();
+      else el.stepDown();
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    return (
+      <div className={cn(styles.wrapper, className)}>
+        <Label
+          htmlFor={controlId}
+          label={label}
+          required={required}
+          optionalHint={optionalHint}
+        />
+        <div className={boxClasses(size, { error, readOnly, disabled })}>
+          {prefix && <span className={styles.adornment}>{prefix}</span>}
+          <input
+            {...rest}
+            ref={(node) => {
+              inner.current = node;
+              if (typeof ref === "function") ref(node);
+              else if (ref) ref.current = node;
+            }}
+            id={controlId}
+            type="number"
+            inputMode="decimal"
+            step={step}
+            min={min}
+            max={max}
+            className={cn(styles.control, styles.numeric)}
+            disabled={disabled}
+            readOnly={readOnly}
+            required={required}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedById}
+          />
+          {suffix && <span className={styles.adornment}>{suffix}</span>}
+          {/* Native spinners are hidden because they are inconsistent across
+           * browsers and unreachable by keyboard in some. These are real
+           * buttons, but aria-hidden: the input already accepts ArrowUp and
+           * ArrowDown, so exposing them would add two redundant tab stops to
+           * every numeric cell in a table. */}
+          <span className={styles.steppers} aria-hidden="true">
+            <button
+              type="button"
+              tabIndex={-1}
+              className={styles.stepper}
+              disabled={disabled || readOnly}
+              onClick={() => nudge(1)}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path
+                  d="M2.5 6.25 5 3.75l2.5 2.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              tabIndex={-1}
+              className={styles.stepper}
+              disabled={disabled || readOnly}
+              onClick={() => nudge(-1)}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path
+                  d="M2.5 3.75 5 6.25l2.5-2.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </span>
+          {invalid && <ErrorIcon />}
+        </div>
+        <Description id={describedById} error={error} helper={helper} />
+      </div>
+    );
+  }
+);
+
+/* ==========================================================================
+ * SearchInput
+ * ========================================================================*/
+
+export interface SearchInputProps extends Omit<InputProps, "prefix" | "suffix" | "type"> {
+  /** Shows a clear button once there is a value. */
+  onClear?: () => void;
+}
+
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  function SearchInput(
+    {
+      label,
+      size = "md",
+      helper,
+      error,
+      disabled,
+      readOnly,
+      className,
+      onClear,
+      value,
+      placeholder = "Search",
+      ...rest
+    },
+    ref
+  ) {
+    const { controlId, describedById, invalid } = useFieldWiring(error, helper);
+    const hasValue = value !== undefined && value !== "";
+
+    return (
+      <div className={cn(styles.wrapper, className)}>
+        <Label htmlFor={controlId} label={label} />
+        <div className={boxClasses(size, { error, readOnly, disabled })}>
+          <span className={styles.searchIcon} aria-hidden="true">
+            <svg viewBox="0 0 14 14" fill="none">
+              <circle cx="6" cy="6" r="4.25" stroke="currentColor" strokeWidth="1.5" />
+              <path
+                d="M9.5 9.5 12.5 12.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </span>
+          <input
+            {...rest}
+            ref={ref}
+            id={controlId}
+            // `type="search"` would add a second, unstyleable native clear
+            // button in WebKit next to this one.
+            type="text"
+            role="searchbox"
+            value={value}
+            placeholder={placeholder}
+            className={styles.control}
+            disabled={disabled}
+            readOnly={readOnly}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedById}
+          />
+          {hasValue && onClear && (
+            <button
+              type="button"
+              className={styles.clear}
+              onClick={onClear}
+              aria-label="Clear search"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path
+                  d="M2.5 2.5l5 5M7.5 2.5l-5 5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+        <Description id={describedById} error={error} helper={helper} />
+      </div>
+    );
+  }
+);
+
+/* ==========================================================================
+ * Select
+ * ========================================================================*/
+
+export interface SelectProps
+  extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "size">,
+    FieldShellProps {
+  children: ReactNode;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  {
+    label,
+    size = "md",
+    helper,
+    error,
+    required,
+    optionalHint,
+    disabled,
+    className,
+    children,
+    ...rest
+  },
+  ref
+) {
+  const { controlId, describedById, invalid } = useFieldWiring(error, helper);
+
+  return (
+    <div className={cn(styles.wrapper, className)}>
+      <Label
+        htmlFor={controlId}
+        label={label}
+        required={required}
+        optionalHint={optionalHint}
+      />
+      <div className={boxClasses(size, { error, disabled })}>
+        {/* A native <select>: it gets the platform's own keyboard handling,
+         * type-ahead and mobile picker for free. A custom listbox would have
+         * to reimplement all three, and usually reimplements two. */}
+        <select
+          {...rest}
+          ref={ref}
+          id={controlId}
+          className={cn(styles.control, styles.select)}
+          disabled={disabled}
+          required={required}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedById}
+        >
+          {children}
+        </select>
+        <svg className={styles.chevron} viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path
+            d="M3 4.5 6 7.5 9 4.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <Description id={describedById} error={error} helper={helper} />
+    </div>
+  );
+});

--- a/src/components/ds/Modal.module.css
+++ b/src/components/ds/Modal.module.css
@@ -1,0 +1,191 @@
+/* Design system — Modal and Drawer (layer 3, Composites) */
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-space-4);
+  background: var(--ds-surface-overlay);
+  z-index: var(--ds-z-modal);
+  animation: ds-fade-in var(--ds-duration-slow) var(--ds-easing-standard);
+}
+
+/* The parent of a stacked modal drops to a lighter scrim and shifts down, so
+ * both layers stay legible and the stack depth is visible rather than implied. */
+.scrimStacked {
+  background: var(--ds-surface-overlay-stacked);
+}
+
+.dialog {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  /* Body scrolls; header and footer stay put. */
+  max-height: 80vh;
+  background: var(--ds-surface-raised);
+  border: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  border-radius: var(--ds-radius-lg);
+  box-shadow: var(--ds-elevation-4);
+  animation: ds-modal-in var(--ds-duration-slow) var(--ds-easing-standard);
+}
+
+.stacked {
+  margin-top: 48px;
+}
+
+.sm {
+  max-width: 400px;
+}
+.md {
+  max-width: 560px;
+}
+.lg {
+  max-width: 760px;
+}
+
+.header {
+  flex: none;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ds-space-4);
+  padding: var(--ds-space-4) var(--ds-space-5);
+  border-bottom: var(--ds-border-hairline) solid transparent;
+  transition: border-color var(--ds-duration-fast) var(--ds-easing-standard);
+}
+
+/* The rule appears only once content is actually behind the header, so a
+ * short dialog has no spurious divider. */
+.headerScrolled {
+  border-bottom-color: var(--ds-border-default);
+}
+
+.titleWrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-1);
+}
+
+.title {
+  font: var(--ds-type-heading-lg);
+  letter-spacing: var(--ds-ls-heading-lg);
+  color: var(--ds-content-primary);
+  margin: 0;
+}
+
+.description {
+  font: var(--ds-type-body-sm);
+  color: var(--ds-content-secondary);
+  margin: 0;
+}
+
+.body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0 var(--ds-space-5) var(--ds-space-4);
+  font: var(--ds-type-body);
+  color: var(--ds-content-primary);
+}
+
+.footer {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  padding: var(--ds-space-4) var(--ds-space-5);
+  border-top: var(--ds-border-hairline) solid var(--ds-border-subtle);
+}
+
+/* Secondary content in the footer sits left, actions stay right. */
+.footerLead {
+  margin-right: auto;
+  font: var(--ds-type-label);
+  letter-spacing: var(--ds-ls-label);
+  color: var(--ds-content-tertiary);
+}
+
+/* ---------------------------------------------------------------------------
+ * Drawer
+ * -------------------------------------------------------------------------*/
+.drawerScrim {
+  position: fixed;
+  inset: 0;
+  background: var(--ds-surface-overlay);
+  z-index: var(--ds-z-overlay);
+  display: flex;
+  justify-content: flex-end;
+  animation: ds-fade-in var(--ds-duration-slow) var(--ds-easing-standard);
+}
+
+.drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(480px, 100vw);
+  height: 100%;
+  background: var(--ds-surface-raised);
+  border-left: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  box-shadow: var(--ds-elevation-3);
+  animation: ds-drawer-in var(--ds-duration-slow) var(--ds-easing-standard);
+}
+
+.drawerWide {
+  width: min(720px, 100vw);
+}
+
+@media (max-width: 640px) {
+  /* Below 640 a side drawer leaves no room for content, so it becomes a
+   * bottom sheet. */
+  .drawerScrim {
+    align-items: flex-end;
+    justify-content: center;
+  }
+
+  .drawer {
+    width: 100%;
+    height: min(85vh, 100%);
+    border-left: none;
+    border-top-left-radius: var(--ds-radius-lg);
+    border-top-right-radius: var(--ds-radius-lg);
+    animation: ds-sheet-in var(--ds-duration-slow) var(--ds-easing-standard);
+  }
+}
+
+@keyframes ds-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes ds-modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+}
+
+@keyframes ds-drawer-in {
+  from {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+}
+
+@keyframes ds-sheet-in {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrim,
+  .dialog,
+  .drawerScrim,
+  .drawer {
+    animation: none;
+  }
+}

--- a/src/components/ds/Modal.tsx
+++ b/src/components/ds/Modal.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+/**
+ * Design system — Modal and Drawer (layer 3, Composites)
+ *
+ * The component this replaces shipped to 28 dialogs with no `role="dialog"`,
+ * no `aria-modal`, no `aria-labelledby`, and `initialFocus: false` — which
+ * tells focus-trap explicitly *not* to move focus into the dialog. Its
+ * evidence file claimed all four were present. Everything below is asserted in
+ * `__tests__/Modal.test.tsx` against the rendered component.
+ *
+ * What this guarantees:
+ *
+ *  - `role="dialog"` + `aria-modal` + a title that is the accessible name.
+ *  - Focus moves *into* the dialog on open, to the first interactive element
+ *    — never to Close, never to a destructive action.
+ *  - Escape closes; the element that opened it regains focus.
+ *  - The page behind cannot be scrolled or reached by Tab.
+ *  - Stacking is capped at two, with the parent made inert.
+ */
+
+import { cn } from "@/lib/utils";
+import FocusTrap from "focus-trap-react";
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import styles from "./Modal.module.css";
+
+/**
+ * How many modals are currently open.
+ *
+ * Module-level because the cap is a property of the screen, not of any one
+ * dialog: the second modal needs to know it is second in order to shift down
+ * and lighten its scrim, and the body scroll lock must only be released by
+ * the last one to close.
+ */
+let openCount = 0;
+
+function useBodyScrollLock(open: boolean) {
+  useEffect(() => {
+    if (!open) return;
+
+    openCount += 1;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      openCount -= 1;
+      // Only the last dialog to close restores scrolling — otherwise closing
+      // a stacked child would unlock the page while its parent is still open.
+      if (openCount === 0) document.body.style.overflow = previous;
+    };
+  }, [open]);
+}
+
+/** True when this dialog opened on top of another. */
+function useStackDepth(open: boolean): number {
+  const [depth, setDepth] = useState(0);
+  useEffect(() => {
+    if (open) setDepth(openCount);
+  }, [open]);
+  return depth;
+}
+
+/**
+ * Focus-trap configuration shared by Modal and Drawer, so the two cannot
+ * diverge on the behaviour that matters most.
+ */
+function focusTrapOptions(
+  bodyRef: React.RefObject<HTMLDivElement | null>,
+  dialogRef: React.RefObject<HTMLDivElement | null>
+) {
+  return {
+    // The default initial focus is the first tabbable node, which in this
+    // layout is the Close button — so the first thing a keyboard user could
+    // do is dismiss the dialog they just opened. Focus goes to the first
+    // interactive element in the *body* instead, and never to a footer
+    // action, which is where destructive buttons live.
+    initialFocus: () => {
+      const candidate = bodyRef.current?.querySelector<HTMLElement>(
+        'input:not([type="hidden"]), select, textarea, [href], button, [tabindex]:not([tabindex="-1"])'
+      );
+      return candidate ?? dialogRef.current ?? undefined;
+    },
+
+    // A dialog of pure prose has no tabbable node at all, and focus-trap
+    // throws rather than silently doing nothing. The dialog itself carries
+    // tabIndex={-1} so there is always somewhere legitimate for focus to
+    // rest — which is also what a screen reader wants, since it puts the
+    // reading cursor at the dialog's accessible name.
+    fallbackFocus: () => dialogRef.current ?? document.body,
+
+    escapeDeactivates: false, // Handled explicitly so `dismissible` is honoured.
+    returnFocusOnDeactivate: true, // The trigger regains focus on close.
+    allowOutsideClick: true,
+
+    tabbableOptions: {
+      // `tabbable` decides visibility from layout boxes, and jsdom performs no
+      // layout, so under test every node looks hidden and the trap refuses to
+      // activate. Production keeps the real check.
+      displayCheck: (process.env.NODE_ENV === "test" ? "none" : "full") as
+        | "none"
+        | "full",
+    },
+  };
+}
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Becomes the dialog's accessible name. Required — an unnamed dialog is unusable. */
+  title: string;
+  /** Optional second line, linked as the accessible description. */
+  description?: string;
+  children: ReactNode;
+  /** Right-aligned actions. Order is [Cancel] [Confirm]. */
+  footer?: ReactNode;
+  /** Secondary text pinned to the footer's left. */
+  footerLead?: ReactNode;
+  size?: "sm" | "md" | "lg";
+  /**
+   * Blocks closing by Escape and scrim click. Use only when abandoning would
+   * lose work, and always leave an explicit way out in the footer.
+   */
+  dismissible?: boolean;
+  className?: string;
+}
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  footerLead,
+  size = "md",
+  dismissible = true,
+  className,
+}: ModalProps) {
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descriptionId = description ? `${id}-desc` : undefined;
+
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const [scrolled, setScrolled] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  const depth = useStackDepth(open);
+  useBodyScrollLock(open);
+
+  // Portals need a DOM target, which does not exist during SSR.
+  useEffect(() => setMounted(true), []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Escape" && dismissible) {
+        event.stopPropagation();
+        onClose();
+      }
+    },
+    [dismissible, onClose]
+  );
+
+  if (!open || !mounted) return null;
+
+  return createPortal(
+    <div
+      className={cn(styles.scrim, depth > 0 && styles.scrimStacked)}
+      onKeyDown={handleKeyDown}
+      onMouseDown={(event) => {
+        // mousedown, not click: a click that *starts* inside the dialog and
+        // ends on the scrim — a text selection dragged past the edge — would
+        // otherwise close it and discard the user's work.
+        if (event.target === event.currentTarget && dismissible) onClose();
+      }}
+    >
+      <FocusTrap focusTrapOptions={focusTrapOptions(bodyRef, dialogRef)}>
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          tabIndex={-1}
+          className={cn(
+            styles.dialog,
+            styles[size],
+            depth > 0 && styles.stacked,
+            className
+          )}
+        >
+          <div className={cn(styles.header, scrolled && styles.headerScrolled)}>
+            <div className={styles.titleWrap}>
+              <h2 className={styles.title} id={titleId}>
+                {title}
+              </h2>
+              {description && (
+                <p className={styles.description} id={descriptionId}>
+                  {description}
+                </p>
+              )}
+            </div>
+            {dismissible && (
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                style={closeButtonStyle}
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                  <path
+                    d="M3.5 3.5l7 7M10.5 3.5l-7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
+
+          <div
+            className={styles.body}
+            ref={bodyRef}
+            onScroll={(event) => setScrolled(event.currentTarget.scrollTop > 0)}
+          >
+            {children}
+          </div>
+
+          {(footer || footerLead) && (
+            <div className={styles.footer}>
+              {footerLead && <div className={styles.footerLead}>{footerLead}</div>}
+              {footer}
+            </div>
+          )}
+        </div>
+      </FocusTrap>
+    </div>,
+    document.body
+  );
+}
+
+const closeButtonStyle: React.CSSProperties = {
+  flex: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 28,
+  height: 28,
+  padding: 0,
+  border: "none",
+  background: "none",
+  borderRadius: "var(--ds-radius-md)",
+  color: "var(--ds-content-tertiary)",
+  cursor: "pointer",
+};
+
+/* ==========================================================================
+ * Drawer
+ * ========================================================================*/
+
+export interface DrawerProps extends Omit<ModalProps, "size"> {
+  width?: "default" | "wide";
+}
+
+/**
+ * A side panel for content a modal should not hold — a long form, a data
+ * table, a nested tab set. Below 640px it becomes a bottom sheet, because a
+ * side drawer on a phone leaves no room for what it is showing.
+ *
+ * Same dialog semantics as Modal; the difference is placement and the fact
+ * that it may legitimately scroll a lot of content.
+ */
+export function Drawer({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  footerLead,
+  width = "default",
+  dismissible = true,
+  className,
+}: DrawerProps) {
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descriptionId = description ? `${id}-desc` : undefined;
+
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useBodyScrollLock(open);
+  useEffect(() => setMounted(true), []);
+
+  if (!open || !mounted) return null;
+
+  return createPortal(
+    <div
+      className={styles.drawerScrim}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && dismissible) {
+          event.stopPropagation();
+          onClose();
+        }
+      }}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && dismissible) onClose();
+      }}
+    >
+      <FocusTrap focusTrapOptions={focusTrapOptions(bodyRef, dialogRef)}>
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          tabIndex={-1}
+          className={cn(styles.drawer, width === "wide" && styles.drawerWide, className)}
+        >
+          <div className={styles.header}>
+            <div className={styles.titleWrap}>
+              <h2 className={styles.title} id={titleId}>
+                {title}
+              </h2>
+              {description && (
+                <p className={styles.description} id={descriptionId}>
+                  {description}
+                </p>
+              )}
+            </div>
+            {dismissible && (
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                style={closeButtonStyle}
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                  <path
+                    d="M3.5 3.5l7 7M10.5 3.5l-7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
+
+          <div className={styles.body} ref={bodyRef}>
+            {children}
+          </div>
+
+          {(footer || footerLead) && (
+            <div className={styles.footer}>
+              {footerLead && <div className={styles.footerLead}>{footerLead}</div>}
+              {footer}
+            </div>
+          )}
+        </div>
+      </FocusTrap>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/ds/__tests__/Choice.test.tsx
+++ b/src/components/ds/__tests__/Choice.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Choice controls — semantics that hand-rolled versions usually lose.
+ *
+ * Each of these keeps a real `<input>` under the visual control. The point of
+ * these tests is that the platform semantics survive: role, checked state,
+ * keyboard operation, and grouping.
+ */
+
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Checkbox, Radio, Toggle, ChoiceGroup } from "../Choice";
+
+describe("Checkbox", () => {
+  test("it is a real checkbox with the label as its name", () => {
+    render(<Checkbox label="Include weekends" />);
+    expect(screen.getByRole("checkbox", { name: "Include weekends" })).toBeInTheDocument();
+  });
+
+  test("it toggles by click and by keyboard", async () => {
+    render(<Checkbox label="Include weekends" />);
+    const box = screen.getByRole("checkbox", { name: "Include weekends" });
+
+    await userEvent.click(box);
+    expect(box).toBeChecked();
+
+    // Space is the platform binding; losing it is the classic cost of
+    // replacing the input with a styled div.
+    await userEvent.keyboard(" ");
+    expect(box).not.toBeChecked();
+  });
+
+  test("indeterminate is set on the DOM property, which has no attribute", () => {
+    render(<Checkbox label="Select all" indeterminate />);
+    const box = screen.getByRole("checkbox", { name: "Select all" }) as HTMLInputElement;
+
+    expect(box.indeterminate).toBe(true);
+    expect(box).toBePartiallyChecked();
+  });
+
+  test("a description is linked to the control", () => {
+    render(<Checkbox label="Select all" description="3 of 12 tasks selected" />);
+    expect(screen.getByRole("checkbox")).toHaveAccessibleDescription(
+      "3 of 12 tasks selected"
+    );
+  });
+
+  test("read-only blocks the change but keeps the control reachable", async () => {
+    render(<Checkbox label="Accept the rate card" readOnly defaultChecked />);
+    const box = screen.getByRole("checkbox");
+
+    expect(box).not.toBeDisabled();
+    await userEvent.click(box);
+    expect(box).toBeChecked();
+  });
+
+  test("disabled blocks the change", async () => {
+    render(<Checkbox label="Accept the rate card" disabled />);
+    const box = screen.getByRole("checkbox");
+
+    await userEvent.click(box);
+    expect(box).not.toBeChecked();
+  });
+
+  test("error is announced, not only coloured", () => {
+    render(<Checkbox label="Accept the rate card" error />);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-invalid", "true");
+  });
+});
+
+describe("Radio", () => {
+  test("radios in a group are mutually exclusive", async () => {
+    render(
+      <ChoiceGroup legend="Pricing model">
+        <Radio name="pricing" label="Fixed price" value="fixed" />
+        <Radio name="pricing" label="Time and materials" value="tm" />
+      </ChoiceGroup>
+    );
+
+    await userEvent.click(screen.getByRole("radio", { name: "Time and materials" }));
+    expect(screen.getByRole("radio", { name: "Time and materials" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Fixed price" })).not.toBeChecked();
+  });
+
+  test("arrow keys move between radios — platform behaviour, kept", async () => {
+    render(
+      <ChoiceGroup legend="Pricing model">
+        <Radio name="pricing" label="Fixed price" value="fixed" defaultChecked />
+        <Radio name="pricing" label="Time and materials" value="tm" />
+      </ChoiceGroup>
+    );
+
+    screen.getByRole("radio", { name: "Fixed price" }).focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(screen.getByRole("radio", { name: "Time and materials" })).toBeChecked();
+  });
+
+  test("a radio carries no aria-invalid — the role does not support it", () => {
+    render(
+      <ChoiceGroup legend="Pricing model" error="Choose a pricing model.">
+        <Radio name="pricing" label="Fixed price" value="fixed" error />
+      </ChoiceGroup>
+    );
+
+    expect(screen.getByRole("radio")).not.toHaveAttribute("aria-invalid");
+  });
+});
+
+describe("ChoiceGroup", () => {
+  test("the legend names the group, so a radio is not announced context-free", () => {
+    render(
+      <ChoiceGroup legend="Pricing model">
+        <Radio name="pricing" label="Fixed price" value="fixed" />
+      </ChoiceGroup>
+    );
+
+    expect(screen.getByRole("group", { name: "Pricing model" })).toBeInTheDocument();
+  });
+
+  test("group-level validity lives on the group, where radios can carry it", () => {
+    render(
+      <ChoiceGroup legend="Pricing model" error="Choose a pricing model.">
+        <Radio name="pricing" label="Fixed price" value="fixed" />
+      </ChoiceGroup>
+    );
+
+    const group = screen.getByRole("group", { name: "Pricing model" });
+    expect(group).toHaveAttribute("aria-invalid", "true");
+    expect(group).toHaveAccessibleDescription("Choose a pricing model.");
+  });
+
+  test("the error replaces the helper rather than stacking", () => {
+    render(
+      <ChoiceGroup legend="Pricing model" helper="Affects the proposal." error="Required.">
+        <Radio name="pricing" label="Fixed price" value="fixed" />
+      </ChoiceGroup>
+    );
+
+    expect(screen.queryByText("Affects the proposal.")).not.toBeInTheDocument();
+    expect(screen.getByText("Required.")).toBeInTheDocument();
+  });
+});
+
+describe("Toggle", () => {
+  test("it is a switch, so it announces on/off rather than checked", () => {
+    render(<Toggle label="Email notifications" />);
+    expect(screen.getByRole("switch", { name: "Email notifications" })).toBeInTheDocument();
+  });
+
+  test("it flips", async () => {
+    const onChange = vi.fn();
+    render(<Toggle label="Email notifications" onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).toBeChecked();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("pending is announced as busy, distinct from on", () => {
+    // A toggle commits immediately with no Save to press, so an unconfirmed
+    // change must not present itself as done.
+    render(<Toggle label="Email notifications" checked pending onChange={() => {}} />);
+    const control = screen.getByRole("switch");
+
+    expect(control).toHaveAttribute("aria-busy", "true");
+    expect(control).toBeChecked();
+  });
+
+  test("a hidden label is still the accessible name", () => {
+    render(<Toggle label="Email notifications" hideLabel />);
+    expect(screen.getByRole("switch", { name: "Email notifications" })).toBeInTheDocument();
+  });
+
+  test("read-only blocks the flip", async () => {
+    render(<Toggle label="Email notifications" readOnly defaultChecked />);
+    await userEvent.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+});

--- a/src/components/ds/__tests__/DataTable.test.tsx
+++ b/src/components/ds/__tests__/DataTable.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * DataTable — the semantics a div-grid loses.
+ */
+
+import React, { useState } from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DataTable, type Column } from "../DataTable";
+
+interface Consultant {
+  id: string;
+  name: string;
+  rate: number;
+}
+
+const ROWS: Consultant[] = [
+  { id: "a", name: "Ada Lovelace", rate: 1240 },
+  { id: "b", name: "Grace Hopper", rate: 1180 },
+  { id: "c", name: "Alan Turing", rate: 1310 },
+];
+
+const COLUMNS: Column<Consultant>[] = [
+  { key: "name", header: "Name", sortable: true, render: (r) => r.name },
+  { key: "rate", header: "Day rate", numeric: true, sortable: true, render: (r) => r.rate },
+];
+
+function Basic(props: Partial<React.ComponentProps<typeof DataTable<Consultant>>>) {
+  return (
+    <DataTable
+      caption="Consultants and day rates"
+      columns={COLUMNS}
+      rows={ROWS}
+      rowKey={(r) => r.id}
+      {...props}
+    />
+  );
+}
+
+describe("table semantics", () => {
+  test("it is a real table with an accessible name", () => {
+    render(<Basic />);
+    expect(screen.getByRole("table", { name: "Consultants and day rates" })).toBeInTheDocument();
+  });
+
+  test("headers are column headers, so cells are announced with them", () => {
+    render(<Basic />);
+    const headers = screen.getAllByRole("columnheader");
+
+    expect(headers.map((h) => h.textContent)).toEqual(["Name", "Day rate"]);
+    headers.forEach((header) => expect(header).toHaveAttribute("scope", "col"));
+  });
+
+  test("every row renders", () => {
+    render(<Basic />);
+    // 3 data rows + 1 header row.
+    expect(screen.getAllByRole("row")).toHaveLength(4);
+  });
+});
+
+describe("sorting", () => {
+  test("a sortable column announces that it can be sorted", () => {
+    render(<Basic onSort={() => {}} />);
+    expect(screen.getByRole("columnheader", { name: /Name/ })).toHaveAttribute(
+      "aria-sort",
+      "none"
+    );
+  });
+
+  test("the sorted column reports its direction", () => {
+    render(<Basic onSort={() => {}} sortKey="rate" sortDirection="desc" />);
+
+    expect(screen.getByRole("columnheader", { name: /Day rate/ })).toHaveAttribute(
+      "aria-sort",
+      "descending"
+    );
+    expect(screen.getByRole("columnheader", { name: /Name/ })).toHaveAttribute(
+      "aria-sort",
+      "none"
+    );
+  });
+
+  test("clicking a header sorts ascending, then toggles", async () => {
+    const onSort = vi.fn();
+    const { rerender } = render(<Basic onSort={onSort} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Name/ }));
+    expect(onSort).toHaveBeenCalledWith("name", "asc");
+
+    rerender(<Basic onSort={onSort} sortKey="name" sortDirection="asc" />);
+    await userEvent.click(screen.getByRole("button", { name: /Name/ }));
+    expect(onSort).toHaveBeenLastCalledWith("name", "desc");
+  });
+
+  test("a non-sortable column has no sort affordance", () => {
+    render(
+      <DataTable
+        caption="Consultants"
+        columns={[{ key: "name", header: "Name", render: (r: Consultant) => r.name }]}
+        rows={ROWS}
+        rowKey={(r) => r.id}
+        onSort={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Name" })).not.toHaveAttribute("aria-sort");
+    expect(screen.queryByRole("button", { name: /Name/ })).not.toBeInTheDocument();
+  });
+});
+
+describe("selection", () => {
+  function Selectable() {
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    return (
+      <Basic
+        selectedKeys={selected}
+        onSelectionChange={setSelected}
+        toolbar={<span>Filters</span>}
+        bulkActions={<button type="button">Delete</button>}
+      />
+    );
+  }
+
+  test("the header checkbox states the real scope of 'select all'", () => {
+    render(<Selectable />);
+    // "Select all" over a paginated set is a promise the table cannot keep.
+    expect(
+      screen.getByRole("checkbox", { name: "Select all 3 rows on this page" })
+    ).toBeInTheDocument();
+  });
+
+  test("selecting all on the page checks every row", async () => {
+    render(<Selectable />);
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Select all 3 rows on this page" })
+    );
+
+    const rowBoxes = screen.getAllByRole("checkbox").slice(1);
+    rowBoxes.forEach((box) => expect(box).toBeChecked());
+  });
+
+  test("a partial selection shows the header checkbox as indeterminate", async () => {
+    render(<Selectable />);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select row a" }));
+    expect(
+      screen.getByRole("checkbox", { name: "Select all 3 rows on this page" })
+    ).toBePartiallyChecked();
+  });
+
+  test("the bulk bar replaces the toolbar rather than stacking under it", async () => {
+    render(<Selectable />);
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select row a" }));
+
+    // The table must not lose vertical space when a row is selected.
+    expect(screen.queryByText("Filters")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  test("the selected count is announced politely", async () => {
+    render(<Selectable />);
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select row a" }));
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("1 selected");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
+  test("a selected row is marked as such", async () => {
+    render(<Selectable />);
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select row a" }));
+
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveAttribute("aria-selected", "true");
+    expect(rows[1]).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("without a selection handler there is no checkbox column", () => {
+    render(<Basic />);
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+});
+
+describe("empty state", () => {
+  test("it renders inside the body, leaving the header operational", () => {
+    render(
+      <Basic
+        rows={[]}
+        toolbar={<button type="button">Clear filters</button>}
+        emptyState={<p>No consultants match these filters</p>}
+      />
+    );
+
+    expect(screen.getByText("No consultants match these filters")).toBeInTheDocument();
+    // The user must still be able to undo the filter that emptied the table.
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeInTheDocument();
+    expect(screen.getAllByRole("columnheader")).toHaveLength(2);
+  });
+});
+
+describe("figures", () => {
+  test("numeric cells are right-aligned via a class, not inline style", () => {
+    render(<Basic />);
+    const firstRow = screen.getAllByRole("row")[1];
+    const cells = within(firstRow).getAllByRole("cell");
+
+    // Column 2 is the rate. Its class carries the tabular-figure treatment so
+    // digits line up between rows.
+    expect(cells[1].className).toMatch(/cellNumeric/);
+  });
+});
+
+describe("loading", () => {
+  test("the body reports busy", () => {
+    const { container } = render(<Basic loading />);
+    expect(container.querySelector("tbody")).toHaveAttribute("aria-busy", "true");
+  });
+});

--- a/src/components/ds/__tests__/Display.test.tsx
+++ b/src/components/ds/__tests__/Display.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Display primitives — principle P4, enforced.
+ *
+ * "Colour is the second channel." These assert that status, counts and
+ * progress each carry a non-colour signal, so the interface survives a
+ * projector, a monochrome printout, and any colour-vision deficiency.
+ */
+
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StatusPill, Badge, Chip, Avatar, Progress, Skeleton } from "../Display";
+
+describe("StatusPill carries a word, not only a colour", () => {
+  test.each([
+    ["success", "On track"],
+    ["warning", "At risk"],
+    ["danger", "Late"],
+    ["info", "Baseline"],
+    ["neutral", "Not started"],
+  ] as const)("%s renders its label as text", (tone, label) => {
+    render(<StatusPill tone={tone}>{label}</StatusPill>);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  test("the glyph is decorative, so it does not pollute the accessible name", () => {
+    const { container } = render(<StatusPill tone="danger">Late</StatusPill>);
+    const svg = container.querySelector("svg");
+
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    // The word carries the meaning; the glyph is the redundant second channel.
+    expect(container.textContent).toBe("Late");
+  });
+});
+
+describe("Badge", () => {
+  test("a bare number is given meaning in its accessible name", () => {
+    // "3" alone tells a screen-reader user nothing.
+    render(<Badge count={3} label="pending approvals" />);
+    expect(screen.getByLabelText("3 pending approvals")).toBeInTheDocument();
+  });
+
+  test("counts above the cap render as N+ but announce the true figure", () => {
+    render(<Badge count={250} max={99} label="notifications" />);
+
+    expect(screen.getByText("99+")).toBeInTheDocument();
+    expect(screen.getByLabelText("250 notifications")).toBeInTheDocument();
+  });
+});
+
+describe("Chip", () => {
+  test("a static chip has no remove control", () => {
+    render(<Chip>EMEA</Chip>);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test("removal names what it removes", async () => {
+    const onRemove = vi.fn();
+    render(
+      <Chip onRemove={onRemove} removeLabel="EMEA">
+        EMEA
+      </Chip>
+    );
+
+    // "Remove" alone is useless in a row of eight filter chips.
+    await userEvent.click(screen.getByRole("button", { name: "Remove EMEA" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Avatar", () => {
+  test("initials come from the first and last name", () => {
+    render(<Avatar name="Ada Lovelace" />);
+    expect(screen.getByRole("img", { name: "Ada Lovelace" })).toHaveTextContent("AL");
+  });
+
+  test("a single name yields one initial", () => {
+    render(<Avatar name="Ada" />);
+    expect(screen.getByRole("img", { name: "Ada" })).toHaveTextContent("A");
+  });
+
+  test("a three-part name still uses first and last", () => {
+    render(<Avatar name="Ada King Lovelace" />);
+    expect(screen.getByRole("img", { name: "Ada King Lovelace" })).toHaveTextContent("AL");
+  });
+
+  test("the name is the accessible name whether or not there is a photo", () => {
+    render(<Avatar name="Ada Lovelace" src="/ada.png" />);
+    expect(screen.getByRole("img", { name: "Ada Lovelace" })).toBeInTheDocument();
+  });
+});
+
+describe("Progress", () => {
+  test("it reports its value, not just its width", () => {
+    render(<Progress value={62} label="Realize phase" />);
+    const bar = screen.getByRole("progressbar", { name: "Realize phase" });
+
+    expect(bar).toHaveAttribute("aria-valuenow", "62");
+    expect(bar).toHaveAttribute("aria-valuetext", "62%");
+  });
+
+  test("the figure is printed, so the bar is readable on a projector", () => {
+    render(<Progress value={62} label="Realize phase" />);
+    expect(screen.getByText("62%")).toBeInTheDocument();
+  });
+
+  test("over-allocation is reported truthfully rather than clamped away", () => {
+    // 120% is a staffing escalation. Reporting it as 100% would hide the very
+    // thing the bar exists to surface.
+    render(<Progress value={120} label="Consultant A" />);
+    const bar = screen.getByRole("progressbar", { name: "Consultant A" });
+
+    expect(bar).toHaveAttribute("aria-valuenow", "120");
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+    expect(screen.getByText("120%")).toBeInTheDocument();
+  });
+
+  test("a negative value does not render a backwards bar", () => {
+    render(<Progress value={-10} label="Consultant A" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "-10");
+  });
+});
+
+describe("Skeleton", () => {
+  test("it is hidden from assistive technology", () => {
+    // A dozen announced empty boxes tell a screen-reader user nothing; the
+    // surrounding region carries aria-busy instead.
+    const { container } = render(<Skeleton width={120} height={12} />);
+    expect(container.firstElementChild).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/components/ds/__tests__/Feedback.test.tsx
+++ b/src/components/ds/__tests__/Feedback.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Feedback composites — the announcement behaviour, which is the part that
+ * silently fails in production and never shows up in a screenshot.
+ */
+
+import React from "react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EmptyState, Banner, ToastProvider, useToast } from "../Feedback";
+
+describe("EmptyState", () => {
+  test("first-run is a status, not an alert — nothing is wrong", () => {
+    render(
+      <EmptyState
+        kind="first-run"
+        title="Build the timeline"
+        body="Start with the five SAP Activate phases."
+      />
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  test("an error is an alert, because the user is blocked", () => {
+    render(
+      <EmptyState
+        kind="error"
+        title="The plan could not be loaded"
+        body="The server did not respond within 30 seconds."
+        reference="PRJ-2291 / 14:32"
+      />
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  test("an error shows its support reference", () => {
+    render(
+      <EmptyState
+        kind="error"
+        title="The plan could not be loaded"
+        body="Your local copy is intact."
+        reference="PRJ-2291 / 14:32"
+      />
+    );
+
+    // Without it, a support conversation starts with "which one?".
+    expect(screen.getByText("PRJ-2291 / 14:32")).toBeInTheDocument();
+  });
+
+  test("the heading and explanation are both rendered", () => {
+    render(
+      <EmptyState
+        kind="no-results"
+        title="No tasks match these filters"
+        body="3 filters are active. Removing the allocation filter would show 46 tasks."
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "No tasks match these filters" })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/would show 46 tasks/)).toBeInTheDocument();
+  });
+
+  test("actions render", () => {
+    render(
+      <EmptyState
+        kind="no-results"
+        title="No tasks match these filters"
+        body="3 filters are active."
+        primaryAction={<button type="button">Remove allocation filter</button>}
+        secondaryAction={<button type="button">Clear all filters</button>}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Remove allocation filter" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear all filters" })).toBeInTheDocument();
+  });
+});
+
+describe("Banner", () => {
+  test("danger is an alert; the rest are statuses", () => {
+    const { rerender } = render(<Banner tone="danger" title="Sync failed" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    rerender(<Banner tone="info" title="Viewing a baseline" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  test("dismissal names what is being dismissed", async () => {
+    const onDismiss = vi.fn();
+    render(<Banner tone="info" title="Viewing a baseline" onDismiss={onDismiss} />);
+
+    // "Dismiss" alone is ambiguous when three banners are stacked.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss: Viewing a baseline" })
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("a banner without onDismiss cannot be dismissed", () => {
+    render(<Banner tone="warning" title="Over-allocated" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("Toast", () => {
+  function Harness() {
+    const { show } = useToast();
+    return (
+      <>
+        <button type="button" onClick={() => show("Plan saved")}>
+          Save
+        </button>
+        <button type="button" onClick={() => show("Sync failed", { tone: "danger" })}>
+          Fail
+        </button>
+      </>
+    );
+  }
+
+  beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+  afterEach(() => vi.useRealTimers());
+
+  test("the live region exists before any toast does", () => {
+    // Creating a live region at the moment a message arrives is the classic
+    // reason announcements are silently dropped — the region has to be in the
+    // DOM first for assistive technology to be watching it.
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toBeEmptyDOMElement();
+  });
+
+  test("a toast appears in the live region", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText("Plan saved")).toBeInTheDocument();
+  });
+
+  test("an ordinary toast auto-dismisses", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText("Plan saved")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5100);
+    });
+    expect(screen.queryByText("Plan saved")).not.toBeInTheDocument();
+  });
+
+  test("an error toast stays until dismissed", async () => {
+    // An error that vanishes on a timer is an error the user may never read.
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Fail" }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+    });
+    expect(screen.getByText("Sync failed")).toBeInTheDocument();
+  });
+
+  test("no more than three are visible at once", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    const save = screen.getByRole("button", { name: "Save" });
+    for (let i = 0; i < 5; i++) await user.click(save);
+
+    expect(screen.getAllByText("Plan saved")).toHaveLength(3);
+  });
+
+  test("useToast outside a provider fails loudly", () => {
+    // A silent no-op here would mean a save confirmation that never appears
+    // and no indication why.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Harness />)).toThrow(/ToastProvider/);
+    spy.mockRestore();
+  });
+});

--- a/src/components/ds/__tests__/Field.test.tsx
+++ b/src/components/ds/__tests__/Field.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Field family — the accessibility contract.
+ *
+ * These assert the wiring that makes a form usable without sight: the label
+ * names the control, the helper and error text are *linked* to it rather than
+ * merely adjacent, and invalidity is announced rather than only painted red.
+ */
+
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Input, Textarea, NumberInput, SearchInput, Select } from "../Field";
+
+describe("labels name their control", () => {
+  test.each([
+    ["Input", <Input key="i" label="Task name" />],
+    ["Textarea", <Textarea key="t" label="Task name" />],
+    ["NumberInput", <NumberInput key="n" label="Task name" />],
+    [
+      "Select",
+      <Select key="s" label="Task name">
+        <option>A</option>
+      </Select>,
+    ],
+  ])("%s is reachable by its label text", (_name, element) => {
+    render(element);
+    expect(screen.getByLabelText(/Task name/)).toBeInTheDocument();
+  });
+
+  test("clicking the label focuses the control", async () => {
+    render(<Input label="Task name" />);
+    await userEvent.click(screen.getByText(/Task name/));
+    expect(screen.getByLabelText(/Task name/)).toHaveFocus();
+  });
+});
+
+describe("helper and error text are linked, not merely adjacent", () => {
+  test("helper text is announced with the field", () => {
+    render(<Input label="Task name" helper="Shown in the Gantt tree." />);
+    expect(screen.getByLabelText(/Task name/)).toHaveAccessibleDescription(
+      "Shown in the Gantt tree."
+    );
+  });
+
+  test("error text replaces the helper as the description", () => {
+    render(
+      <Input label="Task name" helper="Shown in the Gantt tree." error="Task name is required." />
+    );
+
+    const input = screen.getByLabelText(/Task name/);
+    expect(input).toHaveAccessibleDescription("Task name is required.");
+    // One line, not two — a validating form must not grow and push the next
+    // field down the page.
+    expect(screen.queryByText("Shown in the Gantt tree.")).not.toBeInTheDocument();
+  });
+
+  test("an invalid field says so, rather than only looking red", () => {
+    render(<Input label="Task name" error="Task name is required." />);
+    expect(screen.getByLabelText(/Task name/)).toHaveAttribute("aria-invalid", "true");
+  });
+
+  test("a valid field is not marked invalid", () => {
+    render(<Input label="Task name" helper="Optional guidance" />);
+    expect(screen.getByLabelText(/Task name/)).not.toHaveAttribute("aria-invalid");
+  });
+});
+
+describe("read-only and disabled are different states", () => {
+  test("read-only keeps the value editable-looking but not editable", async () => {
+    render(<Input label="Rate" readOnly defaultValue="1200" />);
+    const input = screen.getByLabelText("Rate");
+
+    expect(input).toHaveAttribute("readonly");
+    expect(input).not.toBeDisabled();
+
+    await userEvent.type(input, "999");
+    expect(input).toHaveValue("1200");
+  });
+
+  test("read-only stays focusable, so it can still be read and copied", async () => {
+    render(<Input label="Rate" readOnly defaultValue="1200" />);
+    await userEvent.tab();
+    expect(screen.getByLabelText("Rate")).toHaveFocus();
+  });
+
+  test("disabled is genuinely disabled", () => {
+    render(<Input label="Rate" disabled />);
+    expect(screen.getByLabelText("Rate")).toBeDisabled();
+  });
+});
+
+describe("required", () => {
+  test("required is announced, not just marked with an asterisk", () => {
+    render(<Input label="Task name" required />);
+    expect(screen.getByLabelText(/Task name/)).toBeRequired();
+  });
+});
+
+describe("NumberInput", () => {
+  test("the steppers change the value and notify React", async () => {
+    const onChange = vi.fn();
+    render(<NumberInput label="Allocation" defaultValue={50} step={5} onChange={onChange} />);
+
+    // The steppers are aria-hidden, so query by DOM rather than role — that
+    // is the point of the test: they must not add tab stops.
+    const buttons = document.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
+
+    await userEvent.click(buttons[0]);
+    expect(screen.getByLabelText("Allocation")).toHaveValue(55);
+  });
+
+  test("the steppers add no tab stops", async () => {
+    render(<NumberInput label="Allocation" defaultValue={50} />);
+
+    await userEvent.tab();
+    expect(screen.getByLabelText("Allocation")).toHaveFocus();
+
+    // Tabbing again must leave the field entirely rather than landing on a
+    // stepper — a table of numeric cells would otherwise triple its tab stops.
+    await userEvent.tab();
+    expect(screen.getByLabelText("Allocation")).not.toHaveFocus();
+  });
+
+  test("the preconditions for browser arrow-key stepping are present", () => {
+    // The steppers are deliberately aria-hidden and out of the tab order
+    // because a native number input already steps on ArrowUp/ArrowDown. That
+    // stepping is implemented by the browser, and jsdom does not emulate it —
+    // asserting the value changes here would only prove jsdom's behaviour, not
+    // a user's. So this asserts the preconditions that make browsers do it,
+    // and the keystroke itself belongs in the Playwright suite.
+    render(<NumberInput label="Allocation" defaultValue={50} step={5} />);
+    const input = screen.getByLabelText("Allocation");
+
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("step", "5");
+    expect(input).not.toBeDisabled();
+    expect(input).not.toHaveAttribute("readonly");
+  });
+
+  test("a read-only number cannot be stepped", async () => {
+    render(<NumberInput label="Allocation" defaultValue={50} readOnly />);
+    const buttons = document.querySelectorAll("button");
+
+    await userEvent.click(buttons[0]);
+    expect(screen.getByLabelText("Allocation")).toHaveValue(50);
+  });
+});
+
+describe("SearchInput", () => {
+  test("the clear button appears only when there is something to clear", () => {
+    const { rerender } = render(
+      <SearchInput label="Search" value="" onChange={() => {}} onClear={() => {}} />
+    );
+    expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+
+    rerender(<SearchInput label="Search" value="rate" onChange={() => {}} onClear={() => {}} />);
+    expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+  });
+
+  test("clearing calls back", async () => {
+    const onClear = vi.fn();
+    render(<SearchInput label="Search" value="rate" onChange={() => {}} onClear={onClear} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  test("it is exposed as a searchbox", () => {
+    render(<SearchInput label="Search" value="" onChange={() => {}} />);
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  });
+});
+
+describe("Select", () => {
+  test("it is a native select, so it keeps platform keyboard and type-ahead", async () => {
+    render(
+      <Select label="Region">
+        <option value="emea">EMEA</option>
+        <option value="apac">APAC</option>
+      </Select>
+    );
+
+    const select = screen.getByLabelText("Region");
+    expect(select.tagName).toBe("SELECT");
+
+    await userEvent.selectOptions(select, "apac");
+    expect(select).toHaveValue("apac");
+  });
+});
+
+describe("adornments sit inside the field", () => {
+  test("a prefix does not become a separate focusable control", async () => {
+    render(<Input label="Rate" prefix="MYR" defaultValue="2400" />);
+
+    expect(screen.getByText("MYR")).toBeInTheDocument();
+    await userEvent.tab();
+    expect(screen.getByLabelText("Rate")).toHaveFocus();
+    await userEvent.tab();
+    expect(screen.getByLabelText("Rate")).not.toHaveFocus();
+  });
+});

--- a/src/components/ds/__tests__/Modal.test.tsx
+++ b/src/components/ds/__tests__/Modal.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Modal and Drawer — the guarantees BaseModal claimed and did not have.
+ *
+ * `A11Y_EVIDENCE.md` stated that the dialog carried role="dialog", aria-modal
+ * and aria-labelledby, and trapped focus. It carried none of them, and passed
+ * `initialFocus: false` — telling focus-trap explicitly not to move focus in.
+ * The suite that was supposed to catch this asserted HTML strings, which could
+ * not, and could not have even if written correctly, because getByRole was
+ * broken repo-wide.
+ *
+ * These drive the rendered component.
+ */
+
+import React, { useState } from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Modal, Drawer } from "../Modal";
+
+function Basic({
+  onClose = () => {},
+  ...props
+}: Partial<React.ComponentProps<typeof Modal>>) {
+  return (
+    <Modal open title="Delete phase" onClose={onClose} {...props}>
+      <p>This removes Realize and its 24 tasks.</p>
+      <input aria-label="Confirm phase name" />
+    </Modal>
+  );
+}
+
+describe("dialog semantics", () => {
+  test("it is a dialog", () => {
+    render(<Basic />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  test("it is modal", () => {
+    render(<Basic />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  test("the title is the accessible name", () => {
+    render(<Basic />);
+    expect(screen.getByRole("dialog", { name: "Delete phase" })).toBeInTheDocument();
+  });
+
+  test("the description is linked when present", () => {
+    render(<Basic description="This cannot be undone." />);
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
+      "This cannot be undone."
+    );
+  });
+
+  test("closed renders nothing", () => {
+    render(
+      <Modal open={false} title="Delete phase" onClose={() => {}}>
+        body
+      </Modal>
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("focus", () => {
+  test("focus moves into the dialog, not onto Close", async () => {
+    render(<Basic />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Confirm phase name")).toHaveFocus();
+    });
+    expect(screen.getByRole("button", { name: "Close" })).not.toHaveFocus();
+  });
+
+  test("content behind the dialog cannot be reached by Tab", async () => {
+    // The guarantee stated as a user would experience it: tabbing must never
+    // arrive at the page underneath.
+    //
+    // Not asserted as "activeElement is always inside the dialog" — under
+    // jsdom, userEvent.tab() computes the next tabbable itself and lands on
+    // <body> before focus-trap's handler pulls focus back, so that assertion
+    // would be measuring jsdom's tab emulation rather than the trap.
+    render(
+      <>
+        <button type="button">Behind the dialog</button>
+        <Basic />
+      </>
+    );
+
+    const background = screen.getByRole("button", { name: "Behind the dialog" });
+    await waitFor(() => expect(screen.getByLabelText("Confirm phase name")).toHaveFocus());
+
+    for (let i = 0; i < 8; i++) {
+      await userEvent.tab();
+      expect(background).not.toHaveFocus();
+    }
+
+    // And focus settles back inside rather than drifting away for good.
+    expect(screen.getByRole("dialog")).toContainElement(
+      document.activeElement as HTMLElement
+    );
+  });
+
+  test("the trigger regains focus when the dialog closes", async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <Modal open={open} title="Delete phase" onClose={() => setOpen(false)}>
+            <p>Body</p>
+          </Modal>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "Open" });
+
+    await userEvent.click(trigger);
+    await screen.findByRole("dialog");
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});
+
+describe("dismissal", () => {
+  test("Escape closes", async () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking the scrim closes", async () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+
+    // The dialog is portalled to <body>, so the scrim is found from the
+    // dialog upwards rather than by guessing at the document structure.
+    const scrim = screen.getByRole("dialog").closest("[class*='scrim']");
+    expect(scrim).not.toBeNull();
+
+    await userEvent.click(scrim as Element);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("a drag that starts inside and ends on the scrim does not close", async () => {
+    // Selecting text in the body and releasing past the edge must not discard
+    // the dialog. This is why dismissal is on mousedown, not click.
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+
+    const dialog = screen.getByRole("dialog");
+    const scrim = dialog.parentElement!.parentElement!;
+
+    await userEvent.pointer([
+      { target: dialog, keys: "[MouseLeft>]" },
+      { target: scrim },
+      { keys: "[/MouseLeft]" },
+    ]);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test("a non-dismissible dialog ignores Escape and has no Close button", async () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} dismissible={false} />);
+
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+  });
+});
+
+describe("page behind the dialog", () => {
+  test("the body cannot scroll while open", () => {
+    const { unmount } = render(<Basic />);
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+  });
+
+  test("scrolling is restored on close", async () => {
+    const { unmount } = render(<Basic />);
+    unmount();
+    await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
+  });
+
+  test("a stacked dialog does not unlock the page when it alone closes", async () => {
+    function Harness({ second }: { second: boolean }) {
+      return (
+        <>
+          <Modal open title="Parent" onClose={() => {}}>
+            <p>Parent body</p>
+          </Modal>
+          {second && (
+            <Modal open title="Child" onClose={() => {}}>
+              <p>Child body</p>
+            </Modal>
+          )}
+        </>
+      );
+    }
+
+    const { rerender } = render(<Harness second />);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender(<Harness second={false} />);
+    // The parent is still open, so the lock must survive.
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+});
+
+describe("footer", () => {
+  test("footer content renders", () => {
+    render(
+      <Basic
+        footer={
+          <>
+            <button type="button">Cancel</button>
+            <button type="button">Delete</button>
+          </>
+        }
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  test("focus does not land on a destructive footer action", async () => {
+    render(
+      <Modal
+        open
+        title="Delete phase"
+        onClose={() => {}}
+        footer={
+          <>
+            <button type="button">Cancel</button>
+            <button type="button">Delete phase</button>
+          </>
+        }
+      >
+        <p>This removes Realize and its 24 tasks.</p>
+      </Modal>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toContainElement(
+        document.activeElement as HTMLElement
+      );
+    });
+
+    // A prose-only body has no interactive element, so focus falls back to
+    // the dialog itself — which is what a screen reader wants, and crucially
+    // is not the destructive button.
+    expect(screen.getByRole("button", { name: "Delete phase" })).not.toHaveFocus();
+    expect(screen.getByRole("button", { name: "Close" })).not.toHaveFocus();
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+  });
+});
+
+describe("Drawer", () => {
+  test("it carries the same dialog semantics", () => {
+    render(
+      <Drawer open title="Task details" onClose={() => {}}>
+        <p>Body</p>
+      </Drawer>
+    );
+
+    const drawer = screen.getByRole("dialog", { name: "Task details" });
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+  });
+
+  test("Escape closes it", async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open title="Task details" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>
+    );
+
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ds/index.ts
+++ b/src/components/ds/index.ts
@@ -24,6 +24,26 @@ export type {
 export { Checkbox, Radio, Toggle, ChoiceGroup } from "./Choice";
 export type { CheckboxProps, RadioProps, ToggleProps, ChoiceGroupProps } from "./Choice";
 
+export {
+  AppShell,
+  PageHeader,
+  Card,
+  SyncChip,
+  RoleBadge,
+} from "./AppShell";
+export type {
+  AppShellProps,
+  PageHeaderProps,
+  CardProps,
+  NavItem,
+  SyncChipProps,
+  SyncState,
+  ProjectRole,
+} from "./AppShell";
+
+export { DataTable } from "./DataTable";
+export type { DataTableProps, Column, SortDirection } from "./DataTable";
+
 export { Modal, Drawer } from "./Modal";
 export type { ModalProps, DrawerProps } from "./Modal";
 

--- a/src/components/ds/index.ts
+++ b/src/components/ds/index.ts
@@ -24,6 +24,17 @@ export type {
 export { Checkbox, Radio, Toggle, ChoiceGroup } from "./Choice";
 export type { CheckboxProps, RadioProps, ToggleProps, ChoiceGroupProps } from "./Choice";
 
+export { Modal, Drawer } from "./Modal";
+export type { ModalProps, DrawerProps } from "./Modal";
+
+export { EmptyState, Banner, ToastProvider, useToast } from "./Feedback";
+export type {
+  EmptyStateProps,
+  BannerProps,
+  BannerTone,
+  ToastOptions,
+} from "./Feedback";
+
 export { StatusPill, Badge, Chip, Avatar, Progress, Skeleton } from "./Display";
 export type {
   StatusPillProps,

--- a/src/components/ds/index.ts
+++ b/src/components/ds/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Design system — public surface.
+ *
+ * Import from `@/components/ds` rather than reaching into individual files, so
+ * the internal layout can change without touching call sites.
+ *
+ * Layer 1 (tokens) lives in `src/styles/foundations.css` and is global.
+ * Wrap any subtree using these components in `.ds`.
+ */
+
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
+
+export { Input, Textarea, NumberInput, SearchInput, Select } from "./Field";
+export type {
+  InputProps,
+  TextareaProps,
+  NumberInputProps,
+  SearchInputProps,
+  SelectProps,
+  FieldSize,
+} from "./Field";
+
+export { Checkbox, Radio, Toggle, ChoiceGroup } from "./Choice";
+export type { CheckboxProps, RadioProps, ToggleProps, ChoiceGroupProps } from "./Choice";
+
+export { StatusPill, Badge, Chip, Avatar, Progress, Skeleton } from "./Display";
+export type {
+  StatusPillProps,
+  StatusTone,
+  BadgeProps,
+  ChipProps,
+  AvatarProps,
+  ProgressProps,
+  SkeletonProps,
+} from "./Display";


### PR DESCRIPTION
Builds the component layers the route migration needs, on top of the layer-1 tokens merged in #107.

**Still deliberately invisible.** No route imports any of this yet, so production looks identical after merge. The visible change happens when routes migrate — see "What is not in this change".

## Layer 2 — primitives

Input, Textarea, NumberInput, SearchInput, Select, Checkbox, Radio, Toggle, ChoiceGroup, StatusPill, Badge, Chip, Avatar, Progress, Skeleton. All read only `--ds-` tokens, so both themes come free and no hex appears in a component.

**One accessibility contract, shared.** The field family lives in one module so its five members cannot drift apart: each associates its label through `htmlFor`/`id`, links helper *and* error text via `aria-describedby`, sets `aria-invalid` when invalid, and reuses one line for helper and error so validating a form never grows the layout and pushes the next field down.

Read-only keeps text at `content/primary` — the value is real, and greying it would suggest it is missing. It also stays focusable, so it can still be read and copied, which is why it is not implemented with `disabled`.

**Platform semantics kept rather than reimplemented.** Checkbox, Radio and Toggle keep a real `<input>` at `opacity: 0` under the visual control instead of a styled div with `role="checkbox"`. That preserves keyboard operation, form participation, name/value pairing and the radio group's arrow-key behaviour — the parts hand-rolled versions lose. Select is a native `<select>` for the same reason.

Toggle is `role="switch"`, so it announces on/off rather than checked/unchecked, and has a distinct `pending` state: it commits immediately with no Save to press, so an unconfirmed change must not present itself as done.

**Colour is never the only channel.** Every status pill carries a glyph and a word. Progress prints its figure and reports `aria-valuetext`; over-allocation adds a diagonal hatch rather than just turning red — 120% is a staffing escalation, and reporting it as 100% would hide the thing the bar exists to surface.

## Layer 3 — composites

Modal, Drawer, EmptyState, Banner, Toast, AppShell, DataTable.

**Modal** replaces the dialog primitive that shipped to 28 dialogs with no `role="dialog"`, no `aria-modal`, no `aria-labelledby`, and `initialFocus: false` — which tells focus-trap explicitly *not* to move focus in — while `A11Y_EVIDENCE.md` claimed all four were present. Each is now asserted against the rendered component.

Initial focus goes to the first interactive element in the **body**, never the Close button (the default first-tabbable choice, which means the first thing a keyboard user can do is dismiss what they just opened) and never a footer action, where destructive buttons live.

**DataTable** is a real `<table>` with real `<th scope>`, because that is what lets a screen reader say "Day rate, 1,240" instead of "1,240". Sort is announced via `aria-sort` with an arrow as well as accent colour. The header checkbox is labelled "Select all N rows on this page", because "select all" over a paginated set is a promise the table cannot keep. The bulk bar *replaces* the toolbar rather than stacking beneath it, so selecting a row never shortens the table. Empty and error states render inside the table body, leaving header and toolbar operational so the user can undo the filter that emptied it.

**AppShell** keeps role and cost-visibility on screen at all times: permission changes what every control below it does, and a masked figure must be explainable from the same screen. The sync chip is on every authenticated screen and announces through a polite live region — local-first sync changes what the user sees without changing the layout, and silence about that is a correctness bug, not a polish issue. Its visible text abbreviates at narrow widths, so the full state lives in the accessible name where it cannot be truncated away.

**Toast**'s live region is mounted by the provider and persists across messages. Creating a region at the moment a message arrives is the classic reason announcements are silently dropped. An error toast does not auto-dismiss — an error that vanishes on a timer is one the user may never have read.

## Defects the tests caught before this shipped

- **A dialog whose body is pure prose crashes focus-trap** — there is no tabbable node at all, and it throws rather than degrading. Fixed with `tabIndex={-1}` on the dialog plus `fallbackFocus`, which is also what a screen reader wants: the reading cursor lands on the dialog's accessible name.
- **Dismissal had to move from `click` to `mousedown`.** A click that *starts* inside the dialog and ends on the scrim — a text selection dragged past the edge — would otherwise close it and discard the user's work.
- `prefix` is a global RDFa attribute typed as `string` in React's DOM types, and collided with the field adornment prop.
- `role="radio"` supports neither `aria-invalid` nor `aria-readonly`; validity belongs on the enclosing radiogroup.

## Two assertions deliberately weakened rather than faked

Both would have passed while proving nothing:

- **Browser arrow-key stepping on a number input** is not emulated by jsdom. The test asserts the preconditions and records that the keystroke belongs in the Playwright suite.
- **"Focus is trapped"** was asserting `activeElement` after each Tab, but `userEvent`'s jsdom tab emulation transiently lands on `<body>` before focus-trap pulls focus back — so it was measuring jsdom, not the trap. It now asserts the property a user experiences: background content is never reachable.

## Verified

| Gate | Result |
|---|---|
| `lint:strict` | PASS |
| `typecheck:strict` | PASS |
| `test` | PASS — 75 files, 1882 tests (up from 1773) |
| `test:coverage` | PASS — thresholds met |
| `build` | PASS — 76/76 pages |

The full `ci:strict` gate also ran via the `pre-push` hook before this branch was pushed.

## What is not in this change

**No route has been migrated.** The app still ships 19 routes, 3 layouts and ~33.7k LOC of legacy UI, and production will look unchanged after this merges.

Remaining, in the order I would take it:

1. **Layer 4 — domain surfaces**: Gantt, allocation matrix, org chart, cost, sync (32 gantt components alone)
2. **Route migration**: `/login` + `/register` first (small, self-contained, proves the pattern), then the six `/admin/*` routes (mostly tables, so `DataTable` does the work), then `/dashboard`, `/account`, `/settings/*`, and `/gantt-tool` last since it is largest and needs layer 4 first
3. **Delete the legacy UI** once nothing references it

Stopping short of partial route rewrites was deliberate: a half-migrated route ships two design systems on one screen, which is worse than an unmigrated one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_