### PR TITLE
Apply migrations during the production build, and refuse when that is unsafe

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -36,7 +36,8 @@ Import `ib823/cockpit` in Vercel (Framework preset: **Next.js**). Under
 Optional (recommended for production, app degrades gracefully without them):
 `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` (rate limiting),
 `RESEND_API_KEY` or SMTP vars (email). Install command `pnpm install`,
-build command `pnpm build` (auto-detected; `build` runs `prisma generate`).
+build command `pnpm build` (auto-detected). `build` runs `prisma generate`,
+then `scripts/deploy-migrate.mjs`, then `next build` — see §4a.
 
 Pushing the branch (or merging to `main`) triggers the deploy.
 
@@ -52,6 +53,34 @@ export DATABASE_URL="<Neon DIRECT url>"
 pnpm prisma migrate deploy  # applies prisma/migrations (creates all 65 tables)
 pnpm prisma db seed         # seeds L3 catalog + regional holidays (reference data)
 ```
+
+## 4a. Migrations on deploy
+
+Production builds apply pending migrations automatically. `pnpm build` runs
+`scripts/deploy-migrate.mjs` between `prisma generate` and `next build`.
+
+This exists because a deploy that ships code without its schema is silent and
+severe: Prisma selects every scalar field by default, so a missing column makes
+even a plain read fail. When the optimistic-lock migration shipped without
+being applied, opening a Gantt project broke — not just saving one.
+
+**It only runs when `VERCEL_ENV=production`.** Preview deploys are excluded on
+purpose: unless `DATABASE_URL` is scoped per environment in Vercel, a preview
+build points at the production database, and a migration from an unmerged
+branch would land on live data. Local and CI builds are excluded for the same
+reason — `pnpm build` must not mutate a database as a side effect. Set
+`RUN_DEPLOY_MIGRATIONS=1` to opt in elsewhere.
+
+**It refuses to migrate an un-baselined database.** If the target has tables
+but no `0_init` row in `_prisma_migrations` — the signature of a database
+created by `prisma db push` before this repo had migrations — the build stops
+with instructions rather than attempting `0_init` against populated tables.
+Baseline it once (§4 note above, or `prisma/migrations/README.md`) and every
+migration after that applies on its own.
+
+A build failing here is the intended outcome, not a regression: the deploy it
+stopped would have gone green while production broke.
+
 
 ## 5. Your test login (no email service required)
 The app authenticates with **passkeys**; a one-time **admin code** bootstraps the

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && node scripts/deploy-migrate.mjs && next build",
     "start": "next start",
     "postinstall": "prisma generate",
     "lint": "next lint",

--- a/prisma/migrations/README.md
+++ b/prisma/migrations/README.md
@@ -86,7 +86,38 @@ Database schema is up to date!
 
 66 tables created (65 models + `_prisma_migrations`), no drift reported.
 
-Still untested: the `migrate resolve --applied 0_init` baselining path against a
-database that was originally created by `db push`. That is the path production
-will take, and it should be rehearsed on a copy of a real environment before the
-first restore drill.
+The baselining path has since been rehearsed, on 2026-08-08, against a
+reconstruction rather than a copy of production — a database built by applying
+`0_init`'s SQL directly, which reproduces the shape a `db push` database has
+and, crucially, leaves `_prisma_migrations` absent:
+
+```
+$ node scripts/deploy-migrate.mjs        # VERCEL_ENV=production
+[migrate] REFUSING TO MIGRATE — the database is not baselined.
+  It has 65 tables but no record of the '0_init' baseline.
+
+$ pnpm prisma migrate resolve --applied 0_init
+Migration 0_init marked as applied.
+
+$ node scripts/deploy-migrate.mjs
+[migrate] Database is baselined — applying pending migrations.
+Applying migration `20260807140000_add_optimistic_lock_versions`
+All migrations have been successfully applied.
+
+$ node scripts/deploy-migrate.mjs        # idempotent
+No pending migrations to apply.
+```
+
+That verifies the mechanism — `resolve` records the baseline without executing
+it, and `deploy` then applies only what is genuinely pending. It does **not**
+verify production's data or any drift particular to it: `migrate status` on the
+real database is still the check that matters, and it is worth running before
+the first restore drill.
+
+## Migrations on deploy
+
+Production builds now apply pending migrations through
+`scripts/deploy-migrate.mjs` (see `docs/DEPLOYMENT.md` §4a). That script encodes
+the warning above rather than trusting anyone to remember it: given tables with
+no `0_init` row, it stops the build instead of running the baseline against
+them.

--- a/scripts/deploy-migrate.mjs
+++ b/scripts/deploy-migrate.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Applies pending Prisma migrations during a Vercel production build.
+ *
+ * WHY THIS EXISTS
+ *
+ * The build was `prisma generate && next build`, with nothing anywhere in the
+ * pipeline that applied migrations — `docs/DEPLOYMENT.md` §4 said to run them
+ * by hand. That is fine right up until someone forgets, and then the deploy
+ * succeeds while the schema does not match. It happened: the optimistic-lock
+ * migration merged and shipped, and because Prisma selects every scalar field
+ * by default, `GanttTask.version` missing made even a plain read fail —
+ *
+ *     Invalid `prisma.ganttTask.findMany()` invocation:
+ *     The column `GanttTask.version` does not exist in the current database.
+ *
+ * — so opening a Gantt project broke, not just saving one. A deploy step that
+ * cannot be forgotten is the fix.
+ *
+ * WHY IT DOES NOT SIMPLY RUN `migrate deploy`
+ *
+ * This is the part worth reading before changing anything here. The production
+ * database predates the migration directory: it was created with
+ * `prisma db push`, so it carries all 65 tables and NO `_prisma_migrations`
+ * table. `0_init` is a baseline written as 65 `CREATE TABLE` statements. Run
+ * `migrate deploy` against that database and Prisma sees no applied
+ * migrations, tries `0_init`, and fails on the first table that already
+ * exists — and because this runs inside the build, that failure would block
+ * every deploy, on a database it also left half-touched.
+ *
+ * So the script decides what it is looking at first, and refuses rather than
+ * guesses. Three cases:
+ *
+ *   1. Empty database        -> safe. `migrate deploy` creates everything.
+ *   2. Baselined database    -> safe. `_prisma_migrations` records `0_init`;
+ *                               only genuinely pending migrations run.
+ *   3. Tables but no history -> STOP. Needs a one-time manual baseline, which
+ *                               is a decision about a live database and not
+ *                               something a build should make on its own.
+ *
+ * Case 3 fails the build on purpose. Shipping code whose schema is absent is
+ * the failure this file exists to prevent, and a build that goes green while
+ * production breaks is worse than one that stops with instructions.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Only production deploys migrate. Preview deploys are excluded deliberately:
+ * unless the Vercel project scopes `DATABASE_URL` per environment, a preview
+ * build points at the production database, and a migration from an unmerged
+ * branch would land on live data. Local and CI builds are excluded for the
+ * same reason in miniature — `pnpm build` should not mutate anyone's database
+ * as a side effect.
+ *
+ * `RUN_DEPLOY_MIGRATIONS=1` forces it on for anyone who wants this behaviour
+ * somewhere else, explicitly rather than by accident.
+ */
+const shouldRun =
+  process.env.RUN_DEPLOY_MIGRATIONS === "1" ||
+  process.env.VERCEL_ENV === "production";
+
+if (!shouldRun) {
+  const where = process.env.VERCEL_ENV
+    ? `VERCEL_ENV=${process.env.VERCEL_ENV}`
+    : "not a Vercel build";
+  console.log(
+    `[migrate] Skipping migrations (${where}). ` +
+      `Set RUN_DEPLOY_MIGRATIONS=1 to run them here.`
+  );
+  process.exit(0);
+}
+
+// Migrations need a direct connection; the Neon pooler cannot carry DDL
+// reliably. This mirrors `directUrl` in prisma/schema.prisma.
+const directUrl = process.env.DATABASE_URL_UNPOOLED || process.env.DATABASE_URL;
+
+if (!directUrl) {
+  console.error(
+    "[migrate] Neither DATABASE_URL_UNPOOLED nor DATABASE_URL is set. " +
+      "See docs/DEPLOYMENT.md §3."
+  );
+  process.exit(1);
+}
+
+/** Runs a prisma subcommand, inheriting stdio so its output reaches the build log. */
+function prisma(args) {
+  return execFileSync("node", ["node_modules/prisma/build/index.js", ...args], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
+
+/**
+ * Which of the three cases we are in.
+ *
+ * Uses the Prisma client rather than `migrate status`, whose output is prose
+ * and whose exit code cannot tell "needs baselining" apart from "has pending
+ * migrations" — and those two need opposite responses.
+ */
+async function inspectDatabase() {
+  const { PrismaClient } = await import("@prisma/client");
+  const client = new PrismaClient({ datasources: { db: { url: directUrl } } });
+
+  try {
+    const [{ count: tableCount }] = await client.$queryRaw`
+      SELECT count(*)::int AS count
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    `;
+
+    if (tableCount === 0) {
+      return { state: "empty" };
+    }
+
+    const [{ count: historyCount }] = await client.$queryRaw`
+      SELECT count(*)::int AS count
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = '_prisma_migrations'
+    `;
+
+    if (historyCount === 0) {
+      return { state: "unbaselined", tableCount };
+    }
+
+    // The history table can exist while `0_init` is absent — a partially
+    // baselined database is its own hazard, and is treated as case 3.
+    const [{ count: baselineCount }] = await client.$queryRaw`
+      SELECT count(*)::int AS count
+      FROM "_prisma_migrations"
+      WHERE migration_name = '0_init' AND finished_at IS NOT NULL
+    `;
+
+    return baselineCount > 0
+      ? { state: "baselined" }
+      : { state: "unbaselined", tableCount };
+  } finally {
+    await client.$disconnect();
+  }
+}
+
+const result = await inspectDatabase();
+
+if (result.state === "unbaselined") {
+  console.error(
+    [
+      "",
+      "[migrate] REFUSING TO MIGRATE — the database is not baselined.",
+      "",
+      `  It has ${result.tableCount} tables but no record of the '0_init' baseline.`,
+      "  That is the signature of a database created with `prisma db push`",
+      "  before this repo had migrations.",
+      "",
+      "  Running `migrate deploy` now would try to apply 0_init — 65 CREATE",
+      "  TABLE statements — against a populated database, fail on the first",
+      "  table that already exists, and leave it partially touched.",
+      "",
+      "  Baseline it once, by hand, against the DIRECT (unpooled) URL:",
+      "",
+      "    export DATABASE_URL='<Neon DIRECT url>'",
+      "    pnpm prisma migrate resolve --applied 0_init",
+      "    pnpm prisma migrate status     # expect: schema is up to date",
+      "",
+      "  Then redeploy. Every migration after that applies automatically.",
+      "  See prisma/migrations/README.md.",
+      "",
+    ].join("\n")
+  );
+  process.exit(1);
+}
+
+console.log(
+  result.state === "empty"
+    ? "[migrate] Empty database — applying all migrations."
+    : "[migrate] Database is baselined — applying pending migrations."
+);
+
+prisma(["migrate", "deploy"]);


### PR DESCRIPTION
Closes the gap that let #113 ship a migration without applying it.

## The problem

The build was `prisma generate && next build`. Nothing anywhere in the pipeline applied migrations — `docs/DEPLOYMENT.md` §4 said to run them by hand. That works right up until someone forgets, and then the deploy goes green while the schema does not match.

That just happened. The optimistic-lock migration merged and shipped without being applied. Because Prisma selects every scalar field by default, the missing column makes even a **read** fail — reproduced against a database held at the pre-migration schema:

```
READ FAILED: Invalid `prisma.ganttTask.findMany()` invocation:
The column `GanttTask.version` does not exist in the current database.
```

So opening a Gantt project breaks, not just saving one.

## Why this is not just `prisma migrate deploy`

This is the part worth reading before changing `scripts/deploy-migrate.mjs`.

The production database predates the migration directory. `prisma/migrations/README.md` records that it was created with `prisma db push`: it carries all 65 tables and **no `_prisma_migrations` table**. `0_init` is a baseline written as 65 `CREATE TABLE` statements.

Drop a plain `migrate deploy` into the build and, against that database, Prisma finds no applied migrations, attempts `0_init`, fails on the first table that already exists — and because it runs inside the build, **blocks every deploy**, on a database it also left half-touched. The naive version of this change is worse than the problem it fixes.

## What the script does instead

It decides what it is looking at before acting, and refuses rather than guesses:

| database state | action |
| --- | --- |
| empty | apply everything |
| baselined (`0_init` recorded) | apply only what is pending |
| tables but no `0_init` row | **stop the build**, print the one-time `migrate resolve --applied 0_init` |

The third case fails the build on purpose. The deploy it stops would have gone green while production broke.

It inspects `information_schema` through the Prisma client rather than parsing `migrate status`, whose exit code cannot distinguish "needs baselining" from "has pending migrations" — two states needing opposite responses.

**Only `VERCEL_ENV=production` migrates.** Preview deploys are excluded deliberately: unless `DATABASE_URL` is scoped per environment in Vercel, a preview build points at the production database, and a migration from an unmerged branch would land on live data. Local and CI builds are excluded so `pnpm build` never mutates a database as a side effect. `RUN_DEPLOY_MIGRATIONS=1` opts in explicitly.

## Verification

All four paths exercised against real PostgreSQL 16:

```
# not a production build
[migrate] Skipping migrations (not a Vercel build).                     exit 0

# tables, no _prisma_migrations  (production today)
[migrate] REFUSING TO MIGRATE — the database is not baselined.
  It has 65 tables but no record of the '0_init' baseline.              exit 1

# after `prisma migrate resolve --applied 0_init`
[migrate] Database is baselined — applying pending migrations.
Applying migration `20260807140000_add_optimistic_lock_versions`        exit 0

# rerun — idempotent
No pending migrations to apply.                                         exit 0

# empty database
[migrate] Empty database — applying all migrations.   66 tables         exit 0
```

The read that was failing then succeeds (`READ OK: 0 rows`), and `pnpm build` still completes locally, skipping as designed.

This also rehearses the baselining path that `prisma/migrations/README.md` flagged as **untested** — against a reconstruction of a `db push` database, not a copy of production. The README now says exactly that, and still points at `migrate status` on the real database as the check that matters.

## What this does not fix

- **Production still needs its one-time baseline.** Until `prisma migrate resolve --applied 0_init` is run against Neon, this script will stop the build with instructions rather than deploy. That is the intended behaviour, but it means the first deploy after this merges will fail if the baseline has not happened yet.
- **`/api/health` still reports `"database": "up"` through a schema mismatch.** It is a connectivity probe, not a schema check. Left alone here; worth doing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_