### PR TITLE
Tier-1 remediation: un-skip the accessibility suites, add Playwright to CI, lock the delta route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,103 @@ jobs:
 
     - name: Performance budget check
       run: pnpm vitest run tests/performance/ --run
+
+  # End-to-end smoke tests against the PRODUCTION build.
+  #
+  # Runs in parallel with `validate` rather than after it: the two catch
+  # different classes of failure, and waiting would only delay the e2e signal
+  # without making it more reliable.
+  #
+  # SCOPE: this runs tests/e2e/smoke.spec.ts only, not the whole of tests/e2e.
+  # Measured against a production build, the rest of that directory is 9 passed
+  # / 51 failed / 39 skipped — plan-timeline.spec.ts is 15 placeholder skips,
+  # team-capacity-api.spec.ts needs a seeded database, and the visual and
+  # user-journey specs navigate to /projects and /projects/new, which are not
+  # routes in this app. They assert a UI that does not exist here, so adding
+  # them would mean a permanently red required check. They stay in the tree and
+  # are tracked in docs/REMEDIATION.md; scoping the gate is stated here rather
+  # than hidden behind more skips.
+  #
+  # The smoke spec runs in about 3 seconds and sweeps every route in the app
+  # against the auth boundary. A slow required check is one people learn to
+  # ignore, which is how an e2e suite becomes decorative.
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cockpit_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d cockpit_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/cockpit_ci"
+      DATABASE_URL_UNPOOLED: "postgresql://postgres:postgres@localhost:5432/cockpit_ci"
+      NEXTAUTH_SECRET: "test-secret-key-for-ci-only-min-32-chars"
+      NEXTAUTH_URL: "http://localhost:3002"
+      TOTP_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      JWT_SECRET_KEY: "test-jwt-secret-key-for-ci-only-32-chars"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.13.1
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install
+
+    # Pinned by the @playwright/test version in package.json, so a browser
+    # update cannot silently change what "passing" means. A floating browser is
+    # how an e2e suite becomes "flaky" and then ignored.
+    - name: Install Playwright browsers
+      run: pnpm exec playwright install --with-deps
+
+    - name: Generate Prisma Client
+      run: pnpm prisma generate
+
+    - name: Apply migrations
+      run: pnpm prisma migrate deploy
+
+    - name: Build
+      run: pnpm build
+
+    # Playwright starts the production server itself (see webServer in
+    # playwright.config.ts) and waits for it to answer.
+    #
+    # One project, on pull requests and on main alike. The 9-project device
+    # matrix was tried and is not usable here: the middleware rate-limits by IP
+    # at 60 requests a minute, a CI runner is one IP, and 9 x 16 tests inside a
+    # minute trips it — 108 of 144 passed and the rest returned 429. The route
+    # sweep is viewport-independent by construction, so the matrix would add
+    # flake without adding coverage. Widening it needs the limiter keyed on
+    # something other than IP for test environments, not a bigger timeout.
+    - name: Run E2E smoke
+      run: pnpm exec playwright test tests/e2e/smoke.spec.ts --project=chromium-desktop
+
+    # Uploaded on failure only. An e2e failure with no trace costs more to
+    # diagnose than the test saved.
+    - name: Upload traces and report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-${{ github.run_id }}
+        path: |
+          playwright-report/
+          test-results/
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ yarn.lock
 test-results-*.log
 ultimate-test-results-*.log
 
+# Playwright run output (traces, screenshots, videos, HTML report)
+test-results/
+playwright-report/
+
 # lint / typecheck output captures (generated artifacts, never commit)
 lint_errors.txt
 lint-errors.txt

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -900,3 +900,69 @@ same bug.
 stylesheet measured as script is neither honest nor actionable: the two have
 different costs, different caching behaviour and different fixes. The global
 stylesheet is currently 66.2kB and every route loads all of it.
+
+## 0e. Correction: the "real database" integration tests were not (2026-08-07)
+
+`tests/integration/delta-task-persistence.int.test.ts` was described in its own
+header, in the commit that added it, and in PR #106 as running "against a real
+PostgreSQL 16". **It did not.** It ran entirely against the in-memory mock and
+never opened a connection.
+
+### Why it looked real
+
+Three things had to line up, and all three did:
+
+1. `tests/setup.ts` mocks **`@prisma/client` itself**, not merely `@/lib/db`.
+   So `new PrismaClient()` inside the test returned the mock, and
+   `await import("@prisma/client")` inside the test's own `vi.mock` factory
+   returned the mock too — the override was overridden.
+2. `tests/setup.ts` also overwrote `DATABASE_URL` with a database named
+   `unused`, so even a real client could not have connected.
+3. The mock does not enforce schema constraints, so a seed missing four
+   required fields (`viewSettings`, `color`, `description`, `assignmentNotes`)
+   inserted happily. Against the real schema every one of them fails.
+
+The tests passed, asserted the right behaviour, and proved nothing about a
+database.
+
+### How it was caught
+
+By accident, writing the optimistic-locking tests. Those assert
+`version === 1` after an update, and the mock stores `{ increment: 1 }`
+literally — an object where a number was expected. That mismatch was the only
+reason the illusion surfaced. **A test asserting only shapes the mock happens to
+get right would still be passing today.**
+
+### The fix
+
+- Tests obtain a real client through `vi.importActual("@prisma/client")`,
+  which bypasses the module mock.
+- `tests/setup.ts` no longer overwrites `DATABASE_URL` when `RUN_DB_E2E` is
+  set, so an integration run keeps the URL its caller supplied.
+- The seeds now satisfy the real schema.
+
+Both suites now genuinely connect: **13 tests against real PostgreSQL 16.**
+
+### What this does and does not change
+
+**The delta task-persistence fix itself was correct.** All 7 of its tests pass
+against a real database now, unmodified except for the seed. The defect was in
+the verification claim, not the code.
+
+**The claim was the problem.** "Verified against real Postgres 16" appears in a
+commit message and a merged PR description where it was untrue. That is worse
+than not having tested, because it discourages the next person from checking.
+
+### The general lesson
+
+A mock that is thorough enough to satisfy your assertions is indistinguishable
+from the real thing *until an assertion touches something it models wrongly*.
+The way to tell them apart is not to read the test — it is to assert something
+only the real system can produce. Here that was an atomic increment. For a
+database it might equally be a constraint violation, a transaction rollback, or
+a returned row count.
+
+**If a test claims to use a real dependency, prove it once, deliberately** —
+query the database directly and assert a row exists, or assert a
+schema-constraint failure. One such assertion per suite would have caught this
+on the day it was written.

--- a/docs/REMEDIATION.md
+++ b/docs/REMEDIATION.md
@@ -34,67 +34,93 @@ production.
 
 ---
 
-### 1.2 The accessibility suites are skipped
+### 1.2 The accessibility suites are skipped — DONE
 
-**State:** 201 skipped tests. Among them, by name:
-
-```
-architecture/v3/__tests__/focus-trap.test.tsx          27 tests
-architecture/v3/__tests__/keyboard-navigation.test.tsx 31 tests
-__tests__/aria-labels.test.tsx
-__tests__/integration.test.tsx
-```
-
-These are the tests that would catch exactly the class of defect this audit
+**Was:** 201 skipped tests, including the three architecture/v3 accessibility
+suites (74 tests) that would catch exactly the class of defect this audit
 found — a dialog with no focus trap, a control with no accessible name.
 
-**Why they were skipped is now known and fixed.** `tests/setup.ts` stubbed
-`getComputedStyle` to report `display: 'none'` for every element, which made
-`getByRole` unable to match anything repo-wide. That stub is gone.
+**Done.** All three are un-skipped and passing: `aria-labels` 16/16,
+`focus-trap` 27/27, `keyboard-navigation` 31/31. Full suite 2069 passed, 0
+failed. Working through them one file at a time, treating each failure as a
+finding rather than a test to delete, turned up four defects in shipping code:
 
-**Fix:** un-skip them one file at a time, starting with `focus-trap` and
-`keyboard-navigation`. Expect failures — they were written against a broken
-environment and some will have been written to pass under it. **Treat each
-failure as a finding, not as a test to delete.**
+- Four v3 components had no default `React` import, so they could not render
+  at all under a transform that does not inject one.
+- `src/ui/components/Modal.tsx` passed `initialFocus: false` to focus-trap —
+  opening a dialog left focus on the trigger behind it.
+- The same Modal never referenced its own `<h2>`, so the dialog had no
+  accessible name.
+- Both modal foundations hardcoded the close button's name, so several open
+  dialogs were indistinguishable to a screen reader. `closeLabel` now exists.
 
-**Do not** un-skip all 201 in one commit. A large red suite gets skipped again.
+And one test-environment defect of the same family as the `getComputedStyle`
+stub: jsdom reports zero client rects for everything, `tabbable` reads that as
+"not tabbable", and focus-trap's `activate()` therefore threw for every modal
+in the suite. `tests/setup.ts` now shims `getClientRects` while deferring the
+visibility decision to computed style, so a genuinely hidden control still
+reads as untabbable.
 
-**Cost:** ~1 session per file. **Value:** the highest of anything on this list —
-it converts accessibility from a claim into a gate.
+**Left open:** `architecture/v3/__tests__/integration.test.tsx` is partly
+un-skipped — its keyboard and modal-focus scenarios run; its CRUD, auto-save
+and persistence scenarios stay skipped with a stated reason, because they need
+a store fixture the suite does not stand up. That is the next piece of this
+item, and it is a store problem rather than an accessibility one.
 
 ---
 
-### 1.3 Playwright never runs in CI
+### 1.3 Playwright never runs in CI — DONE, with the scope stated
 
-**State:** `playwright.config.ts` has a `webServer` block and 4 spec files. The
-CI workflow's steps are: lint, typecheck, test with coverage, build, budget
-check. **No e2e step.**
+**Was:** a `webServer` block, several spec files, and no e2e step in CI.
 
-**Fix:** add a job to `.github/workflows/`:
+**Done.** `.github/workflows/ci.yml` has an `e2e` job: postgres service,
+pinned browser install, `prisma migrate deploy`, production build, then
+`tests/e2e/smoke.spec.ts` on `chromium-desktop`, with traces uploaded on
+failure. `playwright.config.ts` now runs `pnpm start` under CI rather than
+`pnpm dev`, so what is tested is what ships.
 
-```yaml
-e2e:
-  needs: validate           # reuse the build, do not rebuild
-  steps:
-    - uses: actions/checkout@v4
-    - run: pnpm install --frozen-lockfile
-    - run: pnpm exec playwright install --with-deps chromium
-    - run: pnpm exec playwright test
-```
+**But the gate is scoped, and that is the important part of this entry.**
+Before wiring the job, the existing suite was run against a production build
+for the first time. It does not work:
 
-**Two things to get right:**
+| spec | tests | state |
+| --- | --- | --- |
+| `smoke.spec.ts` (new) | 16 | passing, ~3s |
+| `plan-timeline.spec.ts` | 15 | all `test.skip()` placeholders |
+| `team-capacity-api.spec.ts` | 21 | gated on `RUN_DB_E2E`; needs a seeded DB and a session |
+| `view-switching.spec.ts` | 23 | asserts a GlobalNav (`[href="/gantt-tool"]`) this app does not render |
+| `visual-regression/p1`,`p2` | 20 | navigate to `/projects`, `/projects/new` — not routes in this app |
+| `user-journeys/01`,`02` | 8 | same missing routes; the passes are lenient assertions, not evidence |
 
-- **Pin the browser version** via the Playwright version in `package.json`.
-  A floating browser makes failures unreproducible, which is how e2e suites
-  become "flaky" and then ignored.
-- **Upload the trace on failure** (`--trace on-first-retry`). An e2e failure
-  with no trace costs more to diagnose than it saves.
+Whole-directory result: **9 passed, 51 failed, 39 skipped.** Three separate
+defects were fixed on the way to that number and are worth recording, because
+each one had been hiding the next:
 
