### PR TITLE
Fix two deployment instructions that could not work as written

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,16 +43,42 @@ Pushing the branch (or merging to `main`) triggers the deploy.
 
 ## 4. Create the schema + seed reference data (run once, locally)
 
-> If the target database **already has tables** (any environment created before
-> migrations existed), do NOT run `migrate deploy` — it will fail on the first
-> table that already exists. Baseline it instead with
-> `pnpm prisma migrate resolve --applied 0_init`, then `pnpm prisma migrate status`.
-> See `prisma/migrations/README.md`.
+**Export both URL variables.** `prisma/schema.prisma` declares
+`directUrl = env("DATABASE_URL_UNPOOLED")`, and Prisma validates every
+env() binding when it loads the schema — for *any* command, whether or not it
+needs the direct connection. Setting only `DATABASE_URL` fails before anything
+runs:
+
+```
+error: Environment variable not found: DATABASE_URL_UNPOOLED.
+Validation Error Count: 1
+```
+
+Both take the Neon **direct** (unpooled) URL here: migrations carry DDL, which
+the pooler does not reliably support.
+
 ```bash
-export DATABASE_URL="<Neon DIRECT url>"
+DIRECT="<Neon DIRECT url>"
+export DATABASE_URL="$DIRECT"
+export DATABASE_URL_UNPOOLED="$DIRECT"
+
 pnpm prisma migrate deploy  # applies prisma/migrations (creates all 65 tables)
 pnpm prisma db seed         # seeds L3 catalog + regional holidays (reference data)
 ```
+
+> **If the target database already has tables** (any environment created before
+> migrations existed), do NOT run `migrate deploy` first — it will fail on the
+> first table that already exists. Baseline it instead:
+>
+> ```bash
+> pnpm prisma migrate resolve --applied 0_init
+> pnpm prisma migrate deploy     # now applies only what is genuinely pending
+> pnpm prisma migrate status     # expect "Database schema is up to date!"
+> ```
+>
+> `migrate status` will **not** say "up to date" between the resolve and the
+> deploy — it correctly reports the remaining migrations as pending. Only run
+> it as the final check. See `prisma/migrations/README.md`.
 
 ## 4a. Migrations on deploy
 
@@ -86,7 +112,9 @@ stopped would have gone green while production broke.
 The app authenticates with **passkeys**; a one-time **admin code** bootstraps the
 first account. Run against the deployed DB:
 ```bash
-export DATABASE_URL="<Neon DIRECT url>"
+DIRECT="<Neon DIRECT url>"
+export DATABASE_URL="$DIRECT"
+export DATABASE_URL_UNPOOLED="$DIRECT"   # required — see §4
 export NEXTAUTH_URL="https://<your-vercel-domain>"
 pnpm admin:generate-code you@example.com "Your Name"
 ```

--- a/prisma/migrations/README.md
+++ b/prisma/migrations/README.md
@@ -27,6 +27,19 @@ It contains 65 `CREATE TABLE` statements (one per model) and 170 indexes.
 
 ## Applying it
 
+Every command below needs **both** URL variables exported, because
+`schema.prisma` declares `directUrl = env("DATABASE_URL_UNPOOLED")` and Prisma
+validates every env() binding when it loads the schema — for any command, even
+one that never opens the direct connection. With only `DATABASE_URL` set you
+get `Environment variable not found: DATABASE_URL_UNPOOLED` before anything
+runs. Both take the direct (unpooled) URL; migrations carry DDL.
+
+```bash
+DIRECT="<direct, unpooled url>"
+export DATABASE_URL="$DIRECT"
+export DATABASE_URL_UNPOOLED="$DIRECT"
+```
+
 ### A NEW database (empty)
 
 ```bash
@@ -47,16 +60,43 @@ Mark it as already applied instead:
 pnpm prisma migrate resolve --applied 0_init
 ```
 
-This writes the row into `_prisma_migrations` without executing any SQL. Verify
-before you do anything else:
+This writes the row into `_prisma_migrations` without executing any SQL. It
+does **not** leave the database up to date: any migration after the baseline is
+still pending, and `migrate status` will correctly say so. Apply those, then
+check:
 
 ```bash
-pnpm prisma migrate status
+pnpm prisma migrate deploy     # applies only what is genuinely pending
+pnpm prisma migrate status     # expect "Database schema is up to date!"
 ```
 
-Expect "Database schema is up to date!". If it instead reports drift, the live
-database does **not** match `schema.prisma` — resolve that difference explicitly
-before the next migration, and do not paper over it with `db push`.
+Run `migrate status` as the final check, not between the two — reading its
+"not yet applied" list at that point as a failure is the easy mistake here.
+
+If the final check reports drift, the live database does **not** match
+`schema.prisma` — resolve that difference explicitly before the next migration,
+and do not paper over it with `db push`.
+
+### Reading `_prisma_migrations` when something looks wrong
+
+A migration name can legitimately appear **twice**: once rolled back, once
+applied. That is a migration that failed and was retried, and it is resolved,
+not broken. What distinguishes the two states is which timestamps are set:
+
+| `finished_at` | `rolled_back_at` | meaning                                                   |
+| ------------- | ---------------- | --------------------------------------------------------- |
+| set           | null             | applied normally                                          |
+| null          | set              | failed, then explicitly rolled back — fine                |
+| null          | null             | **failed and unresolved** — blocks every future migration |
+
+Only the third row is a problem. Prisma refuses to apply anything while a
+migration looks unfinished, failing with `P3009`, which in this repo means the
+production build stops (`scripts/deploy-migrate.mjs` runs `migrate deploy`).
+The fix is `prisma migrate resolve --rolled-back "<migration_name>"` — or
+`--applied` if the change did in fact land and was fixed by hand.
+
+Note that `finished_at IS NULL` alone does not mean failure. Checking only that
+column will make a cleanly rolled-back row look like an outage.
 
 ### After baselining
 
@@ -113,6 +153,29 @@ it, and `deploy` then applies only what is genuinely pending. It does **not**
 verify production's data or any drift particular to it: `migrate status` on the
 real database is still the check that matters, and it is worth running before
 the first restore drill.
+
+## What production actually contained (observed 2026-08-08)
+
+Read from the live database rather than inferred, because it does not match
+what this file assumed:
+
+- `_prisma_migrations` **already existed**. The note above about the database
+  being push-managed is right about `0_init` never having been recorded, but
+  wrong that there was no history table at all.
+- It carried two migrations that **have never existed in this repository** —
+  not in the working tree and not anywhere in git history:
+  `20251020150129_add_org_chart_to_gantt_project` and
+  `20251119032925_team_capacity_models`. Prisma does not object: with the
+  baseline recorded, `migrate status` reports "Database schema is up to date!".
+  But the database's history and this repo's disagree, and that gap is a
+  restore-drill problem waiting to happen — a restore replays what is in the
+  repo, which is not what built the live schema.
+- `20251020150129_...` appears twice: rolled back at 03:14:07 on 2025-10-24 and
+  re-applied in the same second. Resolved, not broken — see the table above.
+
+The baseline itself was applied as SQL through the Neon console rather than via
+the CLI, which is equivalent: `migrate resolve --applied` only inserts a row,
+and the checksum it stores is the plain SHA-256 of the migration file.
 
 ## Migrations on deploy
 


### PR DESCRIPTION
Docs only. Both of these were followed during this week's production baseline, and both failed at the point of use — I repeated the first one to the user before testing it.

## 1. `export DATABASE_URL=...` alone is not enough

`schema.prisma` declares `directUrl = env("DATABASE_URL_UNPOOLED")`, and Prisma validates **every** `env()` binding when it loads the schema — for any command, including ones that never open the direct connection. So the documented sequence stopped before doing anything:

```
error: Environment variable not found: DATABASE_URL_UNPOOLED.
Validation Error Count: 1
```

`docs/DEPLOYMENT.md` §4 and §5 and `prisma/migrations/README.md` now export both and say why. Both take the direct URL, since migrations carry DDL that the pooler does not reliably support.

## 2. "Expect *Database schema is up to date!*" after `migrate resolve`

True only while `0_init` was the sole migration. With anything pending, `migrate status` correctly reports it as not yet applied — and reading that as a failure is the easy mistake, because the doc told you to expect the opposite.

The order is now **resolve → deploy → status**, with the check as the final step rather than the middle one.

## Two things the README gains from doing this for real

**How to read `_prisma_migrations` when a name appears twice.** A rolled-back row and an applied row for the same migration is a retry, not damage:

| `finished_at` | `rolled_back_at` | meaning |
| --- | --- | --- |
| set | null | applied normally |
| null | set | failed, then explicitly rolled back — fine |
| null | null | **failed and unresolved** — blocks every future migration |

Only the third is a problem, and only it triggers `P3009` — which now means a blocked production build, since `deploy-migrate.mjs` runs `migrate deploy`. Checking `finished_at` alone, which is the obvious thing to do, makes a cleanly rolled-back row look like an outage. Production has exactly such a row, from 2025-10-24.

**What production actually contained**, read rather than assumed, because it contradicts what this file claimed:

- `_prisma_migrations` **already existed**. The file said a push-managed database had no history table at all. It was right that `0_init` had never been recorded, wrong about the table.
- It carries two migrations that have **never existed in this repository**, in the working tree or anywhere in git history: `20251020150129_add_org_chart_to_gantt_project` and `20251119032925_team_capacity_models`. Prisma is satisfied — with the baseline recorded, `migrate status` reports "up to date" — but a restore replays what is in the repo, which is not what built the live schema. Recorded here rather than left to be discovered during a restore drill.

## Verification

The corrected sequence was run end to end against a reconstruction of that database (65 tables, no history):

```
1) migrate resolve --applied 0_init  →  Migration 0_init marked as applied.
2) migrate deploy                    →  Applying `20260807140000_add_optimistic_lock_versions`
                                        All migrations have been successfully applied.
3) migrate status                    →  Database schema is up to date!
```

Prettier reformatted only the new table in the README; `docs/DEPLOYMENT.md` was already unformatted on main and is left as-is rather than reflowed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_