-**Also:** the number-input arrow-key behaviour deliberately left untested in
-jsdom belongs here. It is browser behaviour and jsdom does not emulate it.
+- `login-flows.spec.ts` hardcoded `http://localhost:3000` in all 13 tests
+  while the config serves 3002, so it had never once reached the app under
+  test. `view-switching` and `plan-timeline` defaulted to the same wrong port.
+- The same file constructed a `PrismaClient` at module scope and seeded users
+  in `beforeAll`, with no database in CI. Now behind `RUN_DB_E2E`, lazily.
+- The production server refuses to boot without `NEXTAUTH_SECRET` and
+  `NEXTAUTH_URL`. The job sets both.
 
-**Cost:** half a session. **Value:** the only tests that exercise the real
-browser, and the only ones that would catch a CSP or hydration break.
+**The new smoke spec** sweeps every route in the app against the auth
+boundary — 3 public, 11 protected, plus `/admin`'s two-hop redirect — and
+checks that the login page presents a named, keyboard-operable form. It uses
+the `request` fixture rather than page navigations: the middleware rate-limits
+by IP at 60/min, a browser navigation costs several requests, and a 429 reads
+exactly like "the redirect stopped working". The 9-project device matrix was
+tried and rejected for the same reason — 108 of 144 passed, the rest were
+rate-limited.
+
+**Next, in order:** delete or rewrite the visual-regression and user-journey
+specs against routes that exist; give `plan-timeline.spec.ts` real bodies once
+the Gantt strangler port lands; provide a seeded-DB job for
+`team-capacity-api.spec.ts`. Widening the device matrix needs the rate limiter
+keyed on something other than IP in test environments.
+
+**Also still open:** the number-input arrow-key behaviour deliberately left
+untested in jsdom belongs in the browser suite.
 
 ---
 
@@ -131,36 +157,32 @@ between "we have a CSP" and "we have a CSP that does something".
 
 ---
 
-### 2.2 No optimistic locking on the delta route
+### 2.2 No optimistic locking on the delta route — DONE
 
-**State:** the delta route authorises every id and writes. Two clients editing
-the same task both succeed; the second silently overwrites the first.
+**Was:** the delta route authorised every id and wrote. Two clients editing the
+same task both succeeded; the second silently overwrote the first. In a
+local-first app where clients queue changes offline, that is not a rare race —
+it is the normal case after two people work on a plane.
 
-In a local-first app where clients queue changes offline, this is not a rare
-race — it is the normal case after two people work on a plane.
+**Done.** `GanttPhase` and `GanttTask` carry `version Int @default(0)`
+(migration `20260807140000_add_optimistic_lock_versions`), and the route
+applies each write conditionally on the client's version, incrementing it.
+Covered by `tests/integration/delta-optimistic-lock.int.test.ts` (6 tests)
+against real PostgreSQL.
 
-**Fix:** add a version column and check it in the same transaction:
+Two decisions are worth knowing before changing this code:
 
-```prisma
-model GanttTask {
-  version Int @default(0)
-}
-```
+- **An absent version writes unconditionally.** Existing clients do not send
+  one, and rejecting them would have been a breaking change shipped as a bug
+  fix. New clients opt in by sending it.
+- **A conflict is collected, not thrown.** Throwing rolls back the whole
+  batch, and a local-first client batches an entire offline session — one
+  stale task would discard everything else the user did. The response carries
+  a `conflicts` array, always present and possibly empty.
 
-```ts
-const { count } = await tx.ganttTask.updateMany({
-  where: { id, phase: { projectId }, version: clientVersion },
-  data: { ...fields, version: { increment: 1 } },
-});
-if (count === 0) conflicts.push(id);   // do not throw — report
-```
-
-**Return conflicts rather than failing the request.** A 409 for the whole batch
-discards good changes alongside the conflicting one. The client should be told
-*which* entities conflicted so it can present a merge.
-
-**Cost:** one session including a migration and the conflict UI contract.
-**Value:** high — this is silent data loss, and silent is the worst kind.
+**Left open:** the client does not yet send `version`, so the mechanism is
+available but not yet in force end to end. That is the next step, and it
+belongs with the Gantt strangler port rather than ahead of it.
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -114,7 +114,13 @@ export default defineConfig({
   // on port 3000, so the server never became "ready" and every project failed on
   // the 120s timeout — the whole E2E suite was unrunnable.
   webServer: {
-    command: `pnpm dev --port ${E2E_PORT}`,
+    // CI runs the PRODUCTION build. A dev server has different bundling,
+    // different error overlays and no CSP-relevant minification, so passing
+    // e2e against `next dev` says little about what actually ships. Locally it
+    // stays on the dev server, where the fast refresh loop matters more.
+    command: process.env.CI
+      ? `pnpm start --port ${E2E_PORT}`
+      : `pnpm dev --port ${E2E_PORT}`,
     url: E2E_BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/prisma/migrations/20260807140000_add_optimistic_lock_versions/migration.sql
+++ b/prisma/migrations/20260807140000_add_optimistic_lock_versions/migration.sql
@@ -1,0 +1,13 @@
+-- Optimistic-lock counters for the two entities users concurrently edit.
+--
+-- Without these, two clients editing the same task both succeed and the second
+-- silently overwrites the first. In a local-first app whose clients queue
+-- changes while offline, that is not a rare race — it is the ordinary outcome
+-- after two people work on the same plan on a plane.
+--
+-- DEFAULT 0 rather than NULL so existing rows are immediately usable: a client
+-- that has never seen a version sends 0, matches, and writes. NOT NULL keeps
+-- the comparison total, with no three-valued logic in the WHERE clause.
+
+ALTER TABLE "GanttPhase" ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "GanttTask"  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,10 @@ model GanttPhase {
   collapsed                Boolean                        @default(false)
   order                    Int                            @default(0)
   dependencies             String[]
+  /// Optimistic-lock counter. A delta write supplies the version it read and
+  /// the update is scoped to it, so two clients editing the same phase cannot
+  /// silently overwrite each other. Incremented on every successful write.
+  version                  Int                            @default(0)
   project                  GanttProject                   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   phaseResourceAssignments GanttPhaseResourceAssignment[]
   tasks                    GanttTask[]
@@ -699,6 +703,8 @@ model GanttTask {
   collapsed           Boolean                       @default(false)
   isParent            Boolean                       @default(false)
   level               Int                           @default(0)
+  /// Optimistic-lock counter. See GanttPhase.version.
+  version             Int                           @default(0)
   parentTaskId        String?
   parentTask          GanttTask?                    @relation("TaskHierarchy", fields: [parentTaskId], references: [id], onDelete: Cascade)
   childTasks          GanttTask[]                   @relation("TaskHierarchy")

--- a/src/app/api/gantt-tool/projects/[projectId]/delta/route.ts
+++ b/src/app/api/gantt-tool/projects/[projectId]/delta/route.ts
@@ -104,6 +104,53 @@ async function assertDeltaOwnership(
 }
 
 // Validation schema for delta updates
+/**
+ * One entity whose write was rejected because someone else had already changed
+ * it. Reported rather than thrown — see `applyVersioned` below.
+ */
+interface WriteConflict {
+  entity: "phase" | "task";
+  id: string;
+  /** The version the client believed it was editing. */
+  expectedVersion: number;
+}
+
+/**
+ * Applies an update under an optimistic lock and reports, rather than throws,
+ * when it loses.
+ *
+ * Two decisions here, both deliberate:
+ *
+ * **An absent version means an unconditional write.** Existing clients do not
+ * send one, and requiring it would break every one of them on deploy. A client
+ * opts into locking by starting to send the version it read; until then it
+ * behaves exactly as before. The capability ships ahead of its adoption.
+ *
+ * **A conflict is collected, not thrown.** Throwing would roll the whole
+ * transaction back, discarding every other change in the same batch — and a
+ * local-first client batches an entire offline session. Losing forty good edits
+ * because the forty-first collided is worse than the collision. The caller gets
+ * a 200 with the list of ids that did not apply, and can re-read and merge
+ * exactly those.
+ */
+async function applyVersioned(
+  entity: "phase" | "task",
+  id: string,
+  clientVersion: unknown,
+  conflicts: WriteConflict[],
+  run: (versionGuard: { version: number } | Record<string, never>) => Promise<{ count: number }>
+): Promise<void> {
+  const expected = typeof clientVersion === "number" ? clientVersion : undefined;
+  const { count } = await run(expected === undefined ? {} : { version: expected });
+
+  // count === 0 with a supplied version means the guard did not match. Without
+  // a version it means the id is not in this project, which ownership checks
+  // have already rejected — so this can only be a genuine conflict.
+  if (count === 0 && expected !== undefined) {
+    conflicts.push({ entity, id, expectedVersion: expected });
+  }
+}
+
 const DeltaSaveSchema = z.object({
   projectUpdates: z
     .object({
@@ -179,6 +226,10 @@ export const PATCH = withAuth<{ params: Promise<{ projectId: string }> }>(
     }
 
     const delta = DeltaSaveSchema.parse(body);
+
+    // Collected inside the transaction, reported after it commits. See
+    // applyVersioned for why a conflict does not abort the batch.
+    const conflicts: WriteConflict[] = [];
 
     // Check for duplicate project name if name is being updated
     if (delta.projectUpdates?.name) {
@@ -395,19 +446,27 @@ export const PATCH = withAuth<{ params: Promise<{ projectId: string }> }>(
 
           // Phase rows carry distinct data, so update them individually.
           for (const phase of updatedPhases) {
-            await tx.ganttPhase.updateMany({
-              where: { id: phase.id, projectId },
-              data: {
-                name: phase.name,
-                description: phase.description,
-                color: phase.color,
-                startDate: new Date(phase.startDate),
-                endDate: new Date(phase.endDate),
-                collapsed: phase.collapsed || false,
-                order: phase.order || 0,
-                dependencies: phase.dependencies || [],
-              },
-            });
+            await applyVersioned(
+              "phase",
+              phase.id,
+              (phase as unknown as { version?: unknown }).version,
+              conflicts,
+              (versionGuard) =>
+                tx.ganttPhase.updateMany({
+                  where: { id: phase.id, projectId, ...versionGuard },
+                  data: {
+                    name: phase.name,
+                    description: phase.description,
+                    color: phase.color,
+                    startDate: new Date(phase.startDate),
+                    endDate: new Date(phase.endDate),
+                    collapsed: phase.collapsed || false,
+                    order: phase.order || 0,
+                    dependencies: phase.dependencies || [],
+                    version: { increment: 1 },
+                  },
+                })
+            );
           }
 
           // Re-sync tasks for phases that provided a `tasks` array.
@@ -591,21 +650,29 @@ export const PATCH = withAuth<{ params: Promise<{ projectId: string }> }>(
 
         if (delta.tasks.updated && delta.tasks.updated.length > 0) {
           for (const t of delta.tasks.updated as unknown as GanttTask[]) {
-            await tx.ganttTask.updateMany({
-              // Scoped through the phase relation, so a foreign task id cannot
-              // be written even though the caller owns this project.
-              where: { id: t.id, phase: { projectId } },
-              data: {
-                name: t.name,
-                description: t.description,
-                startDate: new Date(t.startDate),
-                endDate: new Date(t.endDate),
-                progress: t.progress || 0,
-                assignee: t.assignee,
-                ...(t.order !== undefined ? { order: t.order } : {}),
-                dependencies: t.dependencies || [],
-              },
-            });
+            await applyVersioned(
+              "task",
+              t.id,
+              (t as unknown as { version?: unknown }).version,
+              conflicts,
+              (versionGuard) =>
+                tx.ganttTask.updateMany({
+                  // Scoped through the phase relation, so a foreign task id
+                  // cannot be written even though the caller owns this project.
+                  where: { id: t.id, phase: { projectId }, ...versionGuard },
+                  data: {
+                    name: t.name,
+                    description: t.description,
+                    startDate: new Date(t.startDate),
+                    endDate: new Date(t.endDate),
+                    progress: t.progress || 0,
+                    assignee: t.assignee,
+                    ...(t.order !== undefined ? { order: t.order } : {}),
+                    dependencies: t.dependencies || [],
+                    version: { increment: 1 },
+                  },
+                })
+            );
           }
         }
       }
@@ -722,6 +789,9 @@ export const PATCH = withAuth<{ params: Promise<{ projectId: string }> }>(
     return NextResponse.json(
       {
         success: true,
+        // Present and empty when nothing collided, so a client can branch on
+        // `length` without first checking for undefined.
+        conflicts,
         project: {
           id: projectId,
           updatedAt: updatedProject.updatedAt.toISOString(),

--- a/src/app/architecture/v3/__tests__/aria-labels.test.tsx
+++ b/src/app/architecture/v3/__tests__/aria-labels.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { BusinessContextTab } from '../components/BusinessContextTab';
 import { CurrentLandscapeTab } from '../components/CurrentLandscapeTab';
@@ -15,10 +15,19 @@ import { ProposedSolutionTab } from '../components/ProposedSolutionTab';
 import { StyleSelector } from '../components/StyleSelector';
 import { ReuseSystemModal } from '../components/ReuseSystemModal';
 
+/**
+ * The entity, actor and capability sections live inside accordions that start
+ * collapsed, so their contents are not in the DOM until the header is
+ * activated. Every test below used to carry a comment saying exactly that and
+ * an `it.skip` — opening the accordion is the fix those comments stood in for.
+ */
+function openAccordion(title: RegExp) {
+  fireEvent.click(screen.getByRole('button', { name: title }));
+}
+
 describe('ARIA Labels - Icon-Only Buttons', () => {
   describe('BusinessContextTab', () => {
-    it.skip('has aria-label on entity card remove button', () => {
-      // Skipped: Entity cards are inside accordions that start closed
+    it('has aria-label on entity card remove button', () => {
       const mockData = {
         entities: [{ id: '1', name: 'Test Entity', location: 'Test', description: 'Test' }],
         actors: [],
@@ -34,13 +43,14 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
+      openAccordion(/Business Entities/);
+
       const removeButton = screen.getByLabelText(/remove entity test entity/i);
       expect(removeButton).toBeInTheDocument();
       expect(removeButton).toHaveAttribute('aria-label', 'Remove entity Test Entity');
     });
 
-    it.skip('has aria-label on actor card remove button', () => {
-      // Skipped: Actor cards are inside accordions that start closed
+    it('has aria-label on actor card remove button', () => {
       const mockData = {
         entities: [],
         actors: [{ id: '1', name: 'Test Actor', role: 'Manager', department: 'IT', activities: ['Test'] }],
@@ -56,13 +66,14 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
+      openAccordion(/Key Actors & Activities/);
+
       const removeButton = screen.getByLabelText(/remove actor test actor/i);
       expect(removeButton).toBeInTheDocument();
       expect(removeButton).toHaveAttribute('aria-label', 'Remove actor Test Actor');
     });
 
-    it.skip('has aria-label on capability tag remove button', () => {
-      // Skipped: Capability tags are inside accordions that start closed
+    it('has aria-label on capability tag remove button', () => {
       const mockData = {
         entities: [],
         actors: [],
@@ -78,12 +89,13 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
+      openAccordion(/Required Capabilities/);
+
       const removeButton = screen.getByLabelText(/remove capability test capability/i);
       expect(removeButton).toBeInTheDocument();
     });
 
-    it.skip('has aria-label on entity list view remove button', () => {
-      // Skipped: List view is inside accordion which requires interaction to open
+    it('has aria-label on entity list view remove button', () => {
       const mockData = {
         entities: [{ id: '1', name: 'Test Entity', location: '', description: '' }],
         actors: [],
@@ -99,16 +111,16 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
-      // Click to switch to list view
-      const listViewButton = screen.getByRole('button', { name: /list view/i });
-      listViewButton.click();
+      // The view toggle is a radiogroup, not a row of buttons — this query
+      // asserted role="button" and so could never match the real markup.
+      fireEvent.click(screen.getByRole('radio', { name: /list view/i }));
+      openAccordion(/Business Entities/);
 
       const removeButton = screen.getByLabelText(/remove entity/i);
       expect(removeButton).toBeInTheDocument();
     });
 
-    it.skip('has aria-label on actor list view remove button', () => {
-      // Skipped: List view is inside accordion which requires interaction to open
+    it('has aria-label on actor list view remove button', () => {
       const mockData = {
         entities: [],
         actors: [{ id: '1', name: 'Test Actor', role: '', department: '', activities: [] }],
@@ -124,9 +136,8 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
-      // Click to switch to list view
-      const listViewButton = screen.getByRole('button', { name: /list view/i });
-      listViewButton.click();
+      fireEvent.click(screen.getByRole('radio', { name: /list view/i }));
+      openAccordion(/Key Actors & Activities/);
 
       const removeButton = screen.getByLabelText(/remove actor/i);
       expect(removeButton).toBeInTheDocument();
@@ -134,7 +145,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
   });
 
   describe('CurrentLandscapeTab', () => {
-    it.skip('has aria-label on system card remove button', () => {
+    it('has aria-label on system card remove button', () => {
       const mockData = {
         systems: [{ id: '1', name: 'SAP ECC', vendor: 'SAP', version: '6.0', modules: ['FI', 'CO'], status: 'active' as const }],
         integrations: [],
@@ -155,7 +166,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
       expect(removeButton).toHaveAttribute('aria-label', 'Remove current system SAP ECC');
     });
 
-    it.skip('has aria-label on external system remove button', () => {
+    it('has aria-label on external system remove button', () => {
       const mockData = {
         systems: [],
         integrations: [],
@@ -176,7 +187,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
       expect(removeButton).toHaveAttribute('aria-label', 'Remove external system External API');
     });
 
-    it.skip('cloud icon is marked as decorative', () => {
+    it('cloud icon is marked as decorative', () => {
       const mockData = {
         systems: [],
         integrations: [],
@@ -198,8 +209,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
   });
 
   describe('ProposedSolutionTab', () => {
-    it.skip('has aria-label on phase card remove button', () => {
-      // Skipped: Phase card only visible when phase is selected in UI
+    it('has aria-label on phase card remove button', () => {
       const mockData = {
         phases: [{
           id: '1',
@@ -229,8 +239,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
       expect(removeButton).toHaveAttribute('aria-label', 'Remove phase Phase 1');
     });
 
-    it.skip('has aria-label on system card remove button', () => {
-      // Skipped: System card only visible when phase is selected in UI
+    it('has aria-label on system card remove button', () => {
       const mockData = {
         phases: [{
           id: '1',
@@ -262,7 +271,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
   });
 
   describe('StyleSelector Modal', () => {
-    it.skip('has aria-label on close button', () => {
+    it('has aria-label on close button', () => {
       const mockSettings = {
         visualStyle: 'bold' as const,
         actorDisplay: 'cards' as const,
@@ -284,7 +293,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
       expect(closeButton).toHaveAttribute('aria-label', 'Close style selector');
     });
 
-    it.skip('close button icon is marked as decorative', () => {
+    it('close button icon is marked as decorative', () => {
       const mockSettings = {
         visualStyle: 'bold' as const,
         actorDisplay: 'cards' as const,
@@ -307,7 +316,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
   });
 
   describe('ReuseSystemModal', () => {
-    it.skip('has aria-label on close button', () => {
+    it('has aria-label on close button', () => {
       const mockSystems = [
         { id: '1', name: 'SAP ECC', vendor: 'SAP', version: '6.0', modules: ['FI'], status: 'keep' as const }
       ];
@@ -328,8 +337,7 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
   });
 
   describe('Edge Cases', () => {
-    it.skip('handles empty names gracefully with "untitled" fallback', () => {
-      // Skipped: Entity cards are inside accordions that start closed
+    it('handles empty names gracefully with "untitled" fallback', () => {
       const mockData = {
         entities: [{ id: '1', name: '', location: '', description: '' }],
         actors: [],
@@ -345,11 +353,13 @@ describe('ARIA Labels - Icon-Only Buttons', () => {
         />
       );
 
+      openAccordion(/Business Entities/);
+
       const removeButton = screen.getByLabelText(/remove entity untitled/i);
       expect(removeButton).toBeInTheDocument();
     });
 
-    it.skip('handles special characters in names correctly', () => {
+    it('handles special characters in names correctly', () => {
       const mockData = {
         systems: [{ id: '1', name: 'SAP S/4HANA', vendor: 'SAP', version: '2023', modules: ['Finance'], status: 'active' as const }],
         integrations: [],

--- a/src/app/architecture/v3/__tests__/focus-trap.test.tsx
+++ b/src/app/architecture/v3/__tests__/focus-trap.test.tsx
@@ -24,7 +24,38 @@ const mockSettings = {
   showIcons: true,
 };
 
-describe.skip('Focus Trap - StyleSelector Modal', () => {
+/**
+ * focus-trap defers its initial focus (delayInitialFocus is on by default), so
+ * when `render` returns it has not yet moved focus in, and its Tab handler is
+ * not yet wrapping at the trap boundary. Tests that interacted synchronously
+ * were reading the pre-activation DOM and failing on the app's behalf.
+ *
+ * Focus landing inside the dialog is the observable signal that the trap is
+ * live, so waiting for it is both the fix and an assertion in its own right.
+ */
+/**
+ * A caveat these tests have to work around: jsdom's querySelectorAll returns a
+ * selector list's matches GROUPED BY SELECTOR rather than in document order
+ * (nwsapi), and `tabbable` builds its candidate list from one comma-joined
+ * list whose first entry is `input`. Every <input> therefore sorts ahead of
+ * every <button>, no matter where they sit in the markup — reproducible with
+ * three plain elements and no application code.
+ *
+ * So under jsdom the trap's idea of "first" and "last" is not the browser's,
+ * and asserting WHICH element receives focus would assert a jsdom artifact.
+ * The assertions below are on the property that actually matters and holds
+ * either way: focus stays inside the dialog. Real tab order belongs in the
+ * Playwright suite, where the browser decides it.
+ */
+async function trapActive(): Promise<HTMLElement> {
+  const dialog = await screen.findByRole('dialog');
+  await waitFor(() => {
+    expect(dialog).toContainElement(document.activeElement as HTMLElement);
+  });
+  return dialog;
+}
+
+describe('Focus Trap - StyleSelector Modal', () => {
   describe('Focus Capture on Open (24 scenarios)', () => {
     it('should focus first focusable element when modal opens', async () => {
       const { rerender: _rerender } = render(
@@ -35,13 +66,20 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
         />
       );
 
-      await waitFor(() => {
-        const firstButton = screen.getAllByRole('button')[0];
-        expect(document.activeElement).toBe(firstButton);
-      });
+      const dialog = await trapActive();
+
+      // The assertion used to be `getAllByRole('button')[0]`, i.e. the Close
+      // button in the header. Landing there means the first thing offered to
+      // a keyboard user is dismissing the dialog they just opened, so the
+      // modal deliberately focuses the first interactive element in the body
+      // instead. What must hold is that focus moved in, and not onto Close.
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
+      expect(document.activeElement).not.toBe(
+        screen.getByRole('button', { name: /close style selector/i })
+      );
     });
 
-    it('should capture focus from body', () => {
+    it('should capture focus from body', async () => {
       document.body.focus();
 
       render(
@@ -52,10 +90,12 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
         />
       );
 
+      await trapActive();
+
       expect(document.activeElement).not.toBe(document.body);
     });
 
-    it('should capture focus from external button', () => {
+    it('should capture focus from external button', async () => {
       const externalButton = document.createElement('button');
       document.body.appendChild(externalButton);
       externalButton.focus();
@@ -67,6 +107,8 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
           onClose={vi.fn()}
         />
       );
+
+      await trapActive();
 
       expect(document.activeElement).not.toBe(externalButton);
       document.body.removeChild(externalButton);
@@ -114,7 +156,7 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
   });
 
   describe('Tab Cycling Forward (24 scenarios)', () => {
-    it('should cycle to first element when tabbing from last', () => {
+    it('should cycle to first element when tabbing from last', async () => {
       render(
         <StyleSelector
           currentSettings={mockSettings}
@@ -122,6 +164,8 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
           onClose={vi.fn()}
         />
       );
+
+      const dialog = await trapActive();
 
       const buttons = screen.getAllByRole('button');
       const lastButton = buttons[buttons.length - 1];
@@ -129,10 +173,13 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
 
       fireEvent.keyDown(lastButton, { key: 'Tab' });
 
-      expect(buttons[0]).toHaveFocus();
+      // Wrapped rather than escaped: focus left the last control but is still
+      // inside the dialog.
+      expect(document.activeElement).not.toBe(lastButton);
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
     });
 
-    it('should cycle through all focusable elements', () => {
+    it('should cycle through all focusable elements', async () => {
       render(
         <StyleSelector
           currentSettings={mockSettings}
@@ -141,19 +188,20 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
         />
       );
 
+      const dialog = await trapActive();
+
       const buttons = screen.getAllByRole('button');
-      let currentIndex = 0;
 
-      for (let i = 0; i < buttons.length; i++) {
-        buttons[currentIndex].focus();
-        expect(buttons[currentIndex]).toHaveFocus();
+      // Tab forward from every control in turn. None of them may let focus
+      // out of the dialog — including the last, which is the wrap point.
+      for (const button of buttons) {
+        button.focus();
+        expect(button).toHaveFocus();
 
-        fireEvent.keyDown(buttons[currentIndex], { key: 'Tab' });
+        fireEvent.keyDown(button, { key: 'Tab' });
 
-        currentIndex = (currentIndex + 1) % buttons.length;
+        expect(dialog).toContainElement(document.activeElement as HTMLElement);
       }
-
-      expect(buttons[0]).toHaveFocus();
     });
 
     it('should handle rapid Tab presses', () => {
@@ -203,7 +251,7 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
   });
 
   describe('Tab Cycling Backward (24 scenarios)', () => {
-    it('should cycle to last element when shift-tabbing from first', () => {
+    it('should cycle to last element when shift-tabbing from first', async () => {
       render(
         <StyleSelector
           currentSettings={mockSettings}
@@ -211,16 +259,22 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
           onClose={vi.fn()}
         />
       );
+
+      const dialog = await trapActive();
 
       const buttons = screen.getAllByRole('button');
       buttons[0].focus();
 
       fireEvent.keyDown(buttons[0], { key: 'Tab', shiftKey: true });
 
-      expect(buttons[buttons.length - 1]).toHaveFocus();
+      // Only asserts containment, not movement: under jsdom's ordering the
+      // first button is not the first tabbable node, so this is not the wrap
+      // boundary and the trap correctly leaves focus alone. Which element is
+      // the boundary is the browser's business — see the note on trapActive.
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
     });
 
-    it('should cycle backward through all elements', () => {
+    it('should cycle backward through all elements', async () => {
       render(
         <StyleSelector
           currentSettings={mockSettings}
@@ -229,19 +283,18 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
         />
       );
 
+      const dialog = await trapActive();
+
       const buttons = screen.getAllByRole('button');
-      let currentIndex = buttons.length - 1;
 
-      for (let i = 0; i < buttons.length; i++) {
-        buttons[currentIndex].focus();
-        expect(buttons[currentIndex]).toHaveFocus();
+      for (const button of [...buttons].reverse()) {
+        button.focus();
+        expect(button).toHaveFocus();
 
-        fireEvent.keyDown(buttons[currentIndex], { key: 'Tab', shiftKey: true });
+        fireEvent.keyDown(button, { key: 'Tab', shiftKey: true });
 
-        currentIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+        expect(dialog).toContainElement(document.activeElement as HTMLElement);
       }
-
-      expect(buttons[buttons.length - 1]).toHaveFocus();
     });
 
     it('should handle rapid Shift+Tab presses', () => {
@@ -291,12 +344,12 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
 
   describe('Escape Key Handling (16 scenarios)', () => {
     it('should call onClose when Escape is pressed', () => {
-      const onClose = jest.fn();
+      const onClose = vi.fn();
 
       render(
         <StyleSelector
           currentSettings={mockSettings}
-          onGenerate={jest.fn()}
+          onGenerate={vi.fn()}
           onClose={onClose}
         />
       );
@@ -324,12 +377,12 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
     });
 
     it('should close on Escape from any focused element', () => {
-      const onClose = jest.fn();
+      const onClose = vi.fn();
 
       render(
         <StyleSelector
           currentSettings={mockSettings}
-          onGenerate={jest.fn()}
+          onGenerate={vi.fn()}
           onClose={onClose}
         />
       );
@@ -344,12 +397,12 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
     });
 
     it('should not close on other keys', () => {
-      const onClose = jest.fn();
+      const onClose = vi.fn();
 
       render(
         <StyleSelector
           currentSettings={mockSettings}
-          onGenerate={jest.fn()}
+          onGenerate={vi.fn()}
           onClose={onClose}
         />
       );
@@ -416,13 +469,13 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
     });
 
     it('should handle multiple modals opening in sequence', async () => {
-      const onClose1 = jest.fn();
-      const onClose2 = jest.fn();
+      const onClose1 = vi.fn();
+      const onClose2 = vi.fn();
 
       const { unmount: unmount1 } = render(
         <StyleSelector
           currentSettings={mockSettings}
-          onGenerate={jest.fn()}
+          onGenerate={vi.fn()}
           onClose={onClose1}
         />
       );
@@ -434,7 +487,7 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
       const { unmount: unmount2 } = render(
         <StyleSelector
           currentSettings={mockSettings}
-          onGenerate={jest.fn()}
+          onGenerate={vi.fn()}
           onClose={onClose2}
         />
       );
@@ -508,26 +561,43 @@ describe.skip('Focus Trap - StyleSelector Modal', () => {
 
       // Focus element that might require scroll
       lastButton.focus();
-      lastButton.scrollIntoView = jest.fn();
+      lastButton.scrollIntoView = vi.fn();
 
       expect(lastButton).toHaveFocus();
     });
   });
 });
 
-describe.skip('Focus Trap - ReuseSystemModal', () => {
+describe('Focus Trap - ReuseSystemModal', () => {
+  // `modules` is not optional — the component joins it for the module list,
+  // so omitting it threw "Cannot read properties of undefined (reading
+  // 'join')" before either assertion ran.
   const mockSystems = [
-    { id: '1', name: 'SAP ECC', type: 'erp' as const, status: 'keep' as const },
-    { id: '2', name: 'Salesforce', type: 'crm' as const, status: 'keep' as const },
+    {
+      id: '1',
+      name: 'SAP ECC',
+      vendor: 'SAP',
+      version: '6.0',
+      modules: ['FI', 'CO'],
+      status: 'keep' as const,
+    },
+    {
+      id: '2',
+      name: 'Salesforce',
+      vendor: 'Salesforce',
+      version: '2024',
+      modules: ['Sales Cloud'],
+      status: 'keep' as const,
+    },
   ];
 
   it('should trap focus in reuse system modal', () => {
     render(
       <ReuseSystemModal
         isOpen={true}
-        onClose={jest.fn()}
+        onClose={vi.fn()}
         systemsToKeep={mockSystems}
-        onReuse={jest.fn()}
+        onReuse={vi.fn()}
       />
     );
 
@@ -541,14 +611,14 @@ describe.skip('Focus Trap - ReuseSystemModal', () => {
   });
 
   it('should close reuse modal on Escape', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
 
     render(
       <ReuseSystemModal
         isOpen={true}
         onClose={onClose}
         systemsToKeep={mockSystems}
-        onReuse={jest.fn()}
+        onReuse={vi.fn()}
       />
     );
 
@@ -558,7 +628,7 @@ describe.skip('Focus Trap - ReuseSystemModal', () => {
   });
 });
 
-describe.skip('Focus Trap - Coverage Summary', () => {
+describe('Focus Trap - Coverage Summary', () => {
   it('confirms comprehensive focus trap testing', () => {
     /**
      * Total Test Scenarios: 96

--- a/src/app/architecture/v3/__tests__/integration.test.tsx
+++ b/src/app/architecture/v3/__tests__/integration.test.tsx
@@ -80,6 +80,13 @@ describe('Architecture V3 - Integration Tests (10 scenarios)', () => {
     vi.useRealTimers();
   });
 
+  /**
+   * Still skipped, but for a stated reason rather than by default: these
+   * exercise the architecture store's save path, which the suite does not
+   * stand up — the scenarios time out waiting for a persistence round trip
+   * that never happens. Tracked in docs/REMEDIATION.md; they need a store
+   * fixture, not a change to the assertions.
+   */
   describe.skip('Full CRUD Workflow (3 scenarios)', () => {
     it('should complete full project lifecycle: create → update → delete', async () => {
       const store = useArchitectureStore.getState();
@@ -215,6 +222,13 @@ describe('Architecture V3 - Integration Tests (10 scenarios)', () => {
     });
   });
 
+  /**
+   * Still skipped, but for a stated reason rather than by default: these
+   * exercise the architecture store's save path, which the suite does not
+   * stand up — the scenarios time out waiting for a persistence round trip
+   * that never happens. Tracked in docs/REMEDIATION.md; they need a store
+   * fixture, not a change to the assertions.
+   */
   describe.skip('Auto-Save Integration (2 scenarios)', () => {
     it('should auto-save after 2 seconds of inactivity', async () => {
       useArchitectureStore.setState({ currentProject: mockProject as any });
@@ -285,7 +299,7 @@ describe('Architecture V3 - Integration Tests (10 scenarios)', () => {
     });
   });
 
-  describe.skip('Navigation + Keyboard Integration (2 scenarios)', () => {
+  describe('Navigation + Keyboard Integration (2 scenarios)', () => {
     it('should navigate tabs with arrow keys and maintain state', () => {
       const TabComponent = () => {
         const [activeTab, setActiveTab] = React.useState(0);
@@ -387,7 +401,7 @@ describe('Architecture V3 - Integration Tests (10 scenarios)', () => {
     });
   });
 
-  describe.skip('Modal + Focus Management Integration (2 scenarios)', () => {
+  describe('Modal + Focus Management Integration (2 scenarios)', () => {
     it('should trap focus in modal and restore on close', () => {
       const ModalComponent = ({ onClose }: { onClose: () => void }) => {
         return (
@@ -481,6 +495,13 @@ describe('Architecture V3 - Integration Tests (10 scenarios)', () => {
     });
   });
 
+  /**
+   * Still skipped, but for a stated reason rather than by default: these
+   * exercise the architecture store's save path, which the suite does not
+   * stand up — the scenarios time out waiting for a persistence round trip
+   * that never happens. Tracked in docs/REMEDIATION.md; they need a store
+   * fixture, not a change to the assertions.
+   */
   describe.skip('Data Persistence Integration (1 scenario)', () => {
     it('should persist data across page refresh simulation', async () => {
       // Simulate: Create project → Save → "Refresh" → Load

--- a/src/app/architecture/v3/__tests__/keyboard-navigation.test.tsx
+++ b/src/app/architecture/v3/__tests__/keyboard-navigation.test.tsx
@@ -44,7 +44,7 @@ function TestTabs() {
   );
 }
 
-describe.skip('Keyboard Navigation - Tab Interface', () => {
+describe('Keyboard Navigation - Tab Interface', () => {
   describe('Arrow Key Navigation (48 scenarios)', () => {
     it('should move to next tab with ArrowRight from first tab', () => {
       render(<TestTabs />);
@@ -303,7 +303,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
       tab1.focus();
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const preventDefault = jest.spyOn(event, 'preventDefault');
+      const preventDefault = vi.spyOn(event, 'preventDefault');
 
       tab1.dispatchEvent(event);
 
@@ -316,7 +316,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
       tab1.focus();
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const preventDefault = jest.spyOn(event, 'preventDefault');
+      const preventDefault = vi.spyOn(event, 'preventDefault');
 
       tab1.dispatchEvent(event);
 
@@ -330,7 +330,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
       tab2.focus();
 
       const event = new KeyboardEvent('keydown', { key: 'Home', bubbles: true, cancelable: true });
-      const preventDefault = jest.spyOn(event, 'preventDefault');
+      const preventDefault = vi.spyOn(event, 'preventDefault');
 
       tab2.dispatchEvent(event);
 
@@ -344,7 +344,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
       tab2.focus();
 
       const event = new KeyboardEvent('keydown', { key: 'End', bubbles: true, cancelable: true });
-      const preventDefault = jest.spyOn(event, 'preventDefault');
+      const preventDefault = vi.spyOn(event, 'preventDefault');
 
       tab2.dispatchEvent(event);
 
@@ -357,7 +357,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
       tab1.focus();
 
       const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
-      const preventDefault = jest.spyOn(event, 'preventDefault');
+      const preventDefault = vi.spyOn(event, 'preventDefault');
 
       tab1.dispatchEvent(event);
 
@@ -406,7 +406,7 @@ describe.skip('Keyboard Navigation - Tab Interface', () => {
   });
 });
 
-describe.skip('Keyboard Navigation - Test Coverage Summary', () => {
+describe('Keyboard Navigation - Test Coverage Summary', () => {
   it('confirms comprehensive test coverage with permutations', () => {
     /**
      * Total Test Scenarios: 156

--- a/src/app/architecture/v3/components/CurrentLandscapeTab.tsx
+++ b/src/app/architecture/v3/components/CurrentLandscapeTab.tsx
@@ -7,7 +7,11 @@
 
 "use client";
 
-import { useState } from "react";
+// Explicit default import: tsconfig uses `jsx: "preserve"` with no automatic
+// runtime, so the compiled JSX calls React.createElement by name. Next's own
+// build injects it, which is why this only ever surfaced under the test
+// transform — as `ReferenceError: React is not defined` on render.
+import React, { useState } from "react";
 import { Plus, Trash2, Cloud } from "lucide-react";
 import type { CurrentLandscapeData, CurrentSystem, ExternalSystem, BusinessEntity } from "../types";
 import clsx from "clsx";

--- a/src/app/architecture/v3/components/ProposedSolutionTab.tsx
+++ b/src/app/architecture/v3/components/ProposedSolutionTab.tsx
@@ -5,7 +5,11 @@
 
 "use client";
 
-import { useState, useEffect } from "react";
+// Explicit default import: tsconfig uses `jsx: "preserve"` with no automatic
+// runtime, so the compiled JSX calls React.createElement by name. Next's own
+// build injects it, which is why this only ever surfaced under the test
+// transform — as `ReferenceError: React is not defined` on render.
+import React, { useState, useEffect } from "react";
 import { Plus, Trash2, Calendar, CheckCircle, Clock, Sparkles, Package, HelpCircle } from "lucide-react";
 import type { ProposedSolutionData, Phase, ProposedSystem, ProposedIntegration, CurrentSystem, ExternalSystem } from "../types";
 import { ReuseSystemModal } from "./ReuseSystemModal";

--- a/src/app/architecture/v3/components/ReuseSystemModal.tsx
+++ b/src/app/architecture/v3/components/ReuseSystemModal.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import type { CurrentSystem } from "../types";
+// Explicit default import: tsconfig uses `jsx: "preserve"` with no automatic
+// runtime, so the compiled JSX calls React.createElement by name. Next's own
+// build injects it, which is why this only ever surfaced under the test
+// transform — as `ReferenceError: React is not defined` on render.
+import React from "react";
 import { Package } from "lucide-react";
 import { BaseModal, ModalButton } from "@/components/ui/BaseModal";
 
@@ -22,6 +27,7 @@ export function ReuseSystemModal({
       isOpen={isOpen}
       onClose={onClose}
       title="Reuse System from AS-IS"
+      closeLabel="Close reuse system dialog"
       subtitle="Select a system from your Current Landscape that was marked with the KEEP status"
       icon={<Package className="w-6 h-6" />}
       size="medium"

--- a/src/app/architecture/v3/components/StyleSelector.tsx
+++ b/src/app/architecture/v3/components/StyleSelector.tsx
@@ -5,7 +5,11 @@
 
 "use client";
 
-import { useState } from "react";
+// Explicit default import: tsconfig uses `jsx: "preserve"` with no automatic
+// runtime, so the compiled JSX calls React.createElement by name. Next's own
+// build injects it, which is why this only ever surfaced under the test
+// transform — as `ReferenceError: React is not defined` on render.
+import React, { useState } from "react";
 import type { DiagramSettings } from "../types";
 import { Modal, ModalButton } from "@/ui/components/Modal";
 import clsx from "clsx";
@@ -28,6 +32,7 @@ export function StyleSelector({ currentSettings, onGenerate, onClose }: StyleSel
       open={true}
       onClose={onClose}
       title="Choose Your Visual Style"
+      closeLabel="Close style selector"
       size="lg"
       footer={
         <>

--- a/src/components/ui/BaseModal.tsx
+++ b/src/components/ui/BaseModal.tsx
@@ -72,6 +72,14 @@ export interface BaseModalProps {
   /** Prevent closing on overlay click */
   preventClose?: boolean;
 
+  /**
+   * Accessible name for the close button. Defaults to "Close modal", which is
+   * enough for one dialog but not for a screen-reader user listing the
+   * buttons on a page with several — WCAG 2.4.6 asks for names that describe
+   * their purpose. Pass "Close reuse system dialog" and the like.
+   */
+  closeLabel?: string;
+
   /** Prevent closing on escape key */
   preventEscapeClose?: boolean;
 
@@ -103,6 +111,7 @@ export function BaseModal({
   children,
   footer,
   preventClose = false,
+  closeLabel = "Close modal",
   preventEscapeClose = false,
   zIndex = 9999,
   className,
@@ -299,7 +308,7 @@ export function BaseModal({
                   <button
                     type="button"
                     onClick={onClose}
-                    aria-label="Close modal"
+                    aria-label={closeLabel}
                     style={{
                       width: '44px', // Apple HIG minimum touch target
                       height: '44px', // Apple HIG minimum touch target

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useId, useRef } from "react";
 import { X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import FocusTrap from "focus-trap-react";
@@ -39,6 +39,14 @@ export interface ModalProps {
   className?: string;
   /** Prevent close on backdrop click */
   preventClose?: boolean;
+  /**
+   * Accessible name for the close button. Defaults to "Close", which is
+   * enough when one dialog is open, but WCAG 2.4.6 asks for names that
+   * describe their purpose — and a screen-reader user listing the buttons on
+   * a page with several dialogs hears "Close" repeated with nothing to tell
+   * them apart. Pass "Close style selector" and the like.
+   */
+  closeLabel?: string;
 }
 
 const sizes: Record<ModalSize, string> = {
@@ -61,7 +69,16 @@ export const Modal: React.FC<ModalProps> = ({
   zIndex = 1050,
   className,
   preventClose = false,
+  closeLabel = "Close",
 }) => {
+  // Stable across renders and unique per instance, so two dialogs mounted at
+  // once cannot both claim the same id and mislabel each other.
+  const titleId = useId();
+
+  // Targets for the focus trap; see focusTrapOptions below.
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
   // Prevent body scroll when modal is open
   useEffect(() => {
     if (open) {
@@ -89,15 +106,48 @@ export const Modal: React.FC<ModalProps> = ({
       {open && (
         <FocusTrap
           focusTrapOptions={{
-            initialFocus: false,
+            // `initialFocus: false` used to be set here, which tells
+            // focus-trap explicitly NOT to move focus into the dialog. The
+            // effect is that opening a modal left focus on the trigger behind
+            // it: a keyboard user got no indication the dialog existed, and a
+            // screen reader went on reading the page underneath.
+            //
+            // Focus goes to the first interactive element in the dialog
+            // *body*, not simply the first tabbable node — that one is the
+            // Close button in the header, so the first thing offered to a
+            // keyboard user would be dismissing what they just opened.
+            initialFocus: () =>
+              bodyRef.current?.querySelector<HTMLElement>(
+                'input:not([type="hidden"]), select, textarea, [href], button, [tabindex]:not([tabindex="-1"])'
+              ) ??
+              dialogRef.current ??
+              undefined,
+
+            // A dialog of pure prose has no tabbable node at all, and
+            // focus-trap throws rather than doing nothing. The dialog itself
+            // carries tabIndex={-1} so there is always somewhere legitimate
+            // for focus to rest — which is also what a screen reader wants,
+            // since it puts the reading cursor on the dialog's name.
+            fallbackFocus: () => dialogRef.current ?? document.body,
+
+            // The trigger regains focus when the dialog closes.
+            returnFocusOnDeactivate: true,
+
             allowOutsideClick: true,
           }}
         >
           <div 
+            ref={dialogRef}
+            tabIndex={-1}
             className="fixed inset-0 flex items-center justify-center p-4 md:p-8" 
             style={{ zIndex }}
             role="dialog"
             aria-modal="true"
+            // Without this the dialog has no accessible name: the <h2> below
+            // was rendered but never referenced, so assistive tech announced
+            // an unnamed dialog. Only set when there is a title to point at —
+            // aria-labelledby resolving to nothing is worse than absent.
+            aria-labelledby={title ? titleId : undefined}
           >
             {/* Backdrop */}
             <motion.div
@@ -130,21 +180,25 @@ export const Modal: React.FC<ModalProps> = ({
                   </div>
                 )}
                 <div className="flex-1 min-w-0">
-                  {title && <h2 className="display-small truncate">{title}</h2>}
+                  {title && (
+                    <h2 id={titleId} className="display-small truncate">
+                      {title}
+                    </h2>
+                  )}
                   {subtitle && <p className="detail text-secondary mt-1">{subtitle}</p>}
                 </div>
                 <button
                   type="button"
                   onClick={onClose}
                   className="w-9 h-9 flex items-center justify-center rounded-md hover:bg-secondary text-secondary transition-default shrink-0"
-                  aria-label="Close"
+                  aria-label={closeLabel}
                 >
                   <X size={20} />
                 </button>
               </div>
 
               {/* Body */}
-              <div className="flex-1 overflow-y-auto p-6 body">
+              <div ref={bodyRef} className="flex-1 overflow-y-auto p-6 body">
                 {children}
               </div>
 

--- a/tests/e2e/login-flows.spec.ts
+++ b/tests/e2e/login-flows.spec.ts
@@ -2,26 +2,55 @@
  * End-to-End Login Flow Tests with Playwright
  * Full browser automation tests for authentication flows
  *
- * Prerequisites:
- *   npm install -D @playwright/test
- *   npx playwright install
- *
  * Run:
  *   npx playwright test tests/e2e/login-flows.spec.ts
+ *
+ * Two things this file used to get wrong, both of which made every test in it
+ * fail regardless of the app's behaviour:
+ *
+ *  - Every navigation hardcoded `http://localhost:3000`, while the Playwright
+ *    config starts the server under test on 3002 (PLAYWRIGHT_PORT). The suite
+ *    was pointed at whatever happened to be on 3000 — usually nothing, hence
+ *    ERR_CONNECTION_REFUSED. Paths are now relative, so `baseURL` resolves them
+ *    and the tests follow the config instead of contradicting it.
+ *  - Half the describes seed users through Prisma, which needs a migrated
+ *    database that CI does not provision. Those are now behind RUN_DB_E2E, the
+ *    same gate `team-capacity-api.spec.ts` uses, and the client is created
+ *    lazily so merely importing this file no longer requires DATABASE_URL.
+ *
+ * What is left ungated needs nothing but the app: it exercises the login page
+ * itself and the middleware redirect on protected routes.
  */
 
-import { test, expect, type Page } from "@playwright/test";
-import { PrismaClient } from "@prisma/client";
+import { test, expect } from "@playwright/test";
+import type { PrismaClient } from "@prisma/client";
 import { randomUUID } from "crypto";
 import { hash } from "bcryptjs";
 
-const prisma = new PrismaClient();
+/**
+ * Constructing a PrismaClient does not connect, but it does read the schema's
+ * env() bindings on first query. Deferring construction keeps the import side
+ * of this module free of database requirements, so the ungated describes run
+ * in an environment that has no database at all.
+ */
+let prismaClient: PrismaClient | undefined;
+function db(): PrismaClient {
+  if (!prismaClient) {
+    // Required lazily for the same reason.
+    const { PrismaClient: Client } = require("@prisma/client");
+    prismaClient = new Client() as PrismaClient;
+  }
+  return prismaClient;
+}
+
+/** Seeding requires a migrated database; CI has none. See the file header. */
+const describeWithDb = process.env.RUN_DB_E2E ? test.describe : test.describe.skip;
 
 // Helper to create test user
 async function createTestUser(email: string, role: "USER" | "ADMIN" = "USER") {
   const userId = `test-${randomUUID()}`;
 
-  await prisma.users.create({
+  await db().users.create({
     data: {
       id: userId,
       email,
@@ -33,7 +62,7 @@ async function createTestUser(email: string, role: "USER" | "ADMIN" = "USER") {
     },
   });
 
-  await prisma.authenticator.create({
+  await db().authenticator.create({
     data: {
       id: randomUUID(),
       userId,
@@ -50,13 +79,13 @@ async function createTestUser(email: string, role: "USER" | "ADMIN" = "USER") {
 
 // Helper to cleanup test user
 async function cleanupTestUser(userId: string) {
-  await prisma.authenticator.deleteMany({ where: { userId } });
-  await prisma.users.delete({ where: { id: userId } });
+  await db().authenticator.deleteMany({ where: { userId } });
+  await db().users.delete({ where: { id: userId } });
 }
 
 test.describe("Login Page UI", () => {
   test("should display login page correctly", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     // Check for login form elements
     await expect(page.locator('input[type="email"]')).toBeVisible();
@@ -64,7 +93,7 @@ test.describe("Login Page UI", () => {
   });
 
   test("should show validation for empty email", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     const loginButton = page.getByRole("button", { name: /login|sign in/i });
     await loginButton.click();
@@ -74,7 +103,7 @@ test.describe("Login Page UI", () => {
   });
 
   test("should show validation for invalid email format", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     const emailInput = page.locator('input[type="email"]');
     await emailInput.fill("not-an-email");
@@ -87,7 +116,7 @@ test.describe("Login Page UI", () => {
   });
 });
 
-test.describe("Login Flow - Regular User", () => {
+describeWithDb("Login Flow - Regular User", () => {
   let testUserId: string;
   const testEmail = `e2e-test-${Date.now()}@example.com`;
 
@@ -101,7 +130,7 @@ test.describe("Login Flow - Regular User", () => {
   });
 
   test("should initiate login for existing user", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     const emailInput = page.locator('input[type="email"]');
     await emailInput.fill(testEmail);
@@ -124,7 +153,7 @@ test.describe("Login Flow - Regular User", () => {
 
 test.describe("Login Flow - Non-existent User", () => {
   test("should show error for non-existent user", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     const emailInput = page.locator('input[type="email"]');
     await emailInput.fill(`nonexistent-${Date.now()}@example.com`);
@@ -139,7 +168,7 @@ test.describe("Login Flow - Non-existent User", () => {
   });
 });
 
-test.describe("Admin Login Flow", () => {
+describeWithDb("Admin Login Flow", () => {
   const adminEmail = `admin-e2e-${Date.now()}@example.com`;
   const adminCode = "123456";
   let adminUserId: string;
@@ -148,7 +177,7 @@ test.describe("Admin Login Flow", () => {
     adminUserId = `test-${randomUUID()}`;
     const tokenHash = await hash(adminCode, 10);
 
-    await prisma.users.create({
+    await db().users.create({
       data: {
         id: adminUserId,
         email: adminEmail,
@@ -160,7 +189,7 @@ test.describe("Admin Login Flow", () => {
       },
     });
 
-    await prisma.emailApproval.create({
+    await db().emailApproval.create({
       data: {
         email: adminEmail,
         tokenHash,
@@ -171,12 +200,12 @@ test.describe("Admin Login Flow", () => {
   });
 
   test.afterAll(async () => {
-    await prisma.emailApproval.deleteMany({ where: { email: adminEmail } });
-    await prisma.users.delete({ where: { id: adminUserId } });
+    await db().emailApproval.deleteMany({ where: { email: adminEmail } });
+    await db().users.delete({ where: { id: adminUserId } });
   });
 
   test("should show admin login form", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     // Look for admin login toggle/link
     const adminLink = page.locator("text=/admin.*login|admin.*access/i").first();
@@ -192,7 +221,7 @@ test.describe("Admin Login Flow", () => {
 
 test.describe("Rate Limiting UI", () => {
   test("should show rate limit message after too many attempts", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     const emailInput = page.locator('input[type="email"]');
     const loginButton = page.getByRole("button", { name: /login|sign in/i });
@@ -220,14 +249,14 @@ test.describe("Protected Routes", () => {
   test("should redirect to login when accessing protected route without session", async ({
     page,
   }) => {
-    await page.goto("http://localhost:3000/dashboard");
+    await page.goto("/dashboard");
 
     // Should redirect to login
     await expect(page).toHaveURL(/\/login/);
   });
 
   test("should redirect to login when accessing admin route without session", async ({ page }) => {
-    await page.goto("http://localhost:3000/admin");
+    await page.goto("/admin");
 
     // Should redirect to login
     await expect(page).toHaveURL(/\/login/);
@@ -236,7 +265,7 @@ test.describe("Protected Routes", () => {
 
 test.describe("Accessibility", () => {
   test("login page should be keyboard navigable", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     // Tab to email input
     await page.keyboard.press("Tab");
@@ -253,7 +282,7 @@ test.describe("Accessibility", () => {
   });
 
   test("login page should have proper ARIA labels", async ({ page }) => {
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     // Check for accessible form labels
     const emailInput = page.locator('input[type="email"]');
@@ -268,7 +297,7 @@ test.describe("Accessibility", () => {
 test.describe("Responsive Design", () => {
   test("login page should work on mobile viewport", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     // Form should still be visible and usable
     await expect(page.locator('input[type="email"]')).toBeVisible();
@@ -277,7 +306,7 @@ test.describe("Responsive Design", () => {
 
   test("login page should work on tablet viewport", async ({ page }) => {
     await page.setViewportSize({ width: 768, height: 1024 }); // iPad
-    await page.goto("http://localhost:3000/login");
+    await page.goto("/login");
 
     await expect(page.locator('input[type="email"]')).toBeVisible();
     await expect(page.getByRole("button", { name: /login|sign in/i })).toBeVisible();

--- a/tests/e2e/plan-timeline.spec.ts
+++ b/tests/e2e/plan-timeline.spec.ts
@@ -16,7 +16,11 @@
 import { test, expect, type Page } from "@playwright/test";
 
 // Test configuration
-const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+// Navigations are relative so Playwright resolves them against the config's
+// `baseURL` (see playwright.config.ts, which also honours
+// PLAYWRIGHT_BASE_URL). The previous default of http://localhost:3000
+// contradicted the server the config actually starts, on 3002.
+const BASE_URL = "";
 
 // Helper to wait for timeline to load
 async function waitForTimeline(page: Page) {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Route smoke tests.
+ *
+ * This exists because the rest of `tests/e2e` could not be made into a CI
+ * gate. Measured against a production build of this app, that suite is 9
+ * passed / 51 failed / 39 skipped: `plan-timeline.spec.ts` is placeholders,
+ * `team-capacity-api.spec.ts` needs a seeded database, and the visual and
+ * user-journey specs navigate to `/projects` and `/projects/new`, which do
+ * not exist here. They assert a UI this app does not have, so making them
+ * required would mean either a permanently red build or 51 more skips.
+ *
+ * What this file asserts instead is small, true, and cheap enough that nobody
+ * learns to ignore it — a slow or flaky required check is how an end-to-end
+ * suite becomes decorative:
+ *
+ *  - Every route in the app answers, and answers the way the auth boundary
+ *    says it should. This catches a build that compiles but 500s on load, a
+ *    page that stops being protected, and a route deleted by accident.
+ *  - The login page — the one screen an unauthenticated visitor can reach —
+ *    renders a usable, named form.
+ *
+ * The table below is deliberately exhaustive rather than a sample: a new page
+ * added without a line here is a page nobody checked. It was built by probing
+ * a running production build, not from the middleware source, so it records
+ * what the app does rather than what it intends.
+ */
+
+import { test, expect } from "@playwright/test";
+
+/**
+ * The middleware sends a relative Location ("/login?callbackUrl=%2Fdashboard"),
+ * which URL cannot parse on its own. The origin here only exists to make it
+ * parseable — nothing asserts against it.
+ */
+function redirectTarget(response: { headers(): Record<string, string> }): URL {
+  const location = response.headers()["location"];
+  expect(location, "response carried no Location header").toBeTruthy();
+  return new URL(location, "http://redirect.invalid");
+}
+
+/** Reachable without a session. */
+const PUBLIC_ROUTES = ["/login", "/register", "/design"];
+
+/**
+ * Redirected to /login when there is no session. `/` and `/admin` are absent
+ * on purpose — they are covered separately below because they redirect
+ * somewhere else first.
+ */
+const PROTECTED_ROUTES = [
+  "/dashboard",
+  "/account",
+  "/admin/users",
+  "/architecture",
+  "/architecture/v3",
+  "/gantt-tool",
+  "/organization-chart",
+  "/settings",
+  "/settings/security",
+];
+
+/**
+ * The route sweep uses the `request` fixture rather than page navigations.
+ * That is not just a speed choice: the middleware rate-limits by IP at 60
+ * requests a minute, and a browser navigation costs far more than one — the
+ * document, the RSC payload, the session endpoint. Sweeping fourteen routes
+ * in a browser tripped the limiter partway through, and a 429 looks exactly
+ * like "the redirect stopped working". One request per route stays well
+ * inside the budget and asserts the middleware contract directly.
+ */
+test.describe("Public routes", () => {
+  for (const route of PUBLIC_ROUTES) {
+    test(`${route} is reachable without a session`, async ({ request }) => {
+      const response = await request.get(route, { maxRedirects: 0 });
+
+      expect(response.status(), `${route} should return 200`).toBe(200);
+    });
+  }
+});
+
+test.describe("Protected routes", () => {
+  for (const route of PROTECTED_ROUTES) {
+    test(`${route} redirects an anonymous visitor to /login`, async ({ request }) => {
+      const response = await request.get(route, { maxRedirects: 0 });
+
+      // Guarded explicitly, because a 429 would otherwise read as "this route
+      // stopped redirecting" and send someone hunting through the middleware.
+      expect(response.status(), `${route} was rate limited, not routed`).not.toBe(429);
+      expect(response.status(), `${route} should redirect`).toBe(307);
+
+      const location = redirectTarget(response);
+      expect(location.pathname).toBe("/login");
+      // The callback is what returns the user to where they were going, so
+      // losing it is a real regression even though the redirect still "works".
+      expect(location.searchParams.get("callbackUrl")).toBe(route);
+    });
+  }
+
+  test("/ redirects an anonymous visitor to /login", async ({ request }) => {
+    const response = await request.get("/", { maxRedirects: 0 });
+
+    expect(response.status()).toBe(307);
+    // No callbackUrl here: the root is where login sends people anyway.
+    expect(redirectTarget(response).pathname).toBe("/login");
+  });
+
+  test("/admin never serves the admin page to an anonymous visitor", async ({
+    request,
+  }) => {
+    // /admin is the one route that does not go straight to /login — the
+    // middleware bounces it to /dashboard, which then redirects. Recorded as
+    // it behaves rather than treated as a defect; what matters is that the
+    // chain terminates at /login and never renders the admin page.
+    const first = await request.get("/admin", { maxRedirects: 0 });
+    expect(first.status()).toBe(307);
+    expect(redirectTarget(first).pathname).toBe("/dashboard");
+
+    const second = await request.get("/dashboard", { maxRedirects: 0 });
+    expect(second.status()).toBe(307);
+    expect(redirectTarget(second).pathname).toBe("/login");
+  });
+});
+
+test.describe("Login page", () => {
+  test("presents a named email field and a submit control", async ({ page }) => {
+    await page.goto("/login");
+
+    // By accessible name, not by selector: the point is that a screen reader
+    // user can find the field, which a CSS selector would not prove.
+    const email = page.getByRole("textbox", { name: /work email/i });
+    await expect(email).toBeVisible();
+    await expect(email).toHaveAttribute("type", "email");
+
+    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+  });
+
+  test("is operable by keyboard alone", async ({ page }) => {
+    await page.goto("/login");
+
+    const email = page.getByRole("textbox", { name: /work email/i });
+    await email.focus();
+    await page.keyboard.type("someone@example.com");
+
+    await expect(email).toHaveValue("someone@example.com");
+
+    // Tab must reach the submit control from the field — if it does not, the
+    // only way to sign in is with a mouse.
+    await page.keyboard.press("Tab");
+    await expect(page.getByRole("button", { name: /continue/i })).toBeFocused();
+  });
+});

--- a/tests/e2e/view-switching.spec.ts
+++ b/tests/e2e/view-switching.spec.ts
@@ -7,7 +7,11 @@
 
 import { test, expect, Page } from '@playwright/test';
 
-const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+// Navigations are relative so Playwright resolves them against the config's
+// `baseURL` (see playwright.config.ts, which also honours
+// PLAYWRIGHT_BASE_URL). The previous default of http://localhost:3000
+// contradicted the server the config actually starts, on 3002.
+const BASE_URL = "";
 
 // Helper to login (if auth is required)
 async function login(page: Page) {

--- a/tests/integration/delta-optimistic-lock.int.test.ts
+++ b/tests/integration/delta-optimistic-lock.int.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Optimistic locking on the delta route, against a real database.
+ *
+ * The defect: two clients editing the same task both succeeded, and the second
+ * silently overwrote the first. In a local-first app whose clients queue
+ * changes while offline, that is not a rare race — it is the ordinary outcome
+ * after two people work on the same plan on a plane.
+ *
+ * Mocked tests cannot demonstrate this. The guarantee is a property of the
+ * WHERE clause in a real transaction, so these call the real route against a
+ * real PostgreSQL.
+ *
+ * Run with:
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/cockpit_e2e \
+ *   RUN_DB_E2E=1 npx vitest run tests/integration/delta-optimistic-lock.int.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterAll, vi } from "vitest";
+import { randomUUID } from "crypto";
+import { NextRequest } from "next/server";
+
+const describeDb = process.env.RUN_DB_E2E ? describe : describe.skip;
+
+/**
+ * A REAL client, obtained through `vi.importActual`.
+ *
+ * `tests/setup.ts` mocks `@prisma/client` itself, not merely `@/lib/db`. So a
+ * plain `new PrismaClient()` here — and a plain `import("@prisma/client")`
+ * inside the mock factory below — both return the in-memory mock, and the
+ * whole suite passes without ever opening a connection.
+ *
+ * That is exactly what happened when this file was first written: it asserted
+ * real database behaviour, passed, and touched no database. `importActual` is
+ * what makes the word "integration" true here.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let db: any;
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@prisma/client")>("@prisma/client");
+  return { prisma: new actual.PrismaClient() };
+});
+
+vi.mock("@/lib/gantt-tool/access-control", () => ({
+  checkProjectAccess: vi.fn().mockResolvedValue({ canWrite: true, canRead: true }),
+}));
+
+let userId = "";
+let projectId = "";
+let phaseId = "";
+let taskId = "";
+
+async function realClient() {
+  const actual = await vi.importActual<typeof import("@prisma/client")>("@prisma/client");
+  return new actual.PrismaClient();
+}
+
+async function seed() {
+  if (!db) db = await realClient();
+  userId = randomUUID();
+  projectId = randomUUID();
+  phaseId = randomUUID();
+  taskId = randomUUID();
+
+  await db.users.create({
+    data: {
+      id: userId,
+      email: `qa-lock-${userId.slice(0, 8)}@example.com`,
+      role: "USER",
+      accessExpiresAt: new Date(Date.now() + 86_400_000),
+      updatedAt: new Date(),
+    },
+  });
+  await db.ganttProject.create({
+    data: { id: projectId, userId, name: `QA lock ${projectId.slice(0, 8)}`, startDate: new Date("2026-01-01"), viewSettings: {} },
+  });
+  await db.ganttPhase.create({
+    data: {
+      id: phaseId,
+      projectId,
+      name: "Realize",
+      // Required by the real schema; the mock let it through as undefined.
+      color: "#0B57D0",
+      startDate: new Date("2026-01-01"),
+      endDate: new Date("2026-06-30"),
+      order: 0,
+    },
+  });
+  await db.ganttTask.create({
+    data: {
+      id: taskId,
+      phaseId,
+      name: "Original",
+      startDate: new Date("2026-01-01"),
+      endDate: new Date("2026-02-01"),
+      order: 0,
+    },
+  });
+}
+
+async function cleanup() {
+  if (!db) return;
+  if (projectId) await db.ganttProject.deleteMany({ where: { id: projectId } });
+  if (userId) await db.users.deleteMany({ where: { id: userId } });
+}
+
+async function patchDelta(delta: unknown) {
+  const { PATCH } = await import("@/app/api/gantt-tool/projects/[projectId]/delta/route");
+  const req = new NextRequest(`http://localhost:3000/api/gantt-tool/projects/${projectId}/delta`, {
+    method: "PATCH",
+    body: JSON.stringify(delta),
+    headers: { "Content-Type": "application/json" },
+  });
+  return PATCH(req, { params: Promise.resolve({ projectId }) });
+}
+
+const DATES = { startDate: "2026-01-01T00:00:00.000Z", endDate: "2026-02-01T00:00:00.000Z" };
+
+afterAll(async () => {
+  if (db) {
+    await cleanup();
+    await db.$disconnect();
+  }
+});
+
+describeDb("delta save — optimistic locking", () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seed();
+  });
+
+  test("a write at the current version succeeds and bumps it", async () => {
+    const res = await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "First edit", version: 0, ...DATES }] },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.conflicts).toEqual([]);
+
+    const after = await db.ganttTask.findUnique({ where: { id: taskId } });
+    expect(after?.name).toBe("First edit");
+    expect(after?.version).toBe(1);
+  });
+
+  test("THE DEFECT: a second client at a stale version does not overwrite", async () => {
+    // Both clients read version 0. The first commits.
+    await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "First edit", version: 0, ...DATES }] },
+    });
+
+    // The second is still holding version 0 — it never saw the first edit.
+    const res = await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "Second edit", version: 0, ...DATES }] },
+    });
+    const body = await res.json();
+
+    // Before this change, "Second edit" won silently and "First edit" was gone.
+    const after = await db.ganttTask.findUnique({ where: { id: taskId } });
+    expect(after?.name).toBe("First edit");
+    expect(after?.version).toBe(1);
+
+    expect(body.conflicts).toEqual([
+      { entity: "task", id: taskId, expectedVersion: 0 },
+    ]);
+  });
+
+  test("a conflict does not roll back the rest of the batch", async () => {
+    // The reason conflicts are reported rather than thrown: a local-first
+    // client batches a whole offline session, and losing forty good edits
+    // because the forty-first collided is worse than the collision.
+    await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "First edit", version: 0, ...DATES }] },
+    });
+
+    const res = await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "Stale", version: 0, ...DATES }] },
+      phases: {
+        updated: [
+          {
+            id: phaseId,
+            name: "Renamed phase",
+            startDate: "2026-01-01T00:00:00.000Z",
+            endDate: "2026-06-30T00:00:00.000Z",
+            order: 0,
+            version: 0,
+          },
+        ],
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // The task collided...
+    expect(body.conflicts).toHaveLength(1);
+    expect(body.conflicts[0].entity).toBe("task");
+    // ...and the phase, which did not, still applied.
+    const phase = await db.ganttPhase.findUnique({ where: { id: phaseId } });
+    expect(phase?.name).toBe("Renamed phase");
+    expect(phase?.version).toBe(1);
+  });
+
+  test("a client that sends no version still writes, as before", async () => {
+    // Backwards compatibility is the point: requiring a version would break
+    // every deployed client on the day this ships.
+    const res = await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "Unversioned", ...DATES }] },
+    });
+    const body = await res.json();
+
+    expect(body.conflicts).toEqual([]);
+    const after = await db.ganttTask.findUnique({ where: { id: taskId } });
+    expect(after?.name).toBe("Unversioned");
+    // Still incremented, so a versioned client that reads afterwards is correct.
+    expect(after?.version).toBe(1);
+  });
+
+  test("phases lock independently of tasks", async () => {
+    await patchDelta({
+      phases: {
+        updated: [
+          {
+            id: phaseId,
+            name: "First",
+            startDate: "2026-01-01T00:00:00.000Z",
+            endDate: "2026-06-30T00:00:00.000Z",
+            order: 0,
+            version: 0,
+          },
+        ],
+      },
+    });
+
+    const res = await patchDelta({
+      phases: {
+        updated: [
+          {
+            id: phaseId,
+            name: "Stale",
+            startDate: "2026-01-01T00:00:00.000Z",
+            endDate: "2026-06-30T00:00:00.000Z",
+            order: 0,
+            version: 0,
+          },
+        ],
+      },
+    });
+    const body = await res.json();
+
+    expect(body.conflicts).toEqual([
+      { entity: "phase", id: phaseId, expectedVersion: 0 },
+    ]);
+    const phase = await db.ganttPhase.findUnique({ where: { id: phaseId } });
+    expect(phase?.name).toBe("First");
+  });
+
+  test("a client that re-reads and retries at the new version succeeds", async () => {
+    // The recovery path the conflict report exists to enable.
+    await patchDelta({
+      tasks: { updated: [{ id: taskId, name: "First edit", version: 0, ...DATES }] },
+    });
+
+    const current = await db.ganttTask.findUnique({ where: { id: taskId } });
+    const res = await patchDelta({
+      tasks: {
+        updated: [{ id: taskId, name: "Merged edit", version: current!.version, ...DATES }],
+      },
+    });
+    const body = await res.json();
+
+    expect(body.conflicts).toEqual([]);
+    const after = await db.ganttTask.findUnique({ where: { id: taskId } });
+    expect(after?.name).toBe("Merged edit");
+    expect(after?.version).toBe(2);
+  });
+});

--- a/tests/integration/delta-task-persistence.int.test.ts
+++ b/tests/integration/delta-task-persistence.int.test.ts
@@ -18,18 +18,30 @@
  */
 
 import { describe, test, expect, beforeEach, afterAll, vi } from "vitest";
-import { PrismaClient } from "@prisma/client";
 import { randomUUID } from "crypto";
 import { NextRequest } from "next/server";
 
 const describeDb = process.env.RUN_DB_E2E ? describe : describe.skip;
 
 // A real client, replacing the global in-memory mock from tests/setup.ts.
-const db = new PrismaClient();
+/**
+ * A REAL client, obtained through `vi.importActual`.
+ *
+ * `tests/setup.ts` mocks `@prisma/client` itself, not merely `@/lib/db`. So a
+ * plain `new PrismaClient()` here — and a plain `import("@prisma/client")`
+ * inside the mock factory below — both return the in-memory mock, and the
+ * whole suite passes without ever opening a connection.
+ *
+ * That is exactly what happened when this file was first written: it asserted
+ * real database behaviour, passed, and touched no database. `importActual` is
+ * what makes the word "integration" true here.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let db: any;
 
 vi.mock("@/lib/db", async () => {
-  const { PrismaClient: PC } = await import("@prisma/client");
-  return { prisma: new PC() };
+  const actual = await vi.importActual<typeof import("@prisma/client")>("@prisma/client");
+  return { prisma: new actual.PrismaClient() };
 });
 
 // The caller legitimately owns the project; object-level authorization is
@@ -46,7 +58,13 @@ let taskBId = "";
 let resourceId = "";
 let assignmentId = "";
 
+async function realClient() {
+  const actual = await vi.importActual<typeof import("@prisma/client")>("@prisma/client");
+  return new actual.PrismaClient();
+}
+
 async function seed() {
+  if (!db) db = await realClient();
   userId = randomUUID();
   projectId = randomUUID();
   phaseId = randomUUID();
@@ -70,6 +88,9 @@ async function seed() {
       userId,
       name: `QA delta ${projectId.slice(0, 8)}`,
       startDate: new Date("2026-01-01"),
+      // Required and non-nullable. The in-memory mock never enforced it, which
+      // is one way these tests looked correct while touching no database.
+      viewSettings: {},
     },
   });
   await db.ganttResource.create({
@@ -79,6 +100,7 @@ async function seed() {
       name: "QA Resource",
       category: "Functional",
       designation: "Consultant",
+      description: "Seed resource",
     },
   });
   await db.ganttPhase.create({
@@ -86,6 +108,8 @@ async function seed() {
       id: phaseId,
       projectId,
       name: "Realize",
+      // Required by the real schema; the mock let it through as undefined.
+      color: "#0B57D0",
       startDate: new Date("2026-01-01"),
       endDate: new Date("2026-06-30"),
       order: 0,
@@ -107,11 +131,18 @@ async function seed() {
     });
   }
   await db.ganttTaskResourceAssignment.create({
-    data: { id: assignmentId, taskId: taskAId, resourceId, allocationPercentage: 50 },
+    data: {
+      id: assignmentId,
+      taskId: taskAId,
+      resourceId,
+      allocationPercentage: 50,
+      assignmentNotes: "",
+    },
   });
 }
 
 async function cleanup() {
+  if (!db) return;
   if (projectId) await db.ganttProject.deleteMany({ where: { id: projectId } });
   if (userId) await db.users.deleteMany({ where: { id: userId } });
 }
@@ -134,8 +165,10 @@ const DATES = { startDate: "2026-01-01T00:00:00.000Z", endDate: "2026-02-01T00:0
 const PHASE_DATES = { startDate: "2026-01-01T00:00:00.000Z", endDate: "2026-06-30T00:00:00.000Z" };
 
 afterAll(async () => {
-  await cleanup();
-  await db.$disconnect();
+  if (db) {
+    await cleanup();
+    await db.$disconnect();
+  }
 });
 
 describeDb("delta save — task persistence via the real route", () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -480,6 +480,41 @@ if (typeof window !== 'undefined') {
     },
   });
 
+  // Element.prototype.getClientRects
+  //
+  // jsdom performs no layout, so every element reports zero client rects.
+  // `tabbable` — which focus-trap uses to find focusable nodes — treats zero
+  // rects as "not rendered", therefore "not tabbable". The consequence is that
+  // focus-trap's activate() throws "must have at least one container with at
+  // least one tabbable node in it" for EVERY modal in the suite, which is why
+  // the focus-trap tests are skipped wholesale rather than passing.
+  //
+  // The shim reports one rect per element, but defers the actual visibility
+  // decision to computed style, which jsdom does implement. An element that is
+  // genuinely hidden still reads as untabbable, so a real regression — a modal
+  // whose only focusable control is display:none — is still caught.
+  const HAS_LAYOUT = [new DOMRect(0, 0, 1, 1)] as unknown as DOMRectList;
+  const NO_LAYOUT = [] as unknown as DOMRectList;
+
+  Object.defineProperty(Element.prototype, 'getClientRects', {
+    configurable: true,
+    value: function (this: Element): DOMRectList {
+      if (!this.isConnected) return NO_LAYOUT;
+
+      // `display` is not inherited: a child of a display:none parent still
+      // computes its own display, while a real browser gives it no rects. The
+      // ancestor walk reproduces that.
+      for (let node: Element | null = this; node; node = node.parentElement) {
+        const style = realGetComputedStyle(node);
+        if (style.display === 'none') return NO_LAYOUT;
+        // visibility IS inherited, so it only needs checking on the element.
+        if (node === this && style.visibility === 'hidden') return NO_LAYOUT;
+      }
+
+      return HAS_LAYOUT;
+    },
+  });
+
   // Mock matchMedia for responsive components
   Object.defineProperty(window, 'matchMedia', {
     writable: true,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,8 +8,19 @@ import { TextEncoder, TextDecoder } from 'util';
 process.env.NEXTAUTH_SECRET = "test-secret-key-for-jwt-encoding-minimum-32-characters-long";
 process.env.ENABLE_MAGIC_LINKS = "true";
 process.env.NODE_ENV = "test";
-process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/unused";
-process.env.DATABASE_URL_UNPOOLED = "postgresql://postgres:postgres@localhost:5432/unused";
+// Pointed at a database that does not exist, so a unit test that reaches for a
+// real connection fails loudly instead of quietly hitting a developer's local
+// data. The `@prisma/client` mock below means nothing normally connects at all.
+//
+// The RUN_DB_E2E integration tests DO connect, via vi.importActual, so they
+// keep whatever DATABASE_URL the caller supplied. Overwriting it here is what
+// made those tests silently unable to reach Postgres.
+if (!process.env.RUN_DB_E2E) {
+  process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/unused";
+  process.env.DATABASE_URL_UNPOOLED = "postgresql://postgres:postgres@localhost:5432/unused";
+} else {
+  process.env.DATABASE_URL_UNPOOLED ??= process.env.DATABASE_URL ?? "";
+}
 process.env.TOTP_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 process.env.JWT_SECRET_KEY = "test-jwt-secret-key-for-ci-only-32-chars";
 


### PR DESCRIPTION
Picks up the three Tier-1 items from `docs/REMEDIATION.md`. Each one turned out to be hiding real defects rather than being a mechanical chore, so this is mostly a record of what was found.

## 1. Optimistic locking on the delta route (`1079528`)

`GanttPhase` and `GanttTask` now carry `version Int @default(0)`, and the delta route applies each write conditionally on the client's version. Two decisions worth knowing before changing this code:

- **An absent version writes unconditionally.** Existing clients do not send one, and rejecting them would have been a breaking change shipped as a bug fix.
- **A conflict is collected, not thrown.** Throwing rolls back the whole batch, and a local-first client batches an entire offline session — one stale task would discard everything else the user did. The response carries a `conflicts` array, always present and possibly empty.

This commit also carries a correction. `delta-task-persistence.int.test.ts` was described in its header, its commit message and merged PR #106 as running "against real PostgreSQL 16". It never opened a connection — `tests/setup.ts` mocks `@prisma/client` itself, not just `@/lib/db`. The fix it validated was correct (all 7 tests pass against a real database, unmodified except for seed fields the mock never enforced), but the verification claim was false. Both integration suites now bypass the mock via `vi.importActual`.

## 2. Un-skipping the accessibility suites (`d811d1f`)

74 tests that had never run. Working through them one file at a time, treating each failure as a finding rather than a test to delete, turned up four defects in shipping code:

- `StyleSelector`, `ReuseSystemModal`, `CurrentLandscapeTab` and `ProposedSolutionTab` had **no default `React` import**. tsconfig uses `jsx: "preserve"` with no automatic runtime, so the compiled JSX calls `React.createElement` by name. Next's build injects it, which is why this only surfaced under the test transform.
- `src/ui/components/Modal.tsx` passed **`initialFocus: false`** to focus-trap, which tells it explicitly *not* to move focus into the dialog. Opening a modal left focus on the trigger behind it. Focus now goes to the first interactive element in the dialog body — not the first tabbable node, which is the Close button, so the first thing offered would have been dismissing what you just opened.
- The same Modal rendered its `<h2>` title but **never referenced it**, so the dialog had `role="dialog"` and no accessible name. Now wired through `aria-labelledby`.
- Both modal foundations **hardcoded the close button's name**. A screen-reader user listing the buttons on a page with several dialogs heard the same word repeated with nothing to tell them apart. `closeLabel` now takes a name that describes its purpose.

Plus one test-environment defect of the same family as the `getComputedStyle` stub fixed earlier: jsdom reports zero client rects for everything, `tabbable` reads that as "not tabbable", and focus-trap's `activate()` therefore **threw for every modal in the suite**. `tests/setup.ts` now shims `getClientRects` but defers the visibility decision to computed style — which jsdom does implement — so a genuinely hidden control still reads as untabbable and a real regression is still caught.

One caveat is recorded on the test helper rather than worked around silently: jsdom's `querySelectorAll` returns a selector list's matches grouped by selector (nwsapi), and `tabbable` builds its candidates from one comma-joined list starting with `input`, so every `<input>` sorts ahead of every `<button>` regardless of markup order — reproducible with three plain elements and no application code. The cycling tests therefore assert the property that holds either way, that focus stays inside the dialog, and real tab order is left to the browser suite.

Result: `aria-labels` 16/16, `focus-trap` 27/27, `keyboard-navigation` 31/31. Full suite **2069 passed, 0 failed**.

## 3. Playwright in CI (`7910bdb`)

The e2e suite had never been run against a production build. Doing that first was the whole value of this change — the suite is **9 passed / 51 failed / 39 skipped**, and adding it to CI as-is would have produced a permanently red required check.

Three defects were fixed on the way to that number, each hiding the next:

- `login-flows.spec.ts` **hardcoded `http://localhost:3000`** in all 13 tests while the config serves 3002. It had never once reached the app under test. `view-switching` and `plan-timeline` defaulted to the same wrong port.
- The same file constructed a `PrismaClient` at module scope and seeded users in `beforeAll`, with no database anywhere in CI. Now behind `RUN_DB_E2E`, lazily.
- The production server refuses to boot without `NEXTAUTH_SECRET` and `NEXTAUTH_URL`; without them the `webServer` block times out after 120s with the real cause buried in the log.

With those fixed the suite reaches the app, and what it asserts turns out not to be this app: `view-switching` wants a GlobalNav link `[href="/gantt-tool"]` that is not rendered, and the visual-regression and user-journey specs navigate to `/projects` and `/projects/new`, which are not routes here. `plan-timeline.spec.ts` is 15 `test.skip()` placeholders.

So the CI job is **scoped to a new smoke spec and says so in a comment**, rather than hiding the gap behind 51 more skips. `tests/e2e/smoke.spec.ts` sweeps every route against the auth boundary — 3 public, 11 protected, plus `/admin`'s two-hop redirect through `/dashboard` — and checks the login page presents a named, keyboard-operable form. The route table is exhaustive on purpose, and was built by probing a running production build rather than reading the middleware.

It uses the `request` fixture rather than page navigations, which is not a speed choice: the middleware rate-limits by IP at 60/min and a browser navigation costs several requests. Sweeping fourteen routes in a browser tripped the limiter partway through, and **a 429 reads exactly like "the redirect stopped working"** — there is now an explicit assertion against 429 so that failure can never masquerade as a routing one. The 9-project device matrix was tried and rejected for the same reason (108 of 144 passed, the rest rate-limited).

16 tests, ~3 seconds. `playwright.config.ts` now runs `pnpm start` under CI instead of `pnpm dev`, so what is tested is what ships.

## Still open

Tracked in `docs/REMEDIATION.md`, updated here:

- The delta route's client does not yet **send** `version`, so the mechanism is available but not in force end to end. That belongs with the Gantt strangler port.
- `architecture/v3/__tests__/integration.test.tsx` is partly un-skipped — its CRUD, auto-save and persistence scenarios stay skipped with a stated reason, because they need a store fixture the suite does not stand up.
- The visual-regression and user-journey specs need rewriting against routes that exist, or deleting.
- Widening the e2e device matrix needs the rate limiter keyed on something other than IP in test environments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_