### PR TITLE
Gantt strangler: the seam, the adapter, and a correction about what is being replaced

### DIFF
--- a/docs/REMEDIATION.md
+++ b/docs/REMEDIATION.md
@@ -211,12 +211,44 @@ problem and a battery problem, not a correctness one.
 
 ### 3.1 `/gantt-tool` and `/architecture/v3`
 
-**State:** 17 of 19 routes migrated. These two are not, deliberately.
-`GanttCanvasV3` is 4,078 lines handling pointer drag, resize, dependency
-editing, resource capacity, milestones and cost gating. `GanttCanvas` is ~400
-lines covering rows, windowing, bars, keyboard move and announcements.
+**State:** 17 of 19 routes migrated. `/gantt-tool` is mid-strangler (PR #116):
+the replacement canvas renders behind `?canvas=next` with Move, milestones,
+axis + shading, AMS chevrons, tree columns and the capacity panel ported —
+each slice verified against the legacy formats.
 
-**Do not swap them.** That deletes working functionality.
+**The original "do not swap, that deletes working functionality" warning was
+substantially wrong**, and the port has been correcting it slice by slice.
+Checked against the code and, where it mattered, the full git history:
+
+- Pointer drag/resize of bars: **never existed.** No gesture changes a date.
+- Dependency editing: **never existed.** Zero references in the canvas;
+  dependencies are stored and read only by the two deletion-impact modals.
+- Resource drag-assignment: **never existed, in any of the repo's 122
+  commits.** There is no drag source — nothing ever calls
+  `setData("resourceId")` and nothing is `draggable` — so all four drop
+  handlers in GanttCanvasV3, including the one that writes, are and always
+  were unreachable. The `div[draggable="true"]` CSS in the page styles a
+  feature that was never built.
+
+**Deeper finding, logged 2026-08-08 — the task-assignment write path is
+dead end to end:**
+
+- `TaskResourceModal.onSave` is a literal `// TODO: Implement resource
+  assignment persistence`; it closes and discards the input.
+- The one assignment path that persists is `ResourceAllocationModal` →
+  `handleApplyBulkAllocation` → the team-capacity allocations API. That
+  writes **weekly allocation overrides**, a different data model from
+  `task.resourceAssignments`.
+- `task.resourceAssignments` — the field the capacity calculator reads for
+  its per-task breakdown — has **no working UI write path at all**. It is
+  populated only by imports and direct API use.
+
+Consequence: "port resource assignment" is not a porting task. Making
+task-level assignment real is a product decision (which of the two data
+models is canonical?) and belongs after the flip, as its own feature. The
+dead drop handlers and ghost CSS in the legacy canvas are safe to delete in
+a cleanup commit whenever convenient — they are unreachable, so removal
+changes nothing observable.
 
 **Recommended approach — strangler, not rewrite:**
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "husky": "^9.1.7",
     "postcss": "8.4.31",
     "prettier": "3.6.2",
+    "tabbable": "6.3.0",
     "tailwindcss": "3.4.0",
     "typescript": "^5",
     "vitest": "3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       prettier:
         specifier: 3.6.2
         version: 3.6.2
+      tabbable:
+        specifier: 6.3.0
+        version: 6.3.0
       tailwindcss:
         specifier: 3.4.0
         version: 3.4.0
@@ -12962,7 +12965,7 @@ snapshots:
 
   webpack@5.109.2(postcss@8.4.31):
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1

--- a/public/logo-bound.svg
+++ b/public/logo-bound.svg
@@ -1,8 +1,0 @@
-<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Bound Icon Mark - ≈ symbol -->
-  <rect x="2" y="2" width="44" height="44" rx="10" fill="#007AFF"/>
-  <!-- Top wave stroke -->
-  <path d="M12 18 C16 14, 22 14, 26 18 C30 22, 36 22, 40 18" stroke="white" stroke-width="3.5" stroke-linecap="round" fill="none"/>
-  <!-- Bottom wave stroke -->
-  <path d="M12 30 C16 26, 22 26, 26 30 C30 34, 36 34, 40 30" stroke="white" stroke-width="3.5" stroke-linecap="round" fill="none"/>
-</svg>

--- a/public/logo-cockpit.svg
+++ b/public/logo-cockpit.svg
@@ -1,81 +1,38 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="1024" height="1024" viewBox="0 0 1024 1024"
-     xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fitted Hex Logo">
-  <!-- Fitted parameters (from your PNG):
-       center C ≈ (511.93, 505.94)
-       sharp-hex radius R ≈ 334.915
-       corner radius r ≈ 44.025  (stroke-width = 2r = 88.05)
-       vertex (extreme) radius R+r ≈ 378.94
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none" role="img" aria-label="Cockpit">
+  <!--
+    The Cockpit mark: a beacon.
+
+    An outer ring broken at the base, an inner arc, a gold point at the
+    centre, and a stem dropping through the break. Recreated as vectors from
+    the supplied artwork so it stays crisp at 16px in a tab and at 512px in
+    an app icon.
+
+    Geometry, so edits keep the proportions of the original: everything is
+    centred on (256, 246); the ring is r=150 with a 22-degree gap at the
+    bottom that the stem passes through; the arc is r=88 spanning 230 degrees
+    across the top; the point is r=27; strokes are 17 with round caps —
+    the original's stroke-to-radius ratio, which is what makes the mark read
+    as drawn rather than stamped.
   -->
   <defs>
-    <!-- Rounded hex via Minkowski sum: fill + round-join stroke -->
-    <mask id="rounded">
-      <rect width="100%" height="100%" fill="black"/>
-      <!-- sharp hex vertices (point-up) -->
-      <polygon
-        points="
-          511.930,171.025
-          801.975,338.482
-          801.975,673.397
-          511.930,840.854
-          221.885,673.397
-          221.885,338.482
-        "
-        fill="white" stroke="white" stroke-linejoin="round" stroke-width="88.05"/>
-    </mask>
-
-    <!-- Per-facet radial gradients (sampled from your image) -->
-    <radialGradient id="w0" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#b8e299"/><stop offset="90%" stop-color="#bfe69d"/>
-    </radialGradient>
-    <radialGradient id="w1" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#a5d98f"/><stop offset="90%" stop-color="#a3d98e"/>
-    </radialGradient>
-    <radialGradient id="w2" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#9bd48b"/><stop offset="90%" stop-color="#99d28a"/>
-    </radialGradient>
-    <radialGradient id="w3" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#aedd93"/><stop offset="90%" stop-color="#aadc91"/>
-    </radialGradient>
-    <radialGradient id="w4" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#bce49b"/><stop offset="90%" stop-color="#c1e79f"/>
-    </radialGradient>
-    <radialGradient id="w5" cx="511.9" cy="505.9" r="360.0" gradientUnits="userSpaceOnUse">
-      <stop offset="18%" stop-color="#cdeca9"/><stop offset="90%" stop-color="#d7f1b2"/>
-    </radialGradient>
-
-    <!-- Corner gloss caps + inner vignette -->
-    <radialGradient id="capGlow" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.50"/>
-      <stop offset="60%" stop-color="#ffffff" stop-opacity="0.18"/>
-      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="innerVignette" cx="70%" cy="75%" r="60%">
-      <stop offset="0%" stop-color="#000000" stop-opacity="0.05"/>
-      <stop offset="100%" stop-color="#000000" stop-opacity="0"/>
-    </radialGradient>
+    <linearGradient id="cockpit-gold" x1="229" y1="219" x2="283" y2="273" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EBC463"/>
+      <stop offset="1" stop-color="#D9A83E"/>
+    </linearGradient>
   </defs>
 
-  <!-- Paint inside the rounded-hex mask -->
-  <g mask="url(#rounded)">
-    <!-- Six facet wedges from center to extreme vertices (fitted coordinates) -->
-    <!-- Vertex extremes (R+r): (511.9,127.0), (840.1,316.5), (840.1,695.4), (511.9,884.9), (183.8,695.4), (183.8,316.5) -->
-    <polygon points="511.9,505.9 183.8,316.5 511.9,127.0" fill="url(#w0)"/>
-    <polygon points="511.9,505.9 511.9,127.0 840.1,316.5" fill="url(#w1)"/>
-    <polygon points="511.9,505.9 840.1,316.5 840.1,695.4" fill="url(#w2)"/>
-    <polygon points="511.9,505.9 840.1,695.4 511.9,884.9" fill="url(#w3)"/>
-    <polygon points="511.9,505.9 511.9,884.9 183.8,695.4" fill="url(#w4)"/>
-    <polygon points="511.9,505.9 183.8,695.4 183.8,316.5" fill="url(#w5)"/>
+  <!-- Outer ring, broken at the base for the stem -->
+  <path d="M 284.6 393.2 A 150 150 0 1 0 227.4 393.2"
+        stroke="#3D5566" stroke-width="17" stroke-linecap="round"/>
 
-    <!-- Subtle inner vignette to mimic center seam falloff -->
-    <rect width="1024" height="1024" fill="url(#innerVignette)"/>
+  <!-- Inner arc -->
+  <path d="M 176.2 283.2 A 88 88 0 1 1 335.8 283.2"
+        stroke="#3D5566" stroke-width="17" stroke-linecap="round"/>
 
-    <!-- Corner gloss caps (radius ≈ 0.75*r ≈ 33px) -->
-    <circle cx="511.9" cy="127.0" r="33.0" fill="url(#capGlow)"/>
-    <circle cx="840.1" cy="316.5" r="33.0" fill="url(#capGlow)"/>
-    <circle cx="840.1" cy="695.4" r="33.0" fill="url(#capGlow)"/>
-    <circle cx="511.9" cy="884.9" r="33.0" fill="url(#capGlow)"/>
-    <circle cx="183.8" cy="695.4" r="33.0" fill="url(#capGlow)"/>
-    <circle cx="183.8" cy="316.5" r="33.0" fill="url(#capGlow)"/>
-  </g>
+  <!-- The gold point -->
+  <circle cx="256" cy="246" r="27" fill="url(#cockpit-gold)"/>
+
+  <!-- Stem, through the break -->
+  <path d="M 256 296 L 256 424"
+        stroke="#3D5566" stroke-width="17" stroke-linecap="round"/>
 </svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Bound",
-  "short_name": "Bound",
+  "name": "Cockpit",
+  "short_name": "Cockpit",
   "description": "SAP S/4HANA project estimation and management tool",
   "start_url": "/dashboard",
   "display": "standalone",
@@ -65,7 +65,11 @@
       "form_factor": "narrow"
     }
   ],
-  "categories": ["business", "productivity", "utilities"],
+  "categories": [
+    "business",
+    "productivity",
+    "utilities"
+  ],
   "lang": "en-US",
   "dir": "ltr",
   "prefer_related_applications": false,

--- a/src/app/api/admin/email-approvals/route.ts
+++ b/src/app/api/admin/email-approvals/route.ts
@@ -144,7 +144,7 @@ export const POST = withAdmin(async (req, auth) => {
 
     <div style="background: #f8fafc; padding: 24px 32px; text-align: center; border-top: 1px solid #e2e8f0;">
       <p style="margin: 0; color: #94a3b8; font-size: 12px;">
-        © ${new Date().getFullYear()} Bound. All rights reserved.
+        © ${new Date().getFullYear()} Cockpit. All rights reserved.
       </p>
     </div>
   </div>

--- a/src/app/api/admin/recovery/[requestId]/approve/route.ts
+++ b/src/app/api/admin/recovery/[requestId]/approve/route.ts
@@ -227,7 +227,7 @@ export const POST = withAdmin<{ params: Promise<{ requestId: string }> }>(
     <div style="background: #f8fafc; padding: 24px 32px; text-align: center; border-top: 1px solid #e2e8f0;">
       <p style="margin: 0; color: #94a3b8; font-size: 12px;">
         Reference ID: ${requestId}<br>
-        © ${new Date().getFullYear()} Bound. All rights reserved.
+        © ${new Date().getFullYear()} Cockpit. All rights reserved.
       </p>
     </div>
   </div>

--- a/src/app/api/admin/recovery/[requestId]/reject/route.ts
+++ b/src/app/api/admin/recovery/[requestId]/reject/route.ts
@@ -149,7 +149,7 @@ export const POST = withAdmin<{ params: Promise<{ requestId: string }> }>(
     <div style="background: #f8fafc; padding: 24px 32px; text-align: center; border-top: 1px solid #e2e8f0;">
       <p style="margin: 0; color: #94a3b8; font-size: 12px;">
         Reference ID: ${requestId}<br>
-        © ${new Date().getFullYear()} Bound. All rights reserved.
+        © ${new Date().getFullYear()} Cockpit. All rights reserved.
       </p>
     </div>
   </div>

--- a/src/app/api/auth/begin-register/route.ts
+++ b/src/app/api/auth/begin-register/route.ts
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
     }
 
     const options = await generateRegistrationOptions({
-      rpName: "Bound",
+      rpName: "Cockpit",
       rpID,
       userName: email,
       authenticatorSelection: { residentKey: "required", userVerification: "required" },

--- a/src/app/api/favicon/route.tsx
+++ b/src/app/api/favicon/route.tsx
@@ -1,7 +1,7 @@
 /**
  * Dynamic Favicon API
  *
- * Generates favicons with status-based colors for Bound brand.
+ * Generates favicons with status-based colors for the Cockpit brand.
  * Use ?status=connected|disconnected|none to change appearance.
  *
  * Status colors:
@@ -34,43 +34,58 @@ const STATUS_COLORS = {
 type Status = keyof typeof STATUS_COLORS;
 
 /**
- * Bound ≈ mark - two parallel wave strokes
+ * The Cockpit mark: a beacon. Same geometry as public/logo-cockpit.svg,
+ * drawn in the status foreground colour so it stays readable on every
+ * status background.
  *
- * Clean, bold, recognizable ≈ design:
- * - Two parallel sinusoidal curves
- * - Optically centered in the container
- * - Gentle wave (Apple-like restraint)
+ * The favicon uses a heavier stroke than the full-size mark (34 vs 17 in a
+ * 512 viewBox): at 16-32px a 17-unit stroke aliases into fog, and a favicon
+ * that cannot be recognised in a tab strip is decoration. The gold point
+ * keeps its brand colour except on the amber "disconnected" background,
+ * where gold-on-amber has no contrast and the foreground colour takes over.
  */
-function BoundMark({
+function CockpitMark({
   color = "#FFFFFF",
+  dotColor,
   size: iconSize = 32,
 }: {
   color?: string;
+  dotColor?: string;
   size?: number;
 }) {
-  const scale = iconSize * 0.65;
+  const scale = iconSize * 0.72;
 
   return (
     <svg
       width={scale}
       height={scale}
-      viewBox="0 0 100 100"
+      viewBox="0 0 512 512"
       fill="none"
       style={{ display: "block" }}
     >
-      {/* Top wave stroke */}
+      {/* Outer ring, broken at the base for the stem */}
       <path
-        d="M15 38 C25 24, 40 24, 50 38 C60 52, 75 52, 85 38"
+        d="M 284.6 393.2 A 150 150 0 1 0 227.4 393.2"
         stroke={color}
-        strokeWidth="10"
+        strokeWidth="34"
         strokeLinecap="round"
         fill="none"
       />
-      {/* Bottom wave stroke */}
+      {/* Inner arc */}
       <path
-        d="M15 62 C25 48, 40 48, 50 62 C60 76, 75 76, 85 62"
+        d="M 176.2 283.2 A 88 88 0 1 1 335.8 283.2"
         stroke={color}
-        strokeWidth="10"
+        strokeWidth="34"
+        strokeLinecap="round"
+        fill="none"
+      />
+      {/* The gold point */}
+      <circle cx="256" cy="246" r="36" fill={dotColor ?? "#E3B54D"} />
+      {/* Stem, through the break */}
+      <path
+        d="M 256 296 L 256 424"
+        stroke={color}
+        strokeWidth="34"
         strokeLinecap="round"
         fill="none"
       />
@@ -110,7 +125,13 @@ export async function GET(request: NextRequest) {
           borderRadius: `${borderRadius}px`,
         }}
       >
-        <BoundMark color={colors.foreground} size={size} />
+        <CockpitMark
+          color={colors.foreground}
+          // Gold on amber has no contrast; the disconnected state hands the
+          // point to the foreground colour instead.
+          dotColor={status === "disconnected" ? colors.foreground : undefined}
+          size={size}
+        />
       </div>
     ),
     {

--- a/src/app/api/user/email/change-request/route.ts
+++ b/src/app/api/user/email/change-request/route.ts
@@ -149,7 +149,7 @@ export const POST = withUser(async (req, user) => {
 
     <div style="background: #f8fafc; padding: 24px 32px; text-align: center; border-top: 1px solid #e2e8f0;">
       <p style="margin: 0; color: #94a3b8; font-size: 12px;">
-        This is an automated email. © ${new Date().getFullYear()} Bound.
+        This is an automated email. © ${new Date().getFullYear()} Cockpit.
       </p>
     </div>
   </div>

--- a/src/app/api/user/recovery/request/route.ts
+++ b/src/app/api/user/recovery/request/route.ts
@@ -173,7 +173,7 @@ export async function POST(req: Request) {
     <div style="background: #f8fafc; padding: 24px 32px; text-align: center; border-top: 1px solid #e2e8f0;">
       <p style="margin: 0; color: #94a3b8; font-size: 12px;">
         Reference ID: ${recoveryRequest.id}<br>
-        © ${new Date().getFullYear()} Bound. All rights reserved.
+        © ${new Date().getFullYear()} Cockpit. All rights reserved.
       </p>
     </div>
   </div>

--- a/src/app/gantt-tool/page.tsx
+++ b/src/app/gantt-tool/page.tsx
@@ -579,6 +579,7 @@ export default function GanttToolV3Page() {
               zoomMode={activeZoomMode}
               showMilestoneModal={showMilestoneModal}
               onShowMilestoneModalChange={setShowMilestoneModal}
+              showResourceCapacity={isCapacityPanelExpanded}
             />
           ) : (
             <GanttCanvasV3

--- a/src/app/gantt-tool/page.tsx
+++ b/src/app/gantt-tool/page.tsx
@@ -14,6 +14,8 @@
 import dynamic from "next/dynamic";
 import { logger } from "@/lib/logger";
 import { GanttCanvasV3 } from "@/components/gantt-tool/GanttCanvasV3";
+import { GanttCanvasNext } from "@/components/gantt-tool/next/GanttCanvasNext";
+import { useGanttCanvasChoice } from "@/components/gantt-tool/next/canvas-flag";
 // Lazy-load modals and heavy tabs (E-02: route-level code splitting)
 const NewProjectModal = dynamic(() => import("@/components/gantt-tool/NewProjectModal").then(m => ({ default: m.NewProjectModal })), { ssr: false });
 const ImportModal = dynamic(() => import("@/components/gantt-tool/ImportModal").then(m => ({ default: m.ImportModal })), { ssr: false });
@@ -59,6 +61,10 @@ export default function GanttToolV3Page() {
     lastSyncAt,
     syncStatus
   } = useGanttToolStore();
+
+  // Which Gantt canvas renders. Always "legacy" unless the URL asks for the
+  // replacement by name; see components/gantt-tool/next/canvas-flag.ts.
+  const canvasChoice = useGanttCanvasChoice();
 
   const [initializing, setInitializing] = useState(true);
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
@@ -561,16 +567,25 @@ export default function GanttToolV3Page() {
           minHeight: 0, // Flexbox fix for scroll containers
         }}
       >
-        {/* Timeline View - GanttCanvasV3 handles everything including resource capacity */}
+        {/* Timeline View.
+          *
+          * The strangler seam: GanttCanvasV3 is the product, GanttCanvasNext is
+          * the replacement being built behind `?canvas=next`. Both read the same
+          * store, so this is a choice of view, not of data. See
+          * `components/gantt-tool/next/canvas-flag.ts`. */}
         <div className="flex-1" style={{ minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
-          <GanttCanvasV3
-            zoomMode={activeZoomMode}
-            showMilestoneModal={showMilestoneModal}
-            onShowMilestoneModalChange={setShowMilestoneModal}
-            showResourceCapacity={isCapacityPanelExpanded}
-            onToggleResourceCapacity={() => setIsCapacityPanelExpanded(!isCapacityPanelExpanded)}
-            hasFinancialAccess={hasFinancialAccess}
-          />
+          {canvasChoice === "next" ? (
+            <GanttCanvasNext zoomMode={activeZoomMode} />
+          ) : (
+            <GanttCanvasV3
+              zoomMode={activeZoomMode}
+              showMilestoneModal={showMilestoneModal}
+              onShowMilestoneModalChange={setShowMilestoneModal}
+              showResourceCapacity={isCapacityPanelExpanded}
+              onToggleResourceCapacity={() => setIsCapacityPanelExpanded(!isCapacityPanelExpanded)}
+              hasFinancialAccess={hasFinancialAccess}
+            />
+          )}
         </div>
 
         {/* Resource Panel - Sidebar or Bottom based on user choice */}

--- a/src/app/gantt-tool/page.tsx
+++ b/src/app/gantt-tool/page.tsx
@@ -575,7 +575,11 @@ export default function GanttToolV3Page() {
           * `components/gantt-tool/next/canvas-flag.ts`. */}
         <div className="flex-1" style={{ minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
           {canvasChoice === "next" ? (
-            <GanttCanvasNext zoomMode={activeZoomMode} />
+            <GanttCanvasNext
+              zoomMode={activeZoomMode}
+              showMilestoneModal={showMilestoneModal}
+              onShowMilestoneModalChange={setShowMilestoneModal}
+            />
           ) : (
             <GanttCanvasV3
               zoomMode={activeZoomMode}

--- a/src/app/gantt-tool/page.tsx
+++ b/src/app/gantt-tool/page.tsx
@@ -14,8 +14,22 @@
 import dynamic from "next/dynamic";
 import { logger } from "@/lib/logger";
 import { GanttCanvasV3 } from "@/components/gantt-tool/GanttCanvasV3";
-import { GanttCanvasNext } from "@/components/gantt-tool/next/GanttCanvasNext";
 import { useGanttCanvasChoice } from "@/components/gantt-tool/next/canvas-flag";
+
+// Loaded lazily, and that is load-bearing: a static import ships the entire
+// replacement canvas (ds canvas, capacity calculator, milestone wiring) to
+// every /gantt-tool visitor ALONGSIDE the legacy canvas — measured at +8kB
+// over the route's 1300kB first-load budget, which is exactly the regression
+// the budget test exists to catch. The strangler's contract is that the
+// replacement costs nothing until the URL asks for it; dynamic() is what
+// makes that true at the bundle level, not just the render level.
+const GanttCanvasNext = dynamic(
+  () =>
+    import("@/components/gantt-tool/next/GanttCanvasNext").then(
+      (m) => m.GanttCanvasNext
+    ),
+  { ssr: false }
+);
 // Lazy-load modals and heavy tabs (E-02: route-level code splitting)
 const NewProjectModal = dynamic(() => import("@/components/gantt-tool/NewProjectModal").then(m => ({ default: m.NewProjectModal })), { ssr: false });
 const ImportModal = dynamic(() => import("@/components/gantt-tool/ImportModal").then(m => ({ default: m.ImportModal })), { ssr: false });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { Providers } from "./providers";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Bound",
+  title: "Cockpit",
   description: "From RFP to Proposal in 10 Minutes",
   manifest: "/manifest.json",
 };

--- a/src/components/ds/gantt/GanttAmsChevron.module.css
+++ b/src/components/ds/gantt/GanttAmsChevron.module.css
@@ -1,0 +1,37 @@
+/*
+ * AMS chevron strip. The hit area mirrors GanttBar's `.hit` — same vertical
+ * centring, same focus treatment — so keyboard focus looks identical whether
+ * the row paints a bar or a contract marker.
+ */
+
+.hit {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  /* Legacy footprint: 5 × 24px chevrons + 4 × 4px gaps = 136px of ink in a
+   * 160px strip; the strip width is the hit area. */
+  width: 160px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  /* Legacy draws the chevrons at 0.7 opacity at rest. */
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.hit:hover,
+.hit[aria-pressed="true"] {
+  opacity: 0.9;
+}
+
+.hit:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+  border-radius: var(--ds-radius-xs);
+  opacity: 1;
+}

--- a/src/components/ds/gantt/GanttAmsChevron.tsx
+++ b/src/components/ds/gantt/GanttAmsChevron.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * Design system — AMS chevron (layer 4, Domain surfaces)
+ *
+ * An AMS phase is an ongoing support contract, and the timeline treats it
+ * differently on purpose: `getProjectDuration()` excludes AMS end dates so a
+ * three-year contract does not stretch a four-month plan into illegibility.
+ * The consequence is that an AMS phase CANNOT be drawn as a duration bar —
+ * its end lies beyond the canvas — so the legacy canvas draws a fixed-width
+ * strip of five chevrons at the start date, and this reproduces that:
+ * same 160px footprint, same 24×32 chevron path, same #FF6B35.
+ *
+ * The interactive surface deliberately mirrors GanttBar's: one `<button>`
+ * whose accessible name carries the whole fact, `aria-pressed` for selection,
+ * select and keydown delegated to the canvas. The cursor, selection and
+ * announcement plumbing then treat an AMS row exactly like any other — the
+ * only thing that differs is the paint.
+ */
+
+import React from "react";
+import styles from "./GanttAmsChevron.module.css";
+
+export interface GanttAmsChevronProps {
+  /** Offset from the canvas origin, in pixels. */
+  left: number;
+  /**
+   * The full accessible fact — name, that it is AMS, the start date. There is
+   * no visible text at all, so this is everything a screen reader gets.
+   */
+  description: string;
+  selected?: boolean;
+  onSelect?: () => void;
+  onKeyDown?: (event: React.KeyboardEvent) => void;
+}
+
+/** Legacy geometry, kept exactly: five chevrons, 24×32 each, 4px gaps. */
+const CHEVRON_COUNT = 5;
+const AMS_COLOR = "#FF6B35";
+
+export function GanttAmsChevron({
+  left,
+  description,
+  selected,
+  onSelect,
+  onKeyDown,
+}: GanttAmsChevronProps) {
+  return (
+    <button
+      type="button"
+      className={styles.hit}
+      style={{ left }}
+      aria-label={description}
+      aria-pressed={selected}
+      onClick={onSelect}
+      onKeyDown={onKeyDown}
+    >
+      {Array.from({ length: CHEVRON_COUNT }, (_, i) => (
+        <svg key={i} width="24" height="32" viewBox="0 0 24 32" aria-hidden="true">
+          <path d="M0 0 L16 0 L24 16 L16 32 L0 32 L8 16 Z" fill={AMS_COLOR} />
+        </svg>
+      ))}
+    </button>
+  );
+}

--- a/src/components/ds/gantt/GanttCanvas.module.css
+++ b/src/components/ds/gantt/GanttCanvas.module.css
@@ -94,6 +94,22 @@
 
 .treeNamePhase { font-weight: 500; }
 
+/* Detail columns, at legacy's widths. Fixed rather than fluid so a long task
+ * name can never squeeze the numbers into ambiguity. */
+.detailCell,
+.detailCellWide {
+  flex: none;
+  text-align: center;
+  font: var(--ds-type-label);
+  color: var(--ds-content-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.detailCell { width: 90px; }
+.detailCellWide { width: 180px; }
+
 .timelineRow {
   position: relative;
   border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);

--- a/src/components/ds/gantt/GanttCanvas.tsx
+++ b/src/components/ds/gantt/GanttCanvas.tsx
@@ -62,6 +62,22 @@ import {
   type BarFacts,
 } from "./announce";
 
+/**
+ * Detail cells for one row of the tree pane, pre-formatted by the caller so
+ * the canvas never owns date or duration formatting — the seam does, where it
+ * can be asserted against the legacy formats.
+ */
+export interface RowDetails {
+  /** Calendar duration, e.g. "3.2 m". */
+  calendar: string;
+  /** Working days as displayed, e.g. "42 d". */
+  working: string;
+  /** Start–end, e.g. "05-Jan-26 (Mon) - 30-Jan-26 (Fri)". */
+  dates: string;
+  /** The working-day count as a number, for the accessible description. */
+  workingDays: number;
+}
+
 /** Timing for one bar on the canvas. Days are offsets from the origin. */
 export interface BarPlacement {
   startDay: number;
@@ -98,6 +114,13 @@ export interface GanttCanvasProps {
   minorTicks?: AxisTick[];
   nonWorkingDays?: NonWorkingDay[];
   todayDay?: number;
+  /**
+   * Per-row detail columns. When present the tree pane becomes the four-column
+   * grid the legacy canvas renders (name, duration, work days, dates); when
+   * absent it stays a name-only tree, which is what the showcase and every
+   * pre-existing caller get.
+   */
+  details?: Record<string, RowDetails>;
   /** Milestones, in the same day-offset space as placements. */
   milestones?: CanvasMilestone[];
   /** Opens milestone editing. Markers render inert without it. */
@@ -126,6 +149,7 @@ export function GanttCanvas({
   minorTicks = [],
   nonWorkingDays = [],
   todayDay,
+  details,
   milestones = [],
   onMilestoneActivate,
   toolbar,
@@ -368,8 +392,23 @@ export function GanttCanvas({
       </div>
 
       <div className={styles.canvas} style={{ height }}>
-        <div className={styles.treePane}>
-          <div className={styles.treeHeader}>Plan</div>
+        {/* With details the tree pane is legacy's four-column grid at legacy's
+          * default widths (280 + 90 + 90 + 180); without, the original
+          * name-only 280px tree. */}
+        <div
+          className={styles.treePane}
+          style={details ? { width: 280 + 90 + 90 + 180 } : undefined}
+        >
+          <div className={styles.treeHeader}>
+            <span className={styles.treeName}>Plan</span>
+            {details && (
+              <>
+                <span className={styles.detailCell}>Duration</span>
+                <span className={styles.detailCell}>Work Days</span>
+                <span className={styles.detailCellWide}>Start-End</span>
+              </>
+            )}
+          </div>
           <div
             className={styles.treeBody}
             style={{ height: viewportHeight }}
@@ -410,6 +449,19 @@ export function GanttCanvas({
                     >
                       {row.name}
                     </span>
+                    {details && (
+                      <>
+                        <span className={styles.detailCell}>
+                          {details[row.id]?.calendar}
+                        </span>
+                        <span className={styles.detailCell}>
+                          {details[row.id]?.working}
+                        </span>
+                        <span className={styles.detailCellWide}>
+                          {details[row.id]?.dates}
+                        </span>
+                      </>
+                    )}
                   </div>
                 ))}
               </div>
@@ -519,7 +571,15 @@ export function GanttCanvas({
                           canvasRemainingPx={
                             (totalDays - startDay - placement.durationDays) * px
                           }
-                          description={`${facts.name}, ${facts.kind}, ${facts.startLabel} to ${facts.finishLabel}`}
+                          description={
+                            // Working days join the accessible name because
+                            // the shading that conveys them visually is
+                            // aria-hidden — this is where that information
+                            // reaches assistive technology (see TimelineAxis).
+                            details?.[row.id]
+                              ? `${facts.name}, ${facts.kind}, ${facts.startLabel} to ${facts.finishLabel}, ${details[row.id].workingDays} working days`
+                              : `${facts.name}, ${facts.kind}, ${facts.startLabel} to ${facts.finishLabel}`
+                          }
                           selected={selected.has(row.id)}
                           onSelect={() => moveCursorTo(row.rowIndex - 1)}
                         />

--- a/src/components/ds/gantt/GanttCanvas.tsx
+++ b/src/components/ds/gantt/GanttCanvas.tsx
@@ -36,6 +36,7 @@ import React, {
   type ReactNode,
 } from "react";
 import styles from "./GanttCanvas.module.css";
+import { GanttAmsChevron } from "./GanttAmsChevron";
 import { GanttBar } from "./GanttBar";
 import { GanttMilestones, type CanvasMilestone } from "./GanttMilestones";
 import { GanttStatus } from "./GanttStatus";
@@ -69,6 +70,13 @@ export interface BarPlacement {
   critical?: boolean;
   baselineStartDay?: number;
   baselineDurationDays?: number;
+  /**
+   * An ongoing contract (AMS). Painted as a fixed-width chevron strip at the
+   * start date instead of a duration bar: the timeline bounds deliberately
+   * exclude AMS end dates, so a duration bar would overrun the canvas.
+   * `durationDays` is ignored for these.
+   */
+  ams?: boolean;
 }
 
 export interface GanttCanvasProps {
@@ -484,7 +492,15 @@ export function GanttCanvas({
                       <span role="gridcell" className={styles.srOnly}>
                         {row.name}
                       </span>
-                      {placement && (
+                      {placement && placement.ams && (
+                        <GanttAmsChevron
+                          left={startDay * px}
+                          description={`${facts.name}, ongoing support contract, starts ${facts.startLabel}`}
+                          selected={selected.has(row.id)}
+                          onSelect={() => moveCursorTo(row.rowIndex - 1)}
+                        />
+                      )}
+                      {placement && !placement.ams && (
                         <GanttBar
                           kind={row.kind}
                           label={row.name}

--- a/src/components/ds/gantt/GanttCanvas.tsx
+++ b/src/components/ds/gantt/GanttCanvas.tsx
@@ -37,6 +37,7 @@ import React, {
 } from "react";
 import styles from "./GanttCanvas.module.css";
 import { GanttBar } from "./GanttBar";
+import { GanttMilestones, type CanvasMilestone } from "./GanttMilestones";
 import { GanttStatus } from "./GanttStatus";
 import { TimelineAxis, type AxisTick, type NonWorkingDay } from "./TimelineAxis";
 import { Button } from "../Button";
@@ -89,6 +90,10 @@ export interface GanttCanvasProps {
   minorTicks?: AxisTick[];
   nonWorkingDays?: NonWorkingDay[];
   todayDay?: number;
+  /** Milestones, in the same day-offset space as placements. */
+  milestones?: CanvasMilestone[];
+  /** Opens milestone editing. Markers render inert without it. */
+  onMilestoneActivate?: (id: string) => void;
   /** Extra toolbar content, e.g. filters. */
   toolbar?: ReactNode;
   height?: number;
@@ -113,6 +118,8 @@ export function GanttCanvas({
   minorTicks = [],
   nonWorkingDays = [],
   todayDay,
+  milestones = [],
+  onMilestoneActivate,
   toolbar,
   height = 520,
   debugAnnouncements,
@@ -434,6 +441,23 @@ export function GanttCanvas({
             />
 
             <div style={{ height: window_.totalHeight, position: "relative", width: totalDays * px }}>
+              {/* Milestone rules and markers span the full canvas height, so
+                * they sit on the unwindowed container rather than the
+                * translated slice below.
+                *
+                * Known ARIA-structure trade, made on purpose: this container
+                * is inside the treegrid, and a strict grid wants only rows as
+                * children. The alternative — an overlay outside the treegrid
+                * kept in sync with two scroll axes — reintroduces exactly the
+                * sync machinery whose drift this canvas was built to avoid.
+                * The markers are real named buttons either way; what is
+                * compromised is validator purity, not reachability. */}
+              <GanttMilestones
+                milestones={milestones}
+                grain={grain}
+                totalDays={totalDays}
+                onActivate={onMilestoneActivate}
+              />
               <div style={{ transform: `translateY(${window_.offsetTop}px)` }}>
                 {visible.map((row) => {
                   const placement = placements[row.id];

--- a/src/components/ds/gantt/GanttCapacityPanel.module.css
+++ b/src/components/ds/gantt/GanttCapacityPanel.module.css
@@ -1,0 +1,117 @@
+/*
+ * Capacity matrix. A real <table>, because that is what it is — a screen
+ * reader gets row and column headers for free, which is exactly the context
+ * an allocation figure needs ("Ada Lovelace, W07: 120% allocated").
+ */
+
+.panel {
+  border-top: var(--ds-border-hairline) solid var(--ds-border-default);
+  background: var(--ds-surface-raised);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-3);
+  padding: var(--ds-space-2) var(--ds-space-3);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+}
+
+.title {
+  margin: 0;
+  font: var(--ds-type-label);
+  color: var(--ds-content-primary);
+}
+
+.search {
+  width: 220px;
+  padding: var(--ds-space-1) var(--ds-space-2);
+  font: var(--ds-type-body-sm);
+  color: var(--ds-content-primary);
+  background: var(--ds-surface-base);
+  border: var(--ds-border-hairline) solid var(--ds-border-default);
+  border-radius: var(--ds-radius-sm);
+}
+
+.search:focus-visible {
+  outline: var(--ds-border-focus-width) solid var(--ds-border-focus);
+  outline-offset: var(--ds-focus-offset);
+}
+
+.count {
+  font: var(--ds-type-label);
+  color: var(--ds-content-secondary);
+}
+
+.scroller {
+  overflow: auto;
+  max-height: 320px;
+}
+
+.matrix {
+  border-collapse: collapse;
+}
+
+.nameHeader,
+.weekHeader {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--ds-surface-sunken);
+  font: var(--ds-type-label);
+  color: var(--ds-content-secondary);
+  text-align: left;
+  padding: var(--ds-space-1) var(--ds-space-2);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-default);
+  white-space: nowrap;
+}
+
+.weekHeader { text-align: center; }
+
+/* The name column stays put while the weeks scroll, or a row loses its
+ * identity forty weeks in. */
+.nameHeader,
+.nameCell {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--ds-surface-raised);
+  min-width: 200px;
+  max-width: 260px;
+}
+
+.nameHeader { z-index: 3; }
+
+.nameCell {
+  padding: var(--ds-space-1) var(--ds-space-2);
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+  font: var(--ds-type-body-sm);
+  font-weight: 400;
+  text-align: left;
+}
+
+.resourceName {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ds-content-primary);
+}
+
+.resourceMeta {
+  display: block;
+  font: var(--ds-type-label);
+  color: var(--ds-content-secondary);
+}
+
+.weekCell {
+  padding: 2px;
+  border-bottom: var(--ds-border-hairline) solid var(--ds-border-subtle);
+}
+
+.empty {
+  margin: 0;
+  padding: var(--ds-space-4);
+  font: var(--ds-type-body-sm);
+  color: var(--ds-content-secondary);
+}

--- a/src/components/ds/gantt/GanttCapacityPanel.tsx
+++ b/src/components/ds/gantt/GanttCapacityPanel.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * Design system — resource capacity panel (layer 4, Domain surfaces)
+ *
+ * The resource × week allocation matrix under the canvas: one row per
+ * resource, one AllocationCell per project week, and the search box that
+ * filters the rows. This is the matrix AllocationCell was built for — the
+ * cell carries figure + fill + hatch so an over-allocation survives a
+ * projector, a printout, and colour-blindness; the panel's job is only to lay
+ * the cells out and keep the rows findable.
+ *
+ * ## One deliberate difference from the legacy panel
+ *
+ * Legacy positions capacity cells under the timeline, pixel-aligned to the
+ * Gantt above. This panel is a self-contained matrix with its own week
+ * header and its own horizontal scroll. That is a v1 trade, made openly: at
+ * Month and Quarter grains a week is 20px or 8px wide, which cannot hold a
+ * figure, so pixel alignment and readable cells are mutually exclusive —
+ * and the cell's whole design is that the figure is always readable.
+ *
+ * ## Search
+ *
+ * Filters on a caller-provided haystack per row rather than on fields this
+ * component knows about, because what is searchable (name, category label,
+ * company, project role — legacy's four) is domain knowledge the seam owns.
+ * The count announces through a live region so a keyboard user typing a
+ * query hears the result without leaving the field.
+ */
+
+import React, { useMemo, useState } from "react";
+import { AllocationCell } from "./AllocationCell";
+import styles from "./GanttCapacityPanel.module.css";
+
+export interface CapacityColumn {
+  /** Stable key, e.g. "W07". */
+  key: string;
+  /** Header label, e.g. "W07" — with a title of the week's dates. */
+  label: string;
+  /** Full name for hover and assistive text, e.g. "W07, 16 Feb – 22 Feb". */
+  title: string;
+}
+
+export interface CapacityRow {
+  id: string;
+  name: string;
+  /** Secondary line under the name, e.g. the category label. */
+  meta?: string;
+  /** Lower-cased haystack the search matches against. */
+  searchText: string;
+  /** Aligned to the panel's columns, one percentage per week. */
+  percents: number[];
+}
+
+export interface GanttCapacityPanelProps {
+  columns: CapacityColumn[];
+  rows: CapacityRow[];
+  /** Called with the row and column of an activated cell. */
+  onCellSelect?: (resourceId: string, weekKey: string) => void;
+}
+
+export function GanttCapacityPanel({
+  columns,
+  rows,
+  onCellSelect,
+}: GanttCapacityPanelProps) {
+  const [query, setQuery] = useState("");
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((row) => row.searchText.includes(q));
+  }, [rows, query]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <section className={styles.panel} aria-label="Resource capacity">
+      <div className={styles.toolbar}>
+        <h3 className={styles.title}>Resource capacity</h3>
+        <input
+          type="search"
+          className={styles.search}
+          placeholder="Search resources…"
+          aria-label="Search resources"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        {/* Announced, not just shown: the visual count sits far from the
+          * field, and a screen-reader user typing should not have to leave
+          * the input to learn whether anything matched. */}
+        <span className={styles.count} role="status">
+          {query.trim()
+            ? `${visible.length} of ${rows.length} resources`
+            : `${rows.length} resources`}
+        </span>
+      </div>
+
+      <div className={styles.scroller}>
+        <table className={styles.matrix}>
+          <thead>
+            <tr>
+              <th scope="col" className={styles.nameHeader}>
+                Resource
+              </th>
+              {columns.map((col) => (
+                <th key={col.key} scope="col" className={styles.weekHeader} title={col.title}>
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((row) => (
+              <tr key={row.id}>
+                <th scope="row" className={styles.nameCell}>
+                  <span className={styles.resourceName} title={row.name}>
+                    {row.name}
+                  </span>
+                  {row.meta && <span className={styles.resourceMeta}>{row.meta}</span>}
+                </th>
+                {columns.map((col, i) => (
+                  <td key={col.key} className={styles.weekCell}>
+                    <AllocationCell
+                      value={row.percents[i] ?? 0}
+                      label={`${row.name}, ${col.title}`}
+                      onSelect={
+                        onCellSelect ? () => onCellSelect(row.id, col.key) : undefined
+                      }
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {visible.length === 0 && (
+          <p className={styles.empty}>No resources match “{query.trim()}”.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ds/gantt/GanttMilestones.module.css
+++ b/src/components/ds/gantt/GanttMilestones.module.css
@@ -1,0 +1,52 @@
+/*
+ * Milestone layer. Positioned children of the rows container, which is
+ * position:relative and sized to the full (unwindowed) canvas, so a rule
+ * spans every row regardless of which slice is mounted.
+ */
+
+.rule {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  /* Legacy drew the rule at half opacity so bars stay readable through it. */
+  opacity: 0.5;
+  pointer-events: none;
+  /* Above bars (which are unpositioned within their rows) but below the
+   * marker, so the marker's focus ring is never cut by its own rule. */
+  z-index: 3;
+}
+
+.marker {
+  position: absolute;
+  top: 2px;
+  /* Centre the hit area on the rule. */
+  transform: translateX(-50%);
+  /* 24px hit target, matching the legacy marker and the pointer-target floor
+   * used across the canvas (MIN_HIT_PX). The visible diamond is smaller. */
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  z-index: 4;
+}
+
+.marker:focus-visible {
+  outline: 2px solid var(--ds-border-focus, #0b57d0);
+  outline-offset: 1px;
+  border-radius: var(--ds-radius-sm, 4px);
+}
+
+.diamond {
+  width: 10px;
+  height: 10px;
+  transform: rotate(45deg);
+  border-radius: 2px;
+  /* A hairline keeps a light-coloured milestone visible on the canvas. */
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 0.9);
+}

--- a/src/components/ds/gantt/GanttMilestones.tsx
+++ b/src/components/ds/gantt/GanttMilestones.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Design system — milestone layer (layer 4, Domain surfaces)
+ *
+ * Vertical rules through the canvas at each milestone's date, with a marker
+ * at the top that opens milestone editing. Ported from the legacy canvas,
+ * which drew the same two pieces — a 2px half-opacity rule and a clickable
+ * diamond — with three deliberate changes:
+ *
+ *  - **The marker is a real `<button>` with an accessible name**, not a div
+ *    with `role="button"` and only a `title`. The name carries the milestone's
+ *    name and date, because "button" repeated once per milestone tells a
+ *    screen reader user nothing.
+ *
+ *  - **The markers cannot live inside the axis.** The axis is `aria-hidden`
+ *    (it is a scale, not data), and a focusable control inside an aria-hidden
+ *    subtree is reachable by Tab but invisible to assistive technology — the
+ *    worst of both. So this layer sits in the rows container, as data.
+ *
+ *  - **Out-of-range milestones are dropped, same as legacy** — a milestone
+ *    outside the plan's bounds has no honest place to be drawn — but the drop
+ *    is per-marker, so one stray date does not hide the rest.
+ */
+
+import React from "react";
+import styles from "./GanttMilestones.module.css";
+import { PX_PER_DAY, type ZoomGrain } from "./scale";
+
+export interface CanvasMilestone {
+  id: string;
+  name: string;
+  /** Day offset from the canvas origin, same space as bar placements. */
+  day: number;
+  /** Human date for the accessible name, e.g. "14 Jul 26". */
+  dateLabel: string;
+  color?: string;
+}
+
+export interface GanttMilestonesProps {
+  milestones: CanvasMilestone[];
+  grain: ZoomGrain;
+  totalDays: number;
+  /** Opens milestone editing. Absent renders the layer inert but visible. */
+  onActivate?: (id: string) => void;
+}
+
+/** Matches the legacy default (#FF3B30) so the two canvases agree on a plan. */
+const DEFAULT_COLOR = "#FF3B30";
+
+export function GanttMilestones({
+  milestones,
+  grain,
+  totalDays,
+  onActivate,
+}: GanttMilestonesProps) {
+  const px = PX_PER_DAY[grain];
+
+  const visible = milestones.filter((m) => m.day >= 0 && m.day <= totalDays);
+  if (visible.length === 0) return null;
+
+  return (
+    <>
+      {visible.map((milestone) => {
+        const left = milestone.day * px;
+        const color = milestone.color || DEFAULT_COLOR;
+
+        return (
+          <React.Fragment key={milestone.id}>
+            {/* The rule is decoration for the marker above it: the same fact
+              * reaches assistive technology once, through the button's name,
+              * instead of once per rule. pointer-events stays off so a rule
+              * crossing a bar never steals the bar's click. */}
+            <span
+              className={styles.rule}
+              style={{ left, backgroundColor: color }}
+              aria-hidden="true"
+            />
+            <button
+              type="button"
+              className={styles.marker}
+              style={{ left }}
+              aria-label={`Milestone: ${milestone.name}, ${milestone.dateLabel}`}
+              title={`${milestone.name} — ${milestone.dateLabel}`}
+              onClick={() => onActivate?.(milestone.id)}
+            >
+              <span className={styles.diamond} style={{ backgroundColor: color }} aria-hidden="true" />
+            </button>
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/ds/gantt/__tests__/GanttAmsChevron.test.tsx
+++ b/src/components/ds/gantt/__tests__/GanttAmsChevron.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * The AMS chevron's contract: it mirrors GanttBar's interactive surface — one
+ * named button, selection via aria-pressed, select/keydown delegated — so the
+ * canvas's plumbing cannot tell an AMS row from any other. The paint is the
+ * only difference, and the paint is legacy's: five chevrons, 160px, #FF6B35.
+ */
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { GanttAmsChevron } from "../GanttAmsChevron";
+
+const DESCRIPTION = "Hypercare, ongoing support contract, starts 1 Mar 26";
+
+describe("GanttAmsChevron", () => {
+  it("is a single named button carrying the whole fact", () => {
+    render(<GanttAmsChevron left={100} description={DESCRIPTION} />);
+
+    // There is no visible text at all, so the accessible name is everything a
+    // screen reader gets — it must say what this is, not just that it exists.
+    expect(screen.getByRole("button", { name: DESCRIPTION })).toBeInTheDocument();
+  });
+
+  it("positions at the given offset and keeps legacy's fixed footprint", () => {
+    render(<GanttAmsChevron left={137} description={DESCRIPTION} />);
+
+    const button = screen.getByRole("button");
+    // Fixed width is the point: the strip must not scale with the contract
+    // duration, which is exactly why it exists instead of a bar.
+    expect(button.style.left).toBe("137px");
+  });
+
+  it("draws five chevrons, all hidden from assistive technology", () => {
+    const { container } = render(
+      <GanttAmsChevron left={0} description={DESCRIPTION} />
+    );
+
+    const svgs = container.querySelectorAll("svg");
+    expect(svgs).toHaveLength(5);
+    for (const svg of svgs) {
+      // Five decorative shapes announced individually would bury the one
+      // named button between them.
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+
+  it("reflects selection through aria-pressed, like GanttBar", () => {
+    const { rerender } = render(
+      <GanttAmsChevron left={0} description={DESCRIPTION} selected={false} />
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+
+    rerender(<GanttAmsChevron left={0} description={DESCRIPTION} selected />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("delegates select and keydown to the canvas", () => {
+    const onSelect = vi.fn();
+    const onKeyDown = vi.fn();
+    render(
+      <GanttAmsChevron
+        left={0}
+        description={DESCRIPTION}
+        onSelect={onSelect}
+        onKeyDown={onKeyDown}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.keyDown(screen.getByRole("button"), { key: "ArrowDown" });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ds/gantt/__tests__/GanttCanvas.test.tsx
+++ b/src/components/ds/gantt/__tests__/GanttCanvas.test.tsx
@@ -36,10 +36,12 @@ function Harness({
   phases,
   initiallyExpanded = [],
   onMove,
+  details,
 }: {
   phases: GanttPhase[];
   initiallyExpanded?: string[];
   onMove?: (id: string, start: number, delta: number) => void;
+  details?: React.ComponentProps<typeof GanttCanvas>["details"];
 }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set(initiallyExpanded));
   const [grain, setGrain] = useState<"Day" | "Week" | "Month" | "Quarter">("Week");
@@ -55,6 +57,7 @@ function Harness({
       expandedIds={expanded}
       onExpandedChange={setExpanded}
       onMove={onMove}
+      details={details}
       pendingChanges={3}
       debugAnnouncements
     />
@@ -302,5 +305,48 @@ describe("the tree pane", () => {
     // so a screen reader hears it once rather than twice.
     const rows = screen.getAllByRole("row");
     expect(within(rows[0]).getByRole("gridcell")).toHaveTextContent("Phase 0");
+  });
+});
+
+describe("detail columns", () => {
+  const details = {
+    p0: { calendar: "0.9 m", working: "20 d", dates: "05-Jan-26 (Mon) - 30-Jan-26 (Fri)", workingDays: 20 },
+  };
+
+  it("stays a name-only tree when no details are given", () => {
+    render(<Harness phases={plan(1, 0)} />);
+
+    // The pre-existing callers and the showcase must be untouched by the new
+    // prop: no column headers appear unless details do.
+    expect(screen.queryByText("Work Days")).not.toBeInTheDocument();
+  });
+
+  it("renders legacy's four-column grid when details are given", () => {
+    render(<Harness phases={plan(1, 0)} details={details} />);
+
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("Work Days")).toBeInTheDocument();
+    expect(screen.getByText("Start-End")).toBeInTheDocument();
+    expect(screen.getByText("20 d")).toBeInTheDocument();
+    expect(screen.getByText("0.9 m")).toBeInTheDocument();
+  });
+
+  it("adds working days to the bar's accessible name", () => {
+    render(<Harness phases={plan(1, 0)} details={details} />);
+
+    // The weekend/holiday shading that conveys this visually is aria-hidden;
+    // the bar's name is where the fact reaches assistive technology.
+    expect(
+      screen.getByRole("button", { name: /Phase 0, phase, .*20 working days/ })
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the accessible name unchanged for rows without details", () => {
+    render(<Harness phases={plan(2, 0)} details={details} />);
+
+    // p1 has no details entry; its name must not gain a dangling phrase.
+    const bars = screen.getAllByRole("button", { name: /, phase, / });
+    const p1 = bars.find((b) => b.getAttribute("aria-label")?.startsWith("Phase 1"));
+    expect(p1?.getAttribute("aria-label")).not.toMatch(/working days/);
   });
 });

--- a/src/components/ds/gantt/__tests__/GanttCapacityPanel.test.tsx
+++ b/src/components/ds/gantt/__tests__/GanttCapacityPanel.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * The capacity panel's contract, asserted against the rendered component:
+ * a real table (row and column headers reach assistive technology for free),
+ * search that filters on the provided haystack with an announced count, and
+ * cells whose accessible names come through AllocationCell fully spelled out.
+ */
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import {
+  GanttCapacityPanel,
+  type CapacityColumn,
+  type CapacityRow,
+} from "../GanttCapacityPanel";
+
+const columns: CapacityColumn[] = [
+  { key: "W01", label: "W01", title: "W01, 5 Jan – 11 Jan 26" },
+  { key: "W02", label: "W02", title: "W02, 12 Jan – 18 Jan 26" },
+];
+
+const rows: CapacityRow[] = [
+  {
+    id: "r1",
+    name: "Ada Lovelace",
+    meta: "Technical",
+    searchText: "ada lovelace technical abeam integration lead",
+    percents: [40, 120],
+  },
+  {
+    id: "r2",
+    name: "Grace Hopper",
+    meta: "Functional",
+    searchText: "grace hopper functional",
+    percents: [95, 0],
+  },
+];
+
+describe("GanttCapacityPanel", () => {
+  it("renders a real table with resource and week headers", () => {
+    render(<GanttCapacityPanel columns={columns} rows={rows} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "W01" })).toBeInTheDocument();
+    expect(screen.getByRole("rowheader", { name: /Ada Lovelace/ })).toBeInTheDocument();
+  });
+
+  it("spells out each cell through AllocationCell, over-allocation included", () => {
+    render(<GanttCapacityPanel columns={columns} rows={rows} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Ada Lovelace, W02, 12 Jan – 18 Jan 26: 120% allocated, over-allocated",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("filters rows on the haystack and announces the count", () => {
+    render(<GanttCapacityPanel columns={columns} rows={rows} />);
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search resources" }), {
+      target: { value: "integration" },
+    });
+
+    // "integration lead" is in Ada's haystack only — the field itself is not
+    // visible anywhere, which is the point: search reaches what the eye
+    // cannot.
+    expect(screen.getByRole("rowheader", { name: /Ada Lovelace/ })).toBeInTheDocument();
+    expect(screen.queryByRole("rowheader", { name: /Grace Hopper/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("1 of 2 resources");
+  });
+
+  it("says so when nothing matches, rather than showing a bare table", () => {
+    render(<GanttCapacityPanel columns={columns} rows={rows} />);
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search resources" }), {
+      target: { value: "nobody" },
+    });
+
+    expect(screen.getByText(/No resources match/)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("0 of 2 resources");
+  });
+
+  it("reports the activated cell's resource and week", () => {
+    const onCellSelect = vi.fn();
+    render(
+      <GanttCapacityPanel columns={columns} rows={rows} onCellSelect={onCellSelect} />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Grace Hopper, W01.*95% allocated/ })
+    );
+
+    expect(onCellSelect).toHaveBeenCalledWith("r2", "W01");
+  });
+
+  it("renders nothing at all with no rows — the toggle owns visibility", () => {
+    const { container } = render(<GanttCapacityPanel columns={[]} rows={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/ds/gantt/__tests__/GanttMilestones.test.tsx
+++ b/src/components/ds/gantt/__tests__/GanttMilestones.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * The milestone layer's contract, asserted against the rendered component.
+ *
+ * The properties that matter:
+ *
+ *  - A marker is a real button whose NAME carries the milestone and its date —
+ *    that is the entire accessibility story, because the rule beside it is
+ *    decoration and says nothing.
+ *  - Out-of-range milestones are dropped per-marker, matching the legacy
+ *    canvas, without hiding their in-range neighbours.
+ *  - Position is day × PX_PER_DAY for the active grain — the same arithmetic
+ *    as the bars, so a milestone and a bar on the same date line up.
+ */
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { GanttMilestones, type CanvasMilestone } from "../GanttMilestones";
+import { PX_PER_DAY } from "../scale";
+
+const uat: CanvasMilestone = {
+  id: "m1",
+  name: "UAT sign-off",
+  day: 40,
+  dateLabel: "14 Jul 26",
+  color: "#0B57D0",
+};
+
+function renderLayer(
+  milestones: CanvasMilestone[],
+  onActivate?: (id: string) => void
+) {
+  return render(
+    <GanttMilestones
+      milestones={milestones}
+      grain="Week"
+      totalDays={90}
+      onActivate={onActivate}
+    />
+  );
+}
+
+describe("GanttMilestones", () => {
+  it("renders a named button per milestone — name and date, not just 'button'", () => {
+    renderLayer([uat]);
+
+    expect(
+      screen.getByRole("button", { name: "Milestone: UAT sign-off, 14 Jul 26" })
+    ).toBeInTheDocument();
+  });
+
+  it("positions the marker with the bars' arithmetic: day × px-per-day", () => {
+    renderLayer([uat]);
+
+    const marker = screen.getByRole("button", { name: /UAT sign-off/ });
+    expect(marker.style.left).toBe(`${40 * PX_PER_DAY.Week}px`);
+  });
+
+  it("drops an out-of-range milestone without hiding its in-range neighbours", () => {
+    renderLayer([
+      uat,
+      { id: "before", name: "Before the plan", day: -3, dateLabel: "x" },
+      { id: "after", name: "After the plan", day: 91, dateLabel: "x" },
+    ]);
+
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /UAT sign-off/ })).toBeInTheDocument();
+  });
+
+  it("keeps a milestone on the plan's last day — the boundary is inclusive", () => {
+    // The end date belongs to the plan (durations are inclusive everywhere in
+    // this codebase), so a go-live milestone on the final day must render.
+    renderLayer([{ id: "golive", name: "Go-live", day: 90, dateLabel: "x" }]);
+
+    expect(screen.getByRole("button", { name: /Go-live/ })).toBeInTheDocument();
+  });
+
+  it("reports the activated milestone's id", () => {
+    const onActivate = vi.fn();
+    renderLayer([uat], onActivate);
+
+    fireEvent.click(screen.getByRole("button", { name: /UAT sign-off/ }));
+
+    expect(onActivate).toHaveBeenCalledWith("m1");
+  });
+
+  it("keeps the rule out of the accessibility tree, outside the button", () => {
+    const { container } = renderLayer([uat]);
+
+    // CSS Modules hash class names, so the selector matches on the stem. What
+    // is asserted is the structure: the rule is aria-hidden AND is not inside
+    // the button — an aria-hidden child of a named button would be fine, but
+    // an interactive thing inside an aria-hidden rule would not.
+    const rule = container.querySelector('span[class*="rule"]') as HTMLElement;
+    expect(rule).not.toBeNull();
+    expect(rule).toHaveAttribute("aria-hidden", "true");
+    expect(rule.closest("button")).toBeNull();
+  });
+
+  it("falls back to the legacy default colour so both canvases agree", () => {
+    const { container } = renderLayer([{ id: "m", name: "Plain", day: 5, dateLabel: "x" }]);
+
+    const rule = container.querySelector('span[class*="rule"]') as HTMLElement;
+    expect(rule.style.backgroundColor).toBe("rgb(255, 59, 48)"); // #FF3B30
+  });
+
+  it("renders nothing at all for an empty or fully out-of-range list", () => {
+    const { container } = renderLayer([
+      { id: "gone", name: "Gone", day: -10, dateLabel: "x" },
+    ]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/gantt-tool/next/GanttCanvasNext.tsx
+++ b/src/components/gantt-tool/next/GanttCanvasNext.tsx
@@ -42,6 +42,7 @@ import { useGanttToolStoreV2 as useGanttToolStore } from "@/stores/gantt-tool-st
 import type { ZoomMode } from "@/components/gantt-tool/ViewModeSelector";
 import { toCanvasMilestones, toCanvasModel } from "./adapter";
 import { buildAxisTicks, buildNonWorkingDays } from "./axis";
+import { buildRowDetails } from "./details";
 
 /**
  * The legacy zoom vocabulary has an "auto" and a "year"; the canvas grain has a
@@ -144,6 +145,13 @@ export function GanttCanvasNext({
     [bounds, currentProject?.holidays]
   );
 
+  // Same holiday list as the shading, so the "working days" a row reports and
+  // the days the axis shades can never disagree.
+  const details = useMemo(
+    () => (phases ? buildRowDetails(phases, currentProject?.holidays ?? []) : {}),
+    [phases, currentProject?.holidays]
+  );
+
   /**
    * Commits a Move to the store.
    *
@@ -203,6 +211,7 @@ export function GanttCanvasNext({
         majorTicks={axis.majorTicks}
         minorTicks={axis.minorTicks}
         nonWorkingDays={nonWorkingDays}
+        details={details}
         expandedIds={expandedIds}
         onExpandedChange={setExpandedIds}
         onMove={handleMove}

--- a/src/components/gantt-tool/next/GanttCanvasNext.tsx
+++ b/src/components/gantt-tool/next/GanttCanvasNext.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * The new Gantt canvas, wired to the live store.
+ *
+ * This is the strangler's replacement half. It renders behind `?canvas=next`
+ * only — see `canvas-flag.ts` for why it can never become the default by
+ * accident — and it reads and writes the same store as `GanttCanvasV3`, so the
+ * two are alternative views of one plan rather than two plans.
+ *
+ * ## What this slice covers
+ *
+ * Rows, windowing, the timeline axis, the treegrid keyboard contract, and
+ * committing a Move.
+ *
+ * Move is worth naming as the first slice because of what it is NOT: it does
+ * not replace anything. The legacy canvas has no way to change a date from the
+ * canvas at all — no drag, no resize, no keyboard nudge; dates are edited by
+ * double-clicking through to a modal. So this slice can only add, and the
+ * regression risk on the legacy path is nil.
+ *
+ * ## What it does not cover yet
+ *
+ * Milestones, the resource capacity panel, resource drag-assignment, search
+ * and column configuration, AMS chevrons, and the WBS third level. Each is a
+ * later slice. Until they land, `?canvas=next` is for comparison, not for use.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import { addDays, differenceInDays, format } from "date-fns";
+import { GanttCanvas } from "@/components/ds/gantt/GanttCanvas";
+import type { ZoomGrain } from "@/components/ds/gantt/scale";
+import { useGanttToolStoreV2 as useGanttToolStore } from "@/stores/gantt-tool-store-v2";
+import type { ZoomMode } from "@/components/gantt-tool/ViewModeSelector";
+import { toCanvasModel } from "./adapter";
+
+/**
+ * The legacy zoom vocabulary has an "auto" and a "year"; the canvas grain has a
+ * "Day" and no "year". Mapping rather than widening the canvas keeps the two
+ * vocabularies from leaking into each other while both exist.
+ *
+ * "auto" resolves to Week because that is what the legacy canvas picks for the
+ * great majority of plans, and a comparison view that silently chose a
+ * different zoom would make every bar look wrong.
+ */
+const GRAIN_BY_ZOOM: Record<ZoomMode, ZoomGrain> = {
+  auto: "Week",
+  week: "Week",
+  month: "Month",
+  quarter: "Quarter",
+  year: "Quarter",
+};
+
+export interface GanttCanvasNextProps {
+  zoomMode: ZoomMode;
+  height?: number;
+}
+
+export function GanttCanvasNext({ zoomMode, height }: GanttCanvasNextProps) {
+  const currentProject = useGanttToolStore((s) => s.currentProject);
+  const getProjectDuration = useGanttToolStore((s) => s.getProjectDuration);
+  const updateTask = useGanttToolStore((s) => s.updateTask);
+  const updatePhase = useGanttToolStore((s) => s.updatePhase);
+
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [grainOverride, setGrainOverride] = useState<ZoomGrain | null>(null);
+
+  const bounds = getProjectDuration();
+  const phases = currentProject?.phases;
+
+  const model = useMemo(
+    () => (bounds && phases ? toCanvasModel(phases, bounds) : null),
+    [phases, bounds]
+  );
+
+  const origin = bounds?.startDate;
+
+  const formatDay = useCallback(
+    (day: number) => (origin ? format(addDays(origin, day), "d MMM yy") : ""),
+    [origin]
+  );
+
+  /**
+   * Today's marker, in the same day-offset space as the bars.
+   *
+   * Undefined when today falls outside the plan, rather than clamped to an
+   * edge: a "today" line pinned to the start of a plan that finished last year
+   * is a lie that reads as a bug in the data.
+   */
+  const todayDay = useMemo(() => {
+    if (!bounds) return undefined;
+    const day = differenceInDays(new Date(), bounds.startDate);
+    return day >= 0 && day < bounds.durationDays ? day : undefined;
+  }, [bounds]);
+
+  /**
+   * Commits a Move to the store.
+   *
+   * The canvas reports `(id, startDay, deltaDays)` — where the bar started and
+   * how far it moved — and this shifts BOTH ends by the delta, so a move
+   * changes when work happens without changing how long it takes. Resizing is
+   * a separate gesture and a separate slice.
+   *
+   * Dates are written back as `yyyy-MM-dd`, matching what the edit modals
+   * write. Writing a full ISO timestamp instead would work until something
+   * compared two dates as strings.
+   */
+  const handleMove = useCallback(
+    (id: string, _startDay: number, deltaDays: number) => {
+      if (!currentProject || deltaDays === 0) return;
+
+      const phase = currentProject.phases.find((p) => p.id === id);
+      if (phase) {
+        void updatePhase(id, {
+          startDate: format(addDays(new Date(phase.startDate), deltaDays), "yyyy-MM-dd"),
+          endDate: format(addDays(new Date(phase.endDate), deltaDays), "yyyy-MM-dd"),
+        });
+        return;
+      }
+
+      for (const candidate of currentProject.phases) {
+        const task = (candidate.tasks ?? []).find((t) => t.id === id);
+        if (!task) continue;
+
+        void updateTask(id, candidate.id, {
+          startDate: format(addDays(new Date(task.startDate), deltaDays), "yyyy-MM-dd"),
+          endDate: format(addDays(new Date(task.endDate), deltaDays), "yyyy-MM-dd"),
+        });
+        return;
+      }
+    },
+    [currentProject, updatePhase, updateTask]
+  );
+
+  if (!model || !bounds) {
+    return (
+      <div style={{ padding: "var(--ds-space-6, 24px)" }}>
+        <p>No plan loaded.</p>
+      </div>
+    );
+  }
+
+  return (
+    <GanttCanvas
+      phases={model.phases}
+      placements={model.placements}
+      totalDays={model.totalDays}
+      formatDay={formatDay}
+      grain={grainOverride ?? GRAIN_BY_ZOOM[zoomMode]}
+      onGrainChange={setGrainOverride}
+      expandedIds={expandedIds}
+      onExpandedChange={setExpandedIds}
+      onMove={handleMove}
+      todayDay={todayDay}
+      height={height}
+    />
+  );
+}

--- a/src/components/gantt-tool/next/GanttCanvasNext.tsx
+++ b/src/components/gantt-tool/next/GanttCanvasNext.tsx
@@ -41,6 +41,7 @@ import type { ZoomGrain } from "@/components/ds/gantt/scale";
 import { useGanttToolStoreV2 as useGanttToolStore } from "@/stores/gantt-tool-store-v2";
 import type { ZoomMode } from "@/components/gantt-tool/ViewModeSelector";
 import { toCanvasMilestones, toCanvasModel } from "./adapter";
+import { buildAxisTicks, buildNonWorkingDays } from "./axis";
 
 /**
  * The legacy zoom vocabulary has an "auto" and a "year"; the canvas grain has a
@@ -96,6 +97,7 @@ export function GanttCanvasNext({
 
   const bounds = getProjectDuration();
   const phases = currentProject?.phases;
+  const grain = grainOverride ?? GRAIN_BY_ZOOM[zoomMode];
 
   const model = useMemo(
     () => (bounds && phases ? toCanvasModel(phases, bounds) : null),
@@ -128,6 +130,18 @@ export function GanttCanvasNext({
         ? toCanvasMilestones(currentProject.milestones, bounds, formatDay)
         : [],
     [currentProject?.milestones, bounds, formatDay]
+  );
+
+  const axis = useMemo(
+    () => (bounds ? buildAxisTicks(bounds, grain) : { majorTicks: [], minorTicks: [] }),
+    [bounds, grain]
+  );
+
+  // Same holiday source, same "ABMY" region default, as the legacy canvas —
+  // so both canvases shade identical days on the same plan.
+  const nonWorkingDays = useMemo(
+    () => (bounds ? buildNonWorkingDays(bounds, currentProject?.holidays ?? []) : []),
+    [bounds, currentProject?.holidays]
   );
 
   /**
@@ -184,8 +198,11 @@ export function GanttCanvasNext({
         placements={model.placements}
         totalDays={model.totalDays}
         formatDay={formatDay}
-        grain={grainOverride ?? GRAIN_BY_ZOOM[zoomMode]}
+        grain={grain}
         onGrainChange={setGrainOverride}
+        majorTicks={axis.majorTicks}
+        minorTicks={axis.minorTicks}
+        nonWorkingDays={nonWorkingDays}
         expandedIds={expandedIds}
         onExpandedChange={setExpandedIds}
         onMove={handleMove}

--- a/src/components/gantt-tool/next/GanttCanvasNext.tsx
+++ b/src/components/gantt-tool/next/GanttCanvasNext.tsx
@@ -43,6 +43,9 @@ import type { ZoomMode } from "@/components/gantt-tool/ViewModeSelector";
 import { toCanvasMilestones, toCanvasModel } from "./adapter";
 import { buildAxisTicks, buildNonWorkingDays } from "./axis";
 import { buildRowDetails } from "./details";
+import { toCapacityMatrix } from "./capacity";
+import { GanttCapacityPanel } from "@/components/ds/gantt/GanttCapacityPanel";
+import { calculateResourceCapacity } from "@/lib/gantt-tool/resource-capacity-calculator";
 
 /**
  * The legacy zoom vocabulary has an "auto" and a "year"; the canvas grain has a
@@ -71,6 +74,13 @@ export interface GanttCanvasNextProps {
    */
   showMilestoneModal?: boolean;
   onShowMilestoneModalChange?: (open: boolean) => void;
+  /**
+   * Shows the resource capacity matrix under the canvas — the same page
+   * toggle the legacy canvas takes. Manual per-week overrides (a legacy
+   * feature held in that component's local state) are not ported yet; the
+   * matrix shows calculated allocations only.
+   */
+  showResourceCapacity?: boolean;
 }
 
 export function GanttCanvasNext({
@@ -78,6 +88,7 @@ export function GanttCanvasNext({
   height,
   showMilestoneModal,
   onShowMilestoneModalChange,
+  showResourceCapacity = false,
 }: GanttCanvasNextProps) {
   const currentProject = useGanttToolStore((s) => s.currentProject);
   const getProjectDuration = useGanttToolStore((s) => s.getProjectDuration);
@@ -152,6 +163,27 @@ export function GanttCanvasNext({
     [phases, currentProject?.holidays]
   );
 
+  const resources = currentProject?.resources;
+
+  // The same calculator with the same inputs as the legacy panel, so the two
+  // can never show different allocations for one plan. Guarded on the toggle:
+  // for a large plan this walks every task × week, and computing it while the
+  // panel is closed is pure waste.
+  const capacity = useMemo(() => {
+    if (!showResourceCapacity || !bounds || !phases || !resources?.length) {
+      return { columns: [], rows: [] };
+    }
+    return toCapacityMatrix(
+      calculateResourceCapacity({
+        phases,
+        resources,
+        projectStartDate: bounds.startDate,
+        projectEndDate: bounds.endDate,
+      }),
+      resources
+    );
+  }, [showResourceCapacity, phases, resources, bounds]);
+
   /**
    * Commits a Move to the store.
    *
@@ -223,6 +255,10 @@ export function GanttCanvasNext({
         onMilestoneActivate={() => setMilestoneModalOpen(true)}
         height={height}
       />
+
+      {showResourceCapacity && (
+        <GanttCapacityPanel columns={capacity.columns} rows={capacity.rows} />
+      )}
 
       {/* The same modal, the same store wiring, as GanttCanvasV3 — including
         * the alert() on failure, which is not this slice's to redesign. */}

--- a/src/components/gantt-tool/next/GanttCanvasNext.tsx
+++ b/src/components/gantt-tool/next/GanttCanvasNext.tsx
@@ -19,9 +19,14 @@
  * double-clicking through to a modal. So this slice can only add, and the
  * regression risk on the legacy path is nil.
  *
+ * Milestones (slice 2) reuse the legacy MilestoneModal verbatim rather than
+ * rebuilding it: the modal is the editing surface both canvases share, and
+ * porting it belongs to a later slice, if at all. Activating any marker opens
+ * it, exactly as the legacy diamond does.
+ *
  * ## What it does not cover yet
  *
- * Milestones, the resource capacity panel, resource drag-assignment, search
+ * The resource capacity panel, resource drag-assignment, search
  * and column configuration, AMS chevrons, and the WBS third level. Each is a
  * later slice. Until they land, `?canvas=next` is for comparison, not for use.
  */
@@ -29,10 +34,13 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { addDays, differenceInDays, format } from "date-fns";
 import { GanttCanvas } from "@/components/ds/gantt/GanttCanvas";
+import { MilestoneModal } from "@/components/gantt-tool/MilestoneModal";
+import type { MilestoneFormData } from "@/types/gantt-tool";
+import { logger } from "@/lib/logger";
 import type { ZoomGrain } from "@/components/ds/gantt/scale";
 import { useGanttToolStoreV2 as useGanttToolStore } from "@/stores/gantt-tool-store-v2";
 import type { ZoomMode } from "@/components/gantt-tool/ViewModeSelector";
-import { toCanvasModel } from "./adapter";
+import { toCanvasMilestones, toCanvasModel } from "./adapter";
 
 /**
  * The legacy zoom vocabulary has an "auto" and a "year"; the canvas grain has a
@@ -54,16 +62,37 @@ const GRAIN_BY_ZOOM: Record<ZoomMode, ZoomGrain> = {
 export interface GanttCanvasNextProps {
   zoomMode: ZoomMode;
   height?: number;
+  /**
+   * The page owns "open the milestone modal" (its toolbar button sets it), so
+   * the next canvas honours the same pair of props the legacy one takes —
+   * otherwise that button silently stops working behind `?canvas=next`.
+   */
+  showMilestoneModal?: boolean;
+  onShowMilestoneModalChange?: (open: boolean) => void;
 }
 
-export function GanttCanvasNext({ zoomMode, height }: GanttCanvasNextProps) {
+export function GanttCanvasNext({
+  zoomMode,
+  height,
+  showMilestoneModal,
+  onShowMilestoneModalChange,
+}: GanttCanvasNextProps) {
   const currentProject = useGanttToolStore((s) => s.currentProject);
   const getProjectDuration = useGanttToolStore((s) => s.getProjectDuration);
   const updateTask = useGanttToolStore((s) => s.updateTask);
   const updatePhase = useGanttToolStore((s) => s.updatePhase);
+  const addMilestone = useGanttToolStore((s) => s.addMilestone);
+  const updateMilestone = useGanttToolStore((s) => s.updateMilestone);
+  const deleteMilestone = useGanttToolStore((s) => s.deleteMilestone);
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [grainOverride, setGrainOverride] = useState<ZoomGrain | null>(null);
+
+  // Controlled by the page when it passes the pair, local otherwise — the
+  // same arrangement GanttCanvasV3 uses for the same prop.
+  const [milestoneModalLocal, setMilestoneModalLocal] = useState(false);
+  const milestoneModalOpen = showMilestoneModal ?? milestoneModalLocal;
+  const setMilestoneModalOpen = onShowMilestoneModalChange ?? setMilestoneModalLocal;
 
   const bounds = getProjectDuration();
   const phases = currentProject?.phases;
@@ -92,6 +121,14 @@ export function GanttCanvasNext({ zoomMode, height }: GanttCanvasNextProps) {
     const day = differenceInDays(new Date(), bounds.startDate);
     return day >= 0 && day < bounds.durationDays ? day : undefined;
   }, [bounds]);
+
+  const milestones = useMemo(
+    () =>
+      bounds && currentProject?.milestones
+        ? toCanvasMilestones(currentProject.milestones, bounds, formatDay)
+        : [],
+    [currentProject?.milestones, bounds, formatDay]
+  );
 
   /**
    * Commits a Move to the store.
@@ -141,18 +178,53 @@ export function GanttCanvasNext({ zoomMode, height }: GanttCanvasNextProps) {
   }
 
   return (
-    <GanttCanvas
-      phases={model.phases}
-      placements={model.placements}
-      totalDays={model.totalDays}
-      formatDay={formatDay}
-      grain={grainOverride ?? GRAIN_BY_ZOOM[zoomMode]}
-      onGrainChange={setGrainOverride}
-      expandedIds={expandedIds}
-      onExpandedChange={setExpandedIds}
-      onMove={handleMove}
-      todayDay={todayDay}
-      height={height}
-    />
+    <>
+      <GanttCanvas
+        phases={model.phases}
+        placements={model.placements}
+        totalDays={model.totalDays}
+        formatDay={formatDay}
+        grain={grainOverride ?? GRAIN_BY_ZOOM[zoomMode]}
+        onGrainChange={setGrainOverride}
+        expandedIds={expandedIds}
+        onExpandedChange={setExpandedIds}
+        onMove={handleMove}
+        todayDay={todayDay}
+        milestones={milestones}
+        // Legacy behaviour exactly: any marker opens the milestone modal,
+        // which lists and edits all of them. A per-milestone editor would be
+        // an improvement, but parity first — improvements after the flip.
+        onMilestoneActivate={() => setMilestoneModalOpen(true)}
+        height={height}
+      />
+
+      {/* The same modal, the same store wiring, as GanttCanvasV3 — including
+        * the alert() on failure, which is not this slice's to redesign. */}
+      <MilestoneModal
+        open={milestoneModalOpen}
+        onOpenChange={setMilestoneModalOpen}
+        onSave={async (data) => {
+          try {
+            if (data.id) {
+              await updateMilestone(data.id, data);
+            } else {
+              await addMilestone(data as MilestoneFormData);
+            }
+          } catch (error) {
+            logger.error("Error saving milestone:", { error });
+            alert("Failed to save milestone. Please try again.");
+          }
+        }}
+        onDelete={async (id) => {
+          try {
+            await deleteMilestone(id);
+          } catch (error) {
+            logger.error("Error deleting milestone:", { error });
+            alert("Failed to delete milestone. Please try again.");
+          }
+        }}
+        milestones={currentProject?.milestones || []}
+      />
+    </>
   );
 }

--- a/src/components/gantt-tool/next/__tests__/adapter.test.ts
+++ b/src/components/gantt-tool/next/__tests__/adapter.test.ts
@@ -211,6 +211,46 @@ describe("toCanvasModel", () => {
     expect(model.phases[0].tasks).toEqual([]);
   });
 
+  it("paints an AMS phase as a chevron placement, not a contract-length bar", () => {
+    // The bounds exclude AMS end dates on purpose, so measuring this phase's
+    // bar to its contract end (a year past the plan) would overrun the canvas
+    // by ~300 days. The placement must say "chevron" and stay at the start.
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "ams",
+          phaseType: "ams",
+          startDate: "2026-03-01",
+          endDate: "2027-03-01",
+        }),
+      ],
+      bounds("2026-01-05", "2026-03-31")
+    );
+
+    expect(model.placements.ams).toMatchObject({ startDay: 55, ams: true });
+    expect(model.placements.ams.durationDays).toBeLessThanOrEqual(
+      model.totalDays
+    );
+  });
+
+  it("gives an AMS task the same chevron treatment", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-03-31",
+          tasks: [
+            task({ id: "support", startDate: "2026-03-01", endDate: "2027-03-01", isAMS: true }),
+          ],
+        }),
+      ],
+      bounds("2026-01-05", "2026-03-31")
+    );
+
+    expect(model.placements.support.ams).toBe(true);
+  });
+
   it("marks a critical task, and leaves the rest unmarked", () => {
     const model = toCanvasModel(
       [

--- a/src/components/gantt-tool/next/__tests__/adapter.test.ts
+++ b/src/components/gantt-tool/next/__tests__/adapter.test.ts
@@ -1,0 +1,232 @@
+/**
+ * The adapter is the strangler's only translation point, so these tests are the
+ * parity contract: if the new canvas ever draws a bar somewhere the legacy one
+ * would not, it is because one of these assertions changed.
+ *
+ * The two that matter most are inclusivity (a task from the 5th to the 30th is
+ * 26 days, and every duration in the legacy canvas carries a `+ 1` for it) and
+ * the origin (day 0 is the timeline start, not the phase start).
+ */
+
+import { describe, expect, it } from "vitest";
+import { differenceInDays } from "date-fns";
+import type { GanttPhase, GanttTask } from "@/types/gantt-tool";
+import {
+  dayOffset,
+  inclusiveDays,
+  toCanvasModel,
+  type ProjectBounds,
+} from "../adapter";
+
+function task(over: Partial<GanttTask> & Pick<GanttTask, "id" | "startDate" | "endDate">): GanttTask {
+  return {
+    phaseId: "p1",
+    name: over.id,
+    dependencies: [],
+    progress: 0,
+    order: 0,
+    level: 0,
+    collapsed: false,
+    isParent: false,
+    ...over,
+  } as GanttTask;
+}
+
+function phase(over: Partial<GanttPhase> & Pick<GanttPhase, "id" | "startDate" | "endDate">): GanttPhase {
+  return {
+    name: over.id,
+    color: "#0B57D0",
+    tasks: [],
+    collapsed: false,
+    dependencies: [],
+    order: 0,
+    ...over,
+  } as GanttPhase;
+}
+
+const bounds = (start: string, end: string): ProjectBounds => ({
+  startDate: new Date(start),
+  endDate: new Date(end),
+  durationDays: differenceInDays(new Date(end), new Date(start)) + 1,
+});
+
+describe("inclusiveDays", () => {
+  it("counts both endpoints, as every legacy duration does", () => {
+    // The legacy canvas writes `differenceInDays(end, start) + 1` at each of
+    // its position sites. Dropping the +1 shortens every bar by a day.
+    expect(inclusiveDays("2026-01-05", "2026-01-30")).toBe(26);
+  });
+
+  it("gives a single-day task a width of 1, not 1 day of nothing", () => {
+    expect(inclusiveDays("2026-01-05", "2026-01-05")).toBe(1);
+  });
+
+  it("never returns zero or less, even for an inverted range", () => {
+    // Imported plans have carried end < start. A zero or negative width bar
+    // vanishes silently, which hides the bad data instead of showing it.
+    expect(inclusiveDays("2026-01-30", "2026-01-05")).toBe(1);
+  });
+});
+
+describe("dayOffset", () => {
+  it("puts the timeline origin at day 0", () => {
+    expect(dayOffset("2026-01-05", new Date("2026-01-05"))).toBe(0);
+  });
+
+  it("is measured from the origin, not from the phase", () => {
+    expect(dayOffset("2026-02-01", new Date("2026-01-05"))).toBe(27);
+  });
+
+  it("goes negative for anything before the origin rather than clamping", () => {
+    // Clamping would draw an out-of-range bar at day 0, where it looks like
+    // legitimate data. Negative is visibly wrong, which is what it is.
+    expect(dayOffset("2026-01-01", new Date("2026-01-05"))).toBe(-4);
+  });
+});
+
+describe("toCanvasModel", () => {
+  it("places phases and tasks against the same origin", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [task({ id: "t1", startDate: "2026-01-12", endDate: "2026-01-16" })],
+        }),
+      ],
+      bounds("2026-01-05", "2026-03-31")
+    );
+
+    expect(model.placements.p1).toMatchObject({ startDay: 0, durationDays: 26 });
+    expect(model.placements.t1).toMatchObject({ startDay: 7, durationDays: 5 });
+  });
+
+  it("carries totalDays from the bounds rather than deriving its own", () => {
+    // Deriving it from the phases would disagree with the axis, which is drawn
+    // from the same bounds — and a timeline whose ticks and bars disagree is
+    // worse than one that is simply too long.
+    const model = toCanvasModel([], bounds("2026-01-05", "2026-03-31"));
+    expect(model.totalDays).toBe(86);
+  });
+
+  it("converts progress from the store's 0-100 to the canvas's 0-1", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [task({ id: "t1", startDate: "2026-01-05", endDate: "2026-01-09", progress: 40 })],
+        }),
+      ],
+      bounds("2026-01-05", "2026-01-30")
+    );
+
+    expect(model.placements.t1.progress).toBeCloseTo(0.4);
+  });
+
+  it("clamps out-of-range progress instead of drawing past the bar", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [
+            task({ id: "over", startDate: "2026-01-05", endDate: "2026-01-09", progress: 150 }),
+            task({ id: "under", startDate: "2026-01-05", endDate: "2026-01-09", progress: -10 }),
+          ],
+        }),
+      ],
+      bounds("2026-01-05", "2026-01-30")
+    );
+
+    expect(model.placements.over.progress).toBe(1);
+    expect(model.placements.under.progress).toBe(0);
+  });
+
+  it("gives a phase no progress rather than an invented average", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [task({ id: "t1", startDate: "2026-01-05", endDate: "2026-01-09", progress: 100 })],
+        }),
+      ],
+      bounds("2026-01-05", "2026-01-30")
+    );
+
+    expect(model.placements.p1.progress).toBeUndefined();
+  });
+
+  it("orders phases and tasks by `order`, not by array position", () => {
+    // The store mutates arrays in place in several actions, so array order is
+    // not the display order and relying on it produces a plan that reshuffles
+    // as it is edited.
+    const model = toCanvasModel(
+      [
+        phase({ id: "second", order: 2, startDate: "2026-02-01", endDate: "2026-02-10" }),
+        phase({
+          id: "first",
+          order: 1,
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [
+            task({ id: "t2", order: 2, startDate: "2026-01-20", endDate: "2026-01-22" }),
+            task({ id: "t1", order: 1, startDate: "2026-01-06", endDate: "2026-01-08" }),
+          ],
+        }),
+      ],
+      bounds("2026-01-05", "2026-02-10")
+    );
+
+    expect(model.phases.map((p) => p.id)).toEqual(["first", "second"]);
+    expect(model.phases[0].tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("does not mutate the phases it is given", () => {
+    // It sorts, and sorting in place would reorder the store's own array —
+    // which is the sort of change that shows up three screens away.
+    const input = [
+      phase({ id: "b", order: 2, startDate: "2026-02-01", endDate: "2026-02-10" }),
+      phase({ id: "a", order: 1, startDate: "2026-01-05", endDate: "2026-01-30" }),
+    ];
+
+    toCanvasModel(input, bounds("2026-01-05", "2026-02-10"));
+
+    expect(input.map((p) => p.id)).toEqual(["b", "a"]);
+  });
+
+  it("survives a phase with no tasks array at all", () => {
+    // `tasks` is required by the type but absent in some imported payloads.
+    const bare = { ...phase({ id: "p1", startDate: "2026-01-05", endDate: "2026-01-30" }) };
+    delete (bare as { tasks?: unknown }).tasks;
+
+    const model = toCanvasModel([bare], bounds("2026-01-05", "2026-01-30"));
+
+    expect(model.phases[0].tasks).toEqual([]);
+  });
+
+  it("marks a critical task, and leaves the rest unmarked", () => {
+    const model = toCanvasModel(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [
+            task({ id: "crit", startDate: "2026-01-05", endDate: "2026-01-09", isCritical: true }),
+            task({ id: "plain", startDate: "2026-01-05", endDate: "2026-01-09" }),
+          ],
+        }),
+      ],
+      bounds("2026-01-05", "2026-01-30")
+    );
+
+    expect(model.placements.crit.critical).toBe(true);
+    expect(model.placements.plain.critical).toBe(false);
+  });
+});

--- a/src/components/gantt-tool/next/__tests__/adapter.test.ts
+++ b/src/components/gantt-tool/next/__tests__/adapter.test.ts
@@ -14,6 +14,7 @@ import type { GanttPhase, GanttTask } from "@/types/gantt-tool";
 import {
   dayOffset,
   inclusiveDays,
+  toCanvasMilestones,
   toCanvasModel,
   type ProjectBounds,
 } from "../adapter";
@@ -228,5 +229,53 @@ describe("toCanvasModel", () => {
 
     expect(model.placements.crit.critical).toBe(true);
     expect(model.placements.plain.critical).toBe(false);
+  });
+});
+
+describe("toCanvasMilestones", () => {
+  const b = bounds("2026-01-05", "2026-03-31");
+
+  it("uses the bars' day arithmetic, so same-date things can never disagree", () => {
+    const [m] = toCanvasMilestones(
+      [{ id: "m1", name: "UAT", date: "2026-02-01", icon: "🚩", color: "#0B57D0" }],
+      b,
+      (day) => `day ${day}`
+    );
+
+    expect(m.day).toBe(dayOffset("2026-02-01", b.startDate));
+    expect(m.day).toBe(27);
+  });
+
+  it("labels the date through the caller's formatter, matching the bars beside it", () => {
+    const [m] = toCanvasMilestones(
+      [{ id: "m1", name: "UAT", date: "2026-02-01", icon: "", color: "" }],
+      b,
+      (day) => `formatted:${day}`
+    );
+
+    expect(m.dateLabel).toBe("formatted:27");
+  });
+
+  it("keeps out-of-range milestones — dropping is the canvas layer's decision", () => {
+    const out = toCanvasMilestones(
+      [{ id: "m1", name: "Early", date: "2025-12-01", icon: "", color: "" }],
+      b,
+      () => ""
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0].day).toBeLessThan(0);
+  });
+
+  it("normalises an empty colour to undefined so the layer's default applies", () => {
+    // The store persists color: "" for milestones created without one, and an
+    // empty string would win over the CSS/prop default and paint nothing.
+    const [m] = toCanvasMilestones(
+      [{ id: "m1", name: "Plain", date: "2026-02-01", icon: "", color: "" }],
+      b,
+      () => ""
+    );
+
+    expect(m.color).toBeUndefined();
   });
 });

--- a/src/components/gantt-tool/next/__tests__/axis.test.ts
+++ b/src/components/gantt-tool/next/__tests__/axis.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The axis model shares the bars' day-offset space; these tests are what keeps
+ * a tick from drifting off its date. The two properties that matter:
+ *
+ *  - Tick offsets come from the same `dayOffset` as the bars, so "1 Feb" on
+ *    the axis and a bar starting 1 Feb are the same pixel.
+ *  - The first period's tick is clamped to day 0 instead of being clipped
+ *    into invisibility, because plans rarely start on the 1st.
+ */
+
+import { describe, expect, it } from "vitest";
+import { differenceInDays } from "date-fns";
+import type { ProjectBounds } from "../adapter";
+import { buildAxisTicks, buildNonWorkingDays } from "../axis";
+
+const bounds = (start: string, end: string): ProjectBounds => ({
+  startDate: new Date(start),
+  endDate: new Date(end),
+  durationDays: differenceInDays(new Date(end), new Date(start)) + 1,
+});
+
+// Mon 5 Jan – Tue 31 Mar 2026. Chosen because it starts mid-month AND
+// mid-week, which exercises both clamps at once.
+const Q1 = bounds("2026-01-05", "2026-03-31");
+
+describe("buildAxisTicks", () => {
+  it("clamps the origin-containing period to day 0 rather than clipping it", () => {
+    const { majorTicks } = buildAxisTicks(Q1, "Week");
+
+    // January "started" on day -4; its label must sit at the visible edge.
+    expect(majorTicks[0]).toEqual({ day: 0, label: "Jan 26" });
+  });
+
+  it("places later ticks with the bars' arithmetic", () => {
+    const { majorTicks } = buildAxisTicks(Q1, "Week");
+
+    // 1 Feb is 27 days after 5 Jan — the same offset the adapter computes
+    // for a bar starting 1 Feb.
+    expect(majorTicks[1]).toEqual({ day: 27, label: "Feb 26" });
+    expect(majorTicks[2]).toEqual({ day: 55, label: "Mar 26" });
+  });
+
+  it("labels weeks the way legacy does, and starts them on Monday", () => {
+    const { minorTicks } = buildAxisTicks(Q1, "Week");
+
+    // The plan starts on a Monday, so the first week tick is day 0 exactly —
+    // no clamp involved — and the next is 7 days later.
+    expect(minorTicks[0].day).toBe(0);
+    expect(minorTicks[1].day).toBe(7);
+    expect(minorTicks[0].label).toMatch(/^W\d+$/);
+  });
+
+  it("splits legacy's 'Q1 '26' across the two rows at Quarter grain", () => {
+    const { minorTicks, majorTicks } = buildAxisTicks(Q1, "Quarter");
+
+    expect(minorTicks[0]).toEqual({ day: 0, label: "Q1" });
+    expect(majorTicks[0]).toEqual({ day: 0, label: "2026" });
+  });
+
+  it("gives Month grain months below and years above", () => {
+    const twoYears = bounds("2026-11-15", "2027-02-10");
+    const { minorTicks, majorTicks } = buildAxisTicks(twoYears, "Month");
+
+    expect(minorTicks.map((t) => t.label)).toEqual(["Nov", "Dec", "Jan", "Feb"]);
+    // 2026's tick clamps to 0; 2027's lands on 1 Jan, 47 days in.
+    expect(majorTicks.map((t) => t.day)).toEqual([0, 47]);
+  });
+
+  it("emits one minor tick per day at Day grain", () => {
+    const week = bounds("2026-01-05", "2026-01-11");
+    const { minorTicks } = buildAxisTicks(week, "Day");
+
+    expect(minorTicks).toHaveLength(7);
+    expect(minorTicks.map((t) => t.day)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(minorTicks[0].label).toBe("05");
+  });
+});
+
+describe("buildNonWorkingDays", () => {
+  it("shades exactly the weekends of the plan", () => {
+    // Mon 5 Jan – Sun 11 Jan: one weekend, days 5 (Sat) and 6 (Sun).
+    const week = bounds("2026-01-05", "2026-01-11");
+    const days = buildNonWorkingDays(week, []);
+
+    const weekends = days.filter((d) => !d.name);
+    expect(weekends.map((d) => d.day)).toEqual(
+      expect.arrayContaining([5, 6])
+    );
+    // No weekday leaked in: Mon–Fri are 0–4, none of which may be shaded
+    // as weekend.
+    expect(weekends.every((d) => d.day === 5 || d.day === 6)).toBe(true);
+  });
+
+  it("carries a project holiday with its name at the bars' offset", () => {
+    const days = buildNonWorkingDays(Q1, [
+      { id: "h1", name: "Company Day", date: "2026-02-02", region: "ABMY", type: "company" },
+    ]);
+
+    // 2 Feb 2026 is a Monday, 28 days in — so it can only be here by name.
+    expect(days).toContainEqual({ day: 28, name: "Company Day" });
+  });
+
+  it("keeps the name when a holiday falls on a weekend", () => {
+    // 1 Feb 2026 is a Sunday. The named entry must win over the anonymous
+    // weekend shading, not be swallowed by it.
+    const days = buildNonWorkingDays(Q1, [
+      { id: "h1", name: "Federal Day", date: "2026-02-01", region: "ABMY", type: "public" },
+    ]);
+
+    const feb1 = days.filter((d) => d.day === 27);
+    expect(feb1).toEqual([{ day: 27, name: "Federal Day" }]);
+  });
+
+  it("drops a holiday outside the plan instead of shading a phantom day", () => {
+    const days = buildNonWorkingDays(Q1, [
+      { id: "h1", name: "Later", date: "2026-06-01", region: "ABMY", type: "company" },
+    ]);
+
+    expect(days.find((d) => d.name === "Later")).toBeUndefined();
+  });
+
+  it("returns days sorted, one entry per day", () => {
+    const days = buildNonWorkingDays(Q1, []);
+
+    const offsets = days.map((d) => d.day);
+    expect(offsets).toEqual([...offsets].sort((a, b) => a - b));
+    expect(new Set(offsets).size).toBe(offsets.length);
+  });
+});

--- a/src/components/gantt-tool/next/__tests__/canvas-flag.test.ts
+++ b/src/components/gantt-tool/next/__tests__/canvas-flag.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The property under test is not "the flag works" but "the flag cannot turn
+ * itself on". `/gantt-tool` is a working screen; the new canvas has to be asked
+ * for explicitly, every time the request is ambiguous.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveChoice } from "../canvas-flag";
+
+describe("resolveChoice", () => {
+  it("defaults to legacy with no URL param and nothing stored", () => {
+    expect(resolveChoice("", null)).toBe("legacy");
+  });
+
+  it("uses the new canvas only when asked for by name", () => {
+    expect(resolveChoice("?canvas=next", null)).toBe("next");
+  });
+
+  it("lets the URL override a stored preference in both directions", () => {
+    expect(resolveChoice("?canvas=legacy", "next")).toBe("legacy");
+    expect(resolveChoice("?canvas=next", "legacy")).toBe("next");
+  });
+
+  it("keeps a stored choice when the URL says nothing", () => {
+    // Otherwise a reload mid-test silently reverts to legacy and a bug in the
+    // new canvas looks fixed.
+    expect(resolveChoice("", "next")).toBe("next");
+  });
+
+  it("treats any unrecognised value as legacy rather than experimenting", () => {
+    expect(resolveChoice("?canvas=v2", null)).toBe("legacy");
+    expect(resolveChoice("?canvas=true", null)).toBe("legacy");
+    expect(resolveChoice("?canvas=", null)).toBe("legacy");
+    expect(resolveChoice("", "garbage")).toBe("legacy");
+  });
+
+  it("is not fooled by a param that merely contains the word", () => {
+    expect(resolveChoice("?nextcanvas=1", null)).toBe("legacy");
+    expect(resolveChoice("?canvasnext=1", null)).toBe("legacy");
+  });
+
+  it("ignores other params around it", () => {
+    expect(resolveChoice("?zoom=week&canvas=next&tab=timeline", null)).toBe("next");
+  });
+});

--- a/src/components/gantt-tool/next/__tests__/capacity.test.ts
+++ b/src/components/gantt-tool/next/__tests__/capacity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The capacity mapping's contract: the matrix must be a pure reshaping of the
+ * calculator's output — no new arithmetic — and the search haystack must
+ * reproduce legacy's four searchable fields, because "search finds it in one
+ * panel but not the other" is the parity break that erodes trust fastest.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Resource } from "@/types/gantt-tool";
+import type { ResourceCapacityResult } from "@/lib/gantt-tool/resource-capacity-calculator";
+import { toCapacityMatrix } from "../capacity";
+
+function week(id: string, start: string, end: string, percent: number) {
+  return {
+    weekIdentifier: id,
+    weekStartDate: new Date(start),
+    weekEndDate: new Date(end),
+    allocatedPercent: percent,
+    allocatedDays: 0,
+    availablePercent: Math.max(0, 100 - percent),
+    availableDays: 0,
+    taskAllocations: [],
+    isOverallocated: percent > 100,
+    isAtRisk: percent > 80 && percent <= 100,
+    isManualOverride: false,
+  };
+}
+
+function result(
+  resourceId: string,
+  name: string,
+  percents: number[]
+): ResourceCapacityResult {
+  return {
+    resourceId,
+    resourceName: name,
+    resourceCategory: "technical",
+    weeks: percents.map((p, i) =>
+      week(`W0${i + 1}`, "2026-01-05", "2026-01-11", p)
+    ),
+    summary: {
+      totalAllocatedDays: 0,
+      totalAvailableDays: 0,
+      averageUtilization: 0,
+      overallocatedWeeks: 0,
+      atRiskWeeks: 0,
+    },
+  };
+}
+
+function resource(over: Partial<Resource> & Pick<Resource, "id" | "name">): Resource {
+  return {
+    category: "technical",
+    designation: "consultant",
+    ...over,
+  } as Resource;
+}
+
+describe("toCapacityMatrix", () => {
+  it("reshapes the calculator's percentages without touching them", () => {
+    const matrix = toCapacityMatrix(
+      [result("r1", "Ada Lovelace", [40, 120, 0])],
+      [resource({ id: "r1", name: "Ada Lovelace" })]
+    );
+
+    // Including the 120: over-allocation is a real state the cell renders,
+    // not something to clamp away in the mapping.
+    expect(matrix.rows[0].percents).toEqual([40, 120, 0]);
+    expect(matrix.columns.map((c) => c.key)).toEqual(["W01", "W02", "W03"]);
+  });
+
+  it("titles a column with the week and its dates", () => {
+    const matrix = toCapacityMatrix(
+      [result("r1", "Ada", [40])],
+      [resource({ id: "r1", name: "Ada" })]
+    );
+
+    expect(matrix.columns[0].title).toBe("W01, 5 Jan – 11 Jan 26");
+  });
+
+  it("builds the haystack from legacy's four fields, lower-cased", () => {
+    const matrix = toCapacityMatrix(
+      [result("r1", "Ada Lovelace", [40])],
+      [
+        resource({
+          id: "r1",
+          name: "Ada Lovelace",
+          category: "technical",
+          companyName: "ABeam",
+          projectRole: "Integration Lead",
+        }),
+      ]
+    );
+
+    const haystack = matrix.rows[0].searchText;
+    // Name, category LABEL (not the key), company, role — findable by any.
+    expect(haystack).toContain("ada lovelace");
+    expect(haystack).toContain("abeam");
+    expect(haystack).toContain("integration lead");
+    expect(haystack).toBe(haystack.toLowerCase());
+  });
+
+  it("survives a result whose resource record is missing", () => {
+    // The calculator ran against a resource since deleted from the list; the
+    // row must still render rather than take the panel down.
+    const matrix = toCapacityMatrix([result("ghost", "Departed", [10])], []);
+
+    expect(matrix.rows[0].name).toBe("Departed");
+    expect(matrix.rows[0].searchText).toContain("departed");
+  });
+
+  it("returns an empty matrix for no results", () => {
+    expect(toCapacityMatrix([], [])).toEqual({ columns: [], rows: [] });
+  });
+});

--- a/src/components/gantt-tool/next/__tests__/details.test.ts
+++ b/src/components/gantt-tool/next/__tests__/details.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The detail columns are parity surface: whatever these produce is what sits
+ * beside the legacy canvas's numbers when the two are compared on one plan.
+ * So the assertions here are against legacy's exact output formats — "3.2 m",
+ * "42 d", "05-Jan-26 (Mon) - 30-Jan-26 (Fri)" — not paraphrases of them.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GanttPhase, GanttTask } from "@/types/gantt-tool";
+import { buildRowDetails } from "../details";
+
+function task(over: Partial<GanttTask> & Pick<GanttTask, "id" | "startDate" | "endDate">): GanttTask {
+  return {
+    phaseId: "p1",
+    name: over.id,
+    dependencies: [],
+    progress: 0,
+    order: 0,
+    level: 0,
+    collapsed: false,
+    isParent: false,
+    ...over,
+  } as GanttTask;
+}
+
+function phase(over: Partial<GanttPhase> & Pick<GanttPhase, "id" | "startDate" | "endDate">): GanttPhase {
+  return {
+    name: over.id,
+    color: "#0B57D0",
+    tasks: [],
+    collapsed: false,
+    dependencies: [],
+    order: 0,
+    ...over,
+  } as GanttPhase;
+}
+
+describe("buildRowDetails", () => {
+  it("renders legacy's formats exactly, for phases and tasks alike", () => {
+    // Mon 5 Jan – Fri 30 Jan 2026: 26 calendar days, 20 working days,
+    // no holidays involved.
+    const details = buildRowDetails(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [task({ id: "t1", startDate: "2026-01-05", endDate: "2026-01-09" })],
+        }),
+      ],
+      []
+    );
+
+    expect(details.p1).toEqual({
+      calendar: "0.9 m", // 26 / 30, rounded to 1dp — legacy's formatCalendarDaysAsMonths
+      working: "20 d",
+      dates: "05-Jan-26 (Mon) - 30-Jan-26 (Fri)",
+      workingDays: 20,
+    });
+    expect(details.t1.working).toBe("5 d");
+  });
+
+  it("subtracts a weekday holiday from working days but not calendar days", () => {
+    // Same task with a holiday on Wed 7 Jan: 5 calendar weekdays, 4 working.
+    const withHoliday = buildRowDetails(
+      [phase({ id: "p1", startDate: "2026-01-05", endDate: "2026-01-09" })],
+      [{ id: "h", name: "Founders Day", date: "2026-01-07", region: "ABMY", type: "company" }]
+    );
+    const without = buildRowDetails(
+      [phase({ id: "p1", startDate: "2026-01-05", endDate: "2026-01-09" })],
+      []
+    );
+
+    expect(without.p1.workingDays).toBe(5);
+    expect(withHoliday.p1.workingDays).toBe(4);
+    // The calendar column is holiday-blind on purpose; only working days move.
+    expect(withHoliday.p1.calendar).toBe(without.p1.calendar);
+  });
+
+  it("computes AMS rows uniformly — the cell describes the contract", () => {
+    // The TIMELINE excludes AMS ends so the canvas does not stretch; the grid
+    // still reports the contract's real duration, exactly as legacy does.
+    const details = buildRowDetails(
+      [phase({ id: "ams", phaseType: "ams", startDate: "2026-03-02", endDate: "2027-03-01" })],
+      []
+    );
+
+    expect(details.ams.workingDays).toBeGreaterThan(250);
+    expect(details.ams.calendar).toBe("12.2 m");
+  });
+
+  it("covers every row it is given and nothing else", () => {
+    const details = buildRowDetails(
+      [
+        phase({
+          id: "p1",
+          startDate: "2026-01-05",
+          endDate: "2026-01-30",
+          tasks: [
+            task({ id: "t1", startDate: "2026-01-05", endDate: "2026-01-09" }),
+            task({ id: "t2", startDate: "2026-01-12", endDate: "2026-01-16" }),
+          ],
+        }),
+      ],
+      []
+    );
+
+    expect(Object.keys(details).sort()).toEqual(["p1", "t1", "t2"]);
+  });
+});

--- a/src/components/gantt-tool/next/adapter.ts
+++ b/src/components/gantt-tool/next/adapter.ts
@@ -81,6 +81,15 @@ export function inclusiveDays(startIso: string, endIso: string): number {
 }
 
 function placeTask(task: StoreTask, origin: Date): BarPlacement {
+  // Same rule as AMS phases: an ongoing task's end is off-canvas by design.
+  if (task.isAMS === true) {
+    return {
+      startDay: dayOffset(task.startDate, origin),
+      durationDays: 1,
+      ams: true,
+    };
+  }
+
   return {
     startDay: dayOffset(task.startDate, origin),
     durationDays: inclusiveDays(task.startDate, task.endDate),
@@ -92,6 +101,18 @@ function placeTask(task: StoreTask, origin: Date): BarPlacement {
 }
 
 function placePhase(phase: StorePhase, origin: Date): BarPlacement {
+  // An AMS phase's endDate is its contract end, which the timeline bounds
+  // deliberately exclude — measuring a bar to it would overrun the canvas by
+  // up to three years. The canvas paints these as a fixed chevron strip and
+  // ignores the duration; 1 is a placeholder, not a claim.
+  if (phase.phaseType === "ams") {
+    return {
+      startDay: dayOffset(phase.startDate, origin),
+      durationDays: 1,
+      ams: true,
+    };
+  }
+
   return {
     startDay: dayOffset(phase.startDate, origin),
     durationDays: inclusiveDays(phase.startDate, phase.endDate),

--- a/src/components/gantt-tool/next/adapter.ts
+++ b/src/components/gantt-tool/next/adapter.ts
@@ -36,9 +36,14 @@
  */
 
 import { differenceInDays } from "date-fns";
-import type { GanttPhase as StorePhase, GanttTask as StoreTask } from "@/types/gantt-tool";
+import type {
+  GanttMilestone as StoreMilestone,
+  GanttPhase as StorePhase,
+  GanttTask as StoreTask,
+} from "@/types/gantt-tool";
 import type { BarPlacement } from "@/components/ds/gantt/GanttCanvas";
 import type { GanttPhase as CanvasPhase } from "@/components/ds/gantt/rows";
+import type { CanvasMilestone } from "@/components/ds/gantt/GanttMilestones";
 
 /** Timeline bounds as `getProjectDuration()` returns them. */
 export interface ProjectBounds {
@@ -132,4 +137,31 @@ export function toCanvasModel(
     placements,
     totalDays: bounds.durationDays,
   };
+}
+
+/**
+ * Store milestones → canvas milestones, in the same day-offset space as the
+ * bars — via the same `dayOffset`, so a milestone and a bar on the same date
+ * can never disagree by a day.
+ *
+ * Out-of-range milestones are NOT dropped here: the canvas layer drops them
+ * against `totalDays`, the same split the bars use. `formatDay` comes in from
+ * the caller so the accessible date reads identically to the bar dates beside
+ * it.
+ */
+export function toCanvasMilestones(
+  milestones: StoreMilestone[],
+  bounds: ProjectBounds,
+  formatDay: (day: number) => string
+): CanvasMilestone[] {
+  return milestones.map((m) => {
+    const day = dayOffset(m.date, bounds.startDate);
+    return {
+      id: m.id,
+      name: m.name,
+      day,
+      dateLabel: formatDay(day),
+      color: m.color || undefined,
+    };
+  });
 }

--- a/src/components/gantt-tool/next/adapter.ts
+++ b/src/components/gantt-tool/next/adapter.ts
@@ -1,0 +1,135 @@
+/**
+ * Strangler seam — store project → design-system canvas model.
+ *
+ * The port replaces `GanttCanvasV3` (4,078 lines) with
+ * `components/ds/gantt/GanttCanvas` (499 lines) one capability at a time. Both
+ * canvases render from the same store, so nothing forks: this file is the only
+ * place that translates between them, and it is pure so the translation can be
+ * asserted rather than eyeballed.
+ *
+ * ## The parity contract
+ *
+ * The legacy canvas positions a bar as a percentage of the container:
+ *
+ *     dayOffset = differenceInDays(date, bounds.startDate)
+ *     left%     = dayOffset / extendedDuration * 100
+ *
+ * Two properties of that are contractual and reproduced exactly here:
+ *
+ *  - **The origin is `getProjectDuration().startDate`** — the earliest phase or
+ *    task start, with AMS phases contributing their start but not their end.
+ *    Passing `bounds` in rather than recomputing it is deliberate: the rule has
+ *    real subtleties (a 21-day AMS chevron buffer, non-AMS ends only), and two
+ *    implementations of it would drift.
+ *  - **Durations are inclusive.** A task from the 5th to the 30th is 26 days,
+ *    not 25. Every duration in the legacy canvas carries a `+ 1` for this, and
+ *    dropping it shortens every bar in the plan by a day.
+ *
+ * ## The one thing that is deliberately NOT the same
+ *
+ * Legacy sizes the timeline as a percentage of the viewport, so a three-year
+ * plan and a three-week plan both fill the width and a day means a different
+ * distance in each. The new canvas uses a fixed px-per-day per zoom grain and
+ * scrolls. That is a real behavioural change, not an oversight: constant day
+ * width is what makes bars comparable, and it is why the new canvas can window
+ * 1,200 rows instead of squeezing them.
+ */
+
+import { differenceInDays } from "date-fns";
+import type { GanttPhase as StorePhase, GanttTask as StoreTask } from "@/types/gantt-tool";
+import type { BarPlacement } from "@/components/ds/gantt/GanttCanvas";
+import type { GanttPhase as CanvasPhase } from "@/components/ds/gantt/rows";
+
+/** Timeline bounds as `getProjectDuration()` returns them. */
+export interface ProjectBounds {
+  startDate: Date;
+  endDate: Date;
+  durationDays: number;
+}
+
+export interface CanvasModel {
+  phases: CanvasPhase[];
+  placements: Record<string, BarPlacement>;
+  totalDays: number;
+}
+
+/**
+ * Day offset of an ISO date from the timeline origin.
+ *
+ * Exported because the milestone and today markers need the identical
+ * calculation, and a marker that disagrees with the bars by a day is the kind
+ * of defect nobody reports and everybody distrusts.
+ */
+export function dayOffset(iso: string, origin: Date): number {
+  return differenceInDays(new Date(iso), origin);
+}
+
+/**
+ * Inclusive span in days between two ISO dates.
+ *
+ * Returns at least 1: a zero-length bar is invisible, and the store does permit
+ * `startDate === endDate` for a single-day task.
+ */
+export function inclusiveDays(startIso: string, endIso: string): number {
+  const span = differenceInDays(new Date(endIso), new Date(startIso)) + 1;
+  return span > 0 ? span : 1;
+}
+
+function placeTask(task: StoreTask, origin: Date): BarPlacement {
+  return {
+    startDay: dayOffset(task.startDate, origin),
+    durationDays: inclusiveDays(task.startDate, task.endDate),
+    // The store keeps progress as 0-100; the canvas wants 0-1. Clamped because
+    // imported plans have been seen carrying 150.
+    progress: Math.max(0, Math.min(1, (task.progress ?? 0) / 100)),
+    critical: task.isCritical === true,
+  };
+}
+
+function placePhase(phase: StorePhase, origin: Date): BarPlacement {
+  return {
+    startDay: dayOffset(phase.startDate, origin),
+    durationDays: inclusiveDays(phase.startDate, phase.endDate),
+    // A phase has no progress of its own in the store. Deriving one by
+    // averaging its tasks would invent a number the plan does not contain, so
+    // the bar shows none.
+    critical: false,
+  };
+}
+
+/**
+ * Flattens the store's phase/task tree into what the canvas renders.
+ *
+ * Child tasks (`parentTaskId`) are included as ordinary rows rather than a
+ * third level: the canvas's row model is two-level by design, and collapsing
+ * the WBS into it is a decision the port has to make explicitly rather than by
+ * silently dropping the deeper rows. Nesting is a later slice.
+ */
+export function toCanvasModel(
+  phases: StorePhase[],
+  bounds: ProjectBounds
+): CanvasModel {
+  const origin = bounds.startDate;
+  const placements: Record<string, BarPlacement> = {};
+
+  const canvasPhases: CanvasPhase[] = [...phases]
+    .sort((a, b) => a.order - b.order)
+    .map((phase) => {
+      placements[phase.id] = placePhase(phase, origin);
+
+      const tasks = [...(phase.tasks ?? [])]
+        .sort((a, b) => a.order - b.order)
+        .map((task) => {
+          placements[task.id] = placeTask(task, origin);
+          return { id: task.id, name: task.name };
+        });
+
+      return { id: phase.id, name: phase.name, tasks };
+    });
+
+  return {
+    phases: canvasPhases,
+    placements,
+    totalDays: bounds.durationDays,
+  };
+}

--- a/src/components/gantt-tool/next/axis.ts
+++ b/src/components/gantt-tool/next/axis.ts
@@ -1,0 +1,143 @@
+/**
+ * Strangler seam — axis ticks and non-working-day shading.
+ *
+ * Pure, like the adapter, and for the same reason: the ticks live in the same
+ * day-offset space as the bars, so the only way the axis can disagree with a
+ * bar is if one of these functions changes — and that is assertable.
+ *
+ * ## Mapping legacy's one labelled row onto the canvas's two
+ *
+ * The legacy canvas renders one row of markers, each with a primary and a
+ * secondary line ("W28" over "06-Jul-26"). The design-system axis renders two
+ * rows: minor (the grain's own step) and major (the containing period). The
+ * legacy pairs translate directly:
+ *
+ *     grain     minor (lower row)         major (upper row)
+ *     Day       day of month "05"         month "Jul 26"
+ *     Week      week "W28"                month "Jul 26"
+ *     Month     month "Jul"               year "2026"
+ *     Quarter   quarter "Q3"              year "2026"
+ *
+ * ## The first-tick clamp
+ *
+ * `eachMonthOfInterval` returns period STARTS, and the first period usually
+ * starts before the plan does — a plan starting 5 Jan gets a "Jan" tick at
+ * day -4, which the axis clips into invisibility. Any tick before day 0 is
+ * clamped to 0: the label belongs to the period containing the origin, and
+ * pinning it to the visible edge is what the legacy percentage layout
+ * effectively did.
+ */
+
+import {
+  addDays,
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  eachQuarterOfInterval,
+  eachWeekOfInterval,
+  eachYearOfInterval,
+  format,
+  getDay,
+  getMonth,
+} from "date-fns";
+import type { AxisTick, NonWorkingDay } from "@/components/ds/gantt/TimelineAxis";
+import type { ZoomGrain } from "@/components/ds/gantt/scale";
+import type { GanttHoliday } from "@/types/gantt-tool";
+import { getUnifiedHolidays } from "@/lib/gantt-tool/holiday-integration";
+import { dayOffset, type ProjectBounds } from "./adapter";
+
+function tick(date: Date, origin: Date, label: string): AxisTick {
+  return { day: Math.max(0, dayOffset(format(date, "yyyy-MM-dd"), origin)), label };
+}
+
+export interface AxisModel {
+  majorTicks: AxisTick[];
+  minorTicks: AxisTick[];
+}
+
+export function buildAxisTicks(bounds: ProjectBounds, grain: ZoomGrain): AxisModel {
+  const { startDate: start, endDate: end } = bounds;
+  const interval = { start, end };
+
+  switch (grain) {
+    case "Day":
+      return {
+        minorTicks: eachDayOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "dd"))
+        ),
+        majorTicks: eachMonthOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "MMM yy"))
+        ),
+      };
+    case "Week":
+      return {
+        minorTicks: eachWeekOfInterval(interval, { weekStartsOn: 1 }).map((d) =>
+          // Legacy labels weeks "W28"; the ISO week number, same format token.
+          tick(d, start, `W${format(d, "w")}`)
+        ),
+        majorTicks: eachMonthOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "MMM yy"))
+        ),
+      };
+    case "Month":
+      return {
+        minorTicks: eachMonthOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "MMM"))
+        ),
+        majorTicks: eachYearOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "yyyy"))
+        ),
+      };
+    case "Quarter":
+      return {
+        minorTicks: eachQuarterOfInterval(interval).map((d) =>
+          // Legacy's "Q3 '26" split across the two rows: Q3 below, year above.
+          tick(d, start, `Q${Math.ceil((getMonth(d) + 1) / 3)}`)
+        ),
+        majorTicks: eachYearOfInterval(interval).map((d) =>
+          tick(d, start, format(d, "yyyy"))
+        ),
+      };
+  }
+}
+
+/**
+ * Weekends and holidays as the axis's shading model.
+ *
+ * Weekends are derived by walking the plan a day at a time — a few thousand
+ * iterations at worst, cheaper than being clever. Holidays come from the same
+ * `getUnifiedHolidays` the legacy canvas calls, with the same hardcoded
+ * "ABMY" region default, so the two canvases shade identical days. A holiday
+ * that lands on a weekend keeps its name: named shading beats anonymous
+ * shading when both apply.
+ *
+ * Generated regardless of grain; the axis itself only renders shading at Day
+ * and Week, where a day is wide enough to be information rather than texture.
+ */
+export function buildNonWorkingDays(
+  bounds: ProjectBounds,
+  projectHolidays: GanttHoliday[]
+): NonWorkingDay[] {
+  const { startDate, durationDays } = bounds;
+  const byDay = new Map<number, NonWorkingDay>();
+
+  for (let day = 0; day < durationDays; day++) {
+    const weekday = getDay(addDays(startDate, day));
+    if (weekday === 0 || weekday === 6) {
+      byDay.set(day, { day });
+    }
+  }
+
+  for (const holiday of getUnifiedHolidays(
+    bounds.startDate,
+    bounds.endDate,
+    projectHolidays,
+    "ABMY"
+  )) {
+    const day = dayOffset(holiday.date, startDate);
+    if (day >= 0 && day < durationDays) {
+      byDay.set(day, { day, name: holiday.name });
+    }
+  }
+
+  return [...byDay.values()].sort((a, b) => a.day - b.day);
+}

--- a/src/components/gantt-tool/next/canvas-flag.ts
+++ b/src/components/gantt-tool/next/canvas-flag.ts
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Which Gantt canvas `/gantt-tool` renders.
+ *
+ * The port is a strangler: both canvases exist, both read the same store, and
+ * this decides which one mounts. Three properties matter more than the
+ * mechanism.
+ *
+ *  - **Legacy is the default, and cannot stop being the default by accident.**
+ *    The only way to get the new canvas is to ask for it by name. There is no
+ *    "roll out to 10%", no env var that flips it for everyone on the next
+ *    deploy. `/gantt-tool` is the product; it does not get to be the testbed.
+ *
+ *  - **Switching is a URL, not a deploy.** `?canvas=next` and `?canvas=legacy`.
+ *    A build-time `NEXT_PUBLIC_` flag would mean a full rebuild per comparison,
+ *    and on Vercel those are inlined at build time — the thing that already
+ *    cost a confused afternoon this week when a DSN change appeared not to
+ *    take. Comparing the two canvases on the same plan, in the same session,
+ *    is the entire point of a strangler; that has to be cheap.
+ *
+ *  - **The choice sticks, so a reload during testing does not silently revert
+ *    to legacy** and make a bug look fixed. It is per-browser, in
+ *    localStorage, and never leaves the device.
+ *
+ * Read it through `useGanttCanvasChoice`, not directly: the value has to be
+ * resolved after mount, because localStorage does not exist during the server
+ * render and reading it inside the component body is a hydration mismatch.
+ */
+
+import { useEffect, useState } from "react";
+
+export type CanvasChoice = "legacy" | "next";
+
+const STORAGE_KEY = "cockpit.ganttCanvas";
+const QUERY_PARAM = "canvas";
+
+/** Anything not explicitly "next" is legacy. Unknown values do not experiment. */
+function parse(value: string | null | undefined): CanvasChoice | null {
+  if (value === "next") return "next";
+  if (value === "legacy") return "legacy";
+  return null;
+}
+
+/**
+ * Resolves the choice from the URL first, then the stored preference.
+ *
+ * Exported for tests, which is why it takes its inputs rather than reading the
+ * globals itself.
+ */
+export function resolveChoice(
+  search: string,
+  stored: string | null
+): CanvasChoice {
+  const fromUrl = parse(new URLSearchParams(search).get(QUERY_PARAM));
+  if (fromUrl) return fromUrl;
+  return parse(stored) ?? "legacy";
+}
+
+export function useGanttCanvasChoice(): CanvasChoice {
+  // Always "legacy" on the server and on the first client render, so the two
+  // agree. A user who asked for `next` sees one legacy frame before the effect
+  // runs — a trade worth making against a hydration error on the live screen.
+  const [choice, setChoice] = useState<CanvasChoice>("legacy");
+
+  useEffect(() => {
+    let stored: string | null = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch {
+      // Safari in private mode throws on localStorage. Falling back to the URL
+      // alone is correct; failing to render the Gantt would not be.
+    }
+
+    const resolved = resolveChoice(window.location.search, stored);
+    setChoice(resolved);
+
+    // Persist only what the URL asked for. Writing on every resolve would
+    // re-save "legacy" over a stored "next" on any navigation without the
+    // param, which is the opposite of sticky.
+    if (parse(new URLSearchParams(window.location.search).get(QUERY_PARAM))) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, resolved);
+      } catch {
+        // See above.
+      }
+    }
+  }, []);
+
+  return choice;
+}

--- a/src/components/gantt-tool/next/capacity.ts
+++ b/src/components/gantt-tool/next/capacity.ts
@@ -1,0 +1,75 @@
+/**
+ * Strangler seam — resource capacity results → the capacity matrix.
+ *
+ * The numbers come from `calculateResourceCapacity`, the same calculator the
+ * legacy panel uses with the same inputs, so the two panels can never show
+ * different allocations for the same plan. This file only reshapes: aligned
+ * per-week percentage arrays for the matrix, and the search haystack.
+ *
+ * The haystack reproduces legacy's four searchable fields exactly — name,
+ * category label, company name, project role — because "search finds it in
+ * one panel but not the other" is the kind of parity break that erodes trust
+ * in the whole port.
+ */
+
+import { format } from "date-fns";
+import type { Resource } from "@/types/gantt-tool";
+import { RESOURCE_CATEGORIES } from "@/types/gantt-tool";
+import type {
+  ResourceCapacityResult,
+} from "@/lib/gantt-tool/resource-capacity-calculator";
+import type {
+  CapacityColumn,
+  CapacityRow,
+} from "@/components/ds/gantt/GanttCapacityPanel";
+
+export interface CapacityMatrix {
+  columns: CapacityColumn[];
+  rows: CapacityRow[];
+}
+
+export function toCapacityMatrix(
+  results: ResourceCapacityResult[],
+  resources: Resource[]
+): CapacityMatrix {
+  if (results.length === 0) return { columns: [], rows: [] };
+
+  const resourceById = new Map(resources.map((r) => [r.id, r]));
+
+  // Every result carries the same project weeks (the calculator builds them
+  // once from the project bounds), so the first result defines the columns.
+  const columns: CapacityColumn[] = results[0].weeks.map((week) => ({
+    key: week.weekIdentifier,
+    label: week.weekIdentifier,
+    title: `${week.weekIdentifier}, ${format(week.weekStartDate, "d MMM")} – ${format(
+      week.weekEndDate,
+      "d MMM yy"
+    )}`,
+  }));
+
+  const rows: CapacityRow[] = results.map((result) => {
+    const resource = resourceById.get(result.resourceId);
+    const category =
+      RESOURCE_CATEGORIES[
+        (resource?.category ?? "other") as keyof typeof RESOURCE_CATEGORIES
+      ] ?? RESOURCE_CATEGORIES.other;
+
+    return {
+      id: result.resourceId,
+      name: result.resourceName,
+      meta: category.label,
+      // Legacy's four fields, lower-cased once here instead of per keystroke.
+      searchText: [
+        result.resourceName,
+        category.label,
+        resource?.companyName ?? "",
+        resource?.projectRole ?? "",
+      ]
+        .join(" ")
+        .toLowerCase(),
+      percents: result.weeks.map((week) => week.allocatedPercent),
+    };
+  });
+
+  return { columns, rows };
+}

--- a/src/components/gantt-tool/next/details.ts
+++ b/src/components/gantt-tool/next/details.ts
@@ -1,0 +1,62 @@
+/**
+ * Strangler seam — per-row detail columns.
+ *
+ * The legacy tree pane is a data grid: name, calendar duration, working days,
+ * start–end dates. This computes those three cells per row, with the same
+ * three functions the legacy canvas calls and the same formats it renders —
+ * "3.2 m", "42 d", "05-Jan-26 (Mon) - 30-Jan-26 (Fri)" — so the two canvases
+ * show identical numbers for the same plan.
+ *
+ * Working days are holiday-aware, which is why this takes the project's
+ * holidays: a two-week task over Chinese New Year has fewer working days than
+ * the same two weeks in March, and a column that ignored that would disagree
+ * with every cost calculation in the app.
+ *
+ * AMS rows get the same treatment as everything else. Their end dates are
+ * contract ends the *timeline* deliberately excludes, but the legacy grid
+ * computes their durations uniformly — the cell describes the contract, the
+ * canvas describes the plan, and those are allowed to differ.
+ */
+
+import { format } from "date-fns";
+import type { GanttHoliday, GanttPhase } from "@/types/gantt-tool";
+import {
+  calculateCalendarDaysInclusive,
+  calculateWorkingDaysInclusive,
+  formatCalendarDaysAsMonths,
+} from "@/lib/gantt-tool/working-days";
+import type { RowDetails } from "@/components/ds/gantt/GanttCanvas";
+
+function detailsFor(
+  startDate: string,
+  endDate: string,
+  holidays: GanttHoliday[]
+): RowDetails {
+  const workingDays = calculateWorkingDaysInclusive(startDate, endDate, holidays);
+  const dateLabel = (iso: string) => format(new Date(iso), "dd-MMM-yy (EEE)");
+
+  return {
+    calendar: formatCalendarDaysAsMonths(
+      calculateCalendarDaysInclusive(startDate, endDate)
+    ),
+    working: `${workingDays} d`,
+    dates: `${dateLabel(startDate)} - ${dateLabel(endDate)}`,
+    workingDays,
+  };
+}
+
+export function buildRowDetails(
+  phases: GanttPhase[],
+  holidays: GanttHoliday[]
+): Record<string, RowDetails> {
+  const details: Record<string, RowDetails> = {};
+
+  for (const phase of phases) {
+    details[phase.id] = detailsFor(phase.startDate, phase.endDate, holidays);
+    for (const task of phase.tasks ?? []) {
+      details[task.id] = detailsFor(task.startDate, task.endDate, holidays);
+    }
+  }
+
+  return details;
+}

--- a/src/components/navigation/GlobalNav.tsx
+++ b/src/components/navigation/GlobalNav.tsx
@@ -70,14 +70,14 @@ export function GlobalNav({ session }: GlobalNavProps) {
       <Link href="/dashboard" className={styles.brand}>
         <div className={styles.logoWrapper}>
           <Image
-            src="/logo-bound.svg"
-            alt="Bound"
+            src="/logo-cockpit.svg"
+            alt="Cockpit"
             width={32}
             height={32}
             priority
           />
         </div>
-        <div className={styles.brandLogo}>Bound</div>
+        <div className={styles.brandLogo}>Cockpit</div>
       </Link>
 
       {/* Center Zone - Global Tabs */}

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -4,7 +4,7 @@
  * All templates are responsive, accessible, and follow email best practices
  */
 
-const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME || "Bound";
+const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME || "Cockpit";
 const APP_URL = process.env.NEXTAUTH_URL || "http://localhost:3000";
 
 // ============================================

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -29,7 +29,7 @@ function emailTemplate(code: string, magicLink?: string): string {
             <div style="max-width: 600px; margin: 40px auto; background: white; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">
               <!-- Header -->
               <div style="background: linear-gradient(135deg, #0f172a 0%, #334155 100%); padding: 32px; text-align: center;">
-                <h1 style="margin: 0; color: white; font-size: 28px; font-weight: 300; letter-spacing: -0.5px;">Bound</h1>
+                <h1 style="margin: 0; color: white; font-size: 28px; font-weight: 300; letter-spacing: -0.5px;">Cockpit</h1>
               </div>
 
               <!-- Content -->
@@ -135,9 +135,9 @@ export async function sendAccessCode(email: string, code: string, magicLink?: st
 
   try {
     await emailTransporter.sendMail({
-      from: `"Bound" <${FROM_EMAIL}>`,
+      from: `"Cockpit" <${FROM_EMAIL}>`,
       to: email,
-      subject: magicLink ? "🚀 Your Bound Access is Ready" : "Your Bound Access Code",
+      subject: magicLink ? "🚀 Your Cockpit Access is Ready" : "Your Cockpit Access Code",
       html: emailTemplate(code, magicLink),
     });
 

--- a/src/lib/gantt-tool/export-utils.ts
+++ b/src/lib/gantt-tool/export-utils.ts
@@ -1233,7 +1233,7 @@ function addExportFooter(
   // Right: Branding
   const branding = document.createElement("span");
   branding.style.cssText = "font-weight: 500; color: #3B82F6;";
-  branding.textContent = "Bound";
+  branding.textContent = "Cockpit";
 
   footer.appendChild(projectName);
   footer.appendChild(exportDate);

--- a/src/lib/webauthn.ts
+++ b/src/lib/webauthn.ts
@@ -6,7 +6,7 @@ import {
 } from "@simplewebauthn/server";
 import { Redis } from "@upstash/redis";
 
-export const rpName = "Bound";
+export const rpName = "Cockpit";
 const dev = process.env.NODE_ENV !== "production";
 
 function getWebAuthnConfig() {

--- a/tests/__tests__/get-client-rects-shim.test.tsx
+++ b/tests/__tests__/get-client-rects-shim.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Guards the `getClientRects` shim in tests/setup.ts.
+ *
+ * jsdom performs no layout, so every element reports zero client rects, and
+ * `tabbable` — which focus-trap uses — reads zero rects as "not rendered" and
+ * therefore "not tabbable". Without the shim, focus-trap's activate() throws
+ * for every modal in the repo, which is why the focus-trap suite was skipped
+ * wholesale before it was fixed.
+ *
+ * The shim exists to make VISIBLE things tabbable. It must not make HIDDEN
+ * things tabbable, or it stops being a test environment fix and becomes a way
+ * to pass tests that should fail — a modal whose only control is display:none
+ * would look fine.
+ *
+ * These assertions matter more than usual because the ancestor check was
+ * deliberately narrowed for speed: a full getComputedStyle per ancestor cost
+ * 21.4s across the 27 focus-trap tests against 7.3s without it, and under
+ * coverage instrumentation that pushed three past the 5s timeout. What remains
+ * is asserted here rather than assumed from the comment.
+ */
+
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { tabbable } from "tabbable";
+
+function names(container: HTMLElement): string[] {
+  return tabbable(container).map((node) => node.textContent ?? "");
+}
+
+describe("getClientRects shim", () => {
+  it("reports a rect for an attached, visible element", () => {
+    // The whole reason the shim exists: without it this list is empty and
+    // every focus trap in the repo throws on activation.
+    const { container } = render(
+      <div>
+        <button>visible</button>
+      </div>
+    );
+
+    expect(container.querySelector("button")!.getClientRects()).toHaveLength(1);
+    expect(names(container)).toEqual(["visible"]);
+  });
+
+  it("reports no rect for a detached element", () => {
+    const orphan = document.createElement("button");
+    expect(orphan.getClientRects()).toHaveLength(0);
+  });
+
+  it("still hides an element with its own display:none", () => {
+    const { container } = render(
+      <div>
+        <button style={{ display: "none" }}>hidden</button>
+        <button>visible</button>
+      </div>
+    );
+
+    expect(names(container)).toEqual(["visible"]);
+  });
+
+  it("still hides an element with its own visibility:hidden", () => {
+    const { container } = render(
+      <div>
+        <button style={{ visibility: "hidden" }}>hidden</button>
+        <button>visible</button>
+      </div>
+    );
+
+    expect(names(container)).toEqual(["visible"]);
+  });
+
+  it("still hides a control inside a display:none ancestor", () => {
+    // This is the case the narrowed ancestor walk has to keep catching. A
+    // collapsed accordion or a closed panel is exactly this shape, and if its
+    // contents read as tabbable, a focus-trap test passes on a dialog whose
+    // controls nobody can reach.
+    const { container } = render(
+      <div>
+        <div style={{ display: "none" }}>
+          <span>
+            <button>buried</button>
+          </span>
+        </div>
+        <button>visible</button>
+      </div>
+    );
+
+    expect(names(container)).toEqual(["visible"]);
+  });
+
+  it("still hides a control inside a [hidden] ancestor", () => {
+    const { container } = render(
+      <div>
+        <div hidden>
+          <button>buried</button>
+        </div>
+        <button>visible</button>
+      </div>
+    );
+
+    expect(names(container)).toEqual(["visible"]);
+  });
+
+  it("does not hide a control merely because an ancestor sets other styles", () => {
+    // The narrowed walk looks only at display and [hidden]. An ancestor with
+    // opacity or overflow set must not take its children out of the tab order.
+    const { container } = render(
+      <div>
+        <div style={{ opacity: 0.5, overflow: "hidden", visibility: "visible" }}>
+          <button>reachable</button>
+        </div>
+      </div>
+    );
+
+    expect(names(container)).toEqual(["reachable"]);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -501,14 +501,31 @@ if (typeof window !== 'undefined') {
     value: function (this: Element): DOMRectList {
       if (!this.isConnected) return NO_LAYOUT;
 
+      // The element itself gets the full cascade: its own display and
+      // visibility are what a hidden control is usually hidden by.
+      const own = realGetComputedStyle(this);
+      if (own.display === 'none' || own.visibility === 'hidden') return NO_LAYOUT;
+
       // `display` is not inherited: a child of a display:none parent still
-      // computes its own display, while a real browser gives it no rects. The
-      // ancestor walk reproduces that.
-      for (let node: Element | null = this; node; node = node.parentElement) {
-        const style = realGetComputedStyle(node);
-        if (style.display === 'none') return NO_LAYOUT;
-        // visibility IS inherited, so it only needs checking on the element.
-        if (node === this && style.visibility === 'hidden') return NO_LAYOUT;
+      // computes its own display, while a real browser gives it no rects. So
+      // ancestors have to be checked too — but with the cheap signals only,
+      // not another full cascade each.
+      //
+      // That is a measured trade, not a shortcut. `tabbable` calls this for
+      // every candidate, and candidates share ancestors, so a full
+      // getComputedStyle per ancestor is quadratic-ish over one query. It cost
+      // 21.4s for the 27 focus-trap tests against 7.4s without the walk — and
+      // under coverage instrumentation that pushed three of them past the 5s
+      // per-test timeout and turned CI red.
+      //
+      // What this still catches: `style="display:none"` and `hidden`, which is
+      // how a test or a component hides a subtree here. What it would miss: a
+      // stylesheet rule setting display:none on an ancestor. Vitest does not
+      // load CSS Modules, so no such rule exists in this environment; if that
+      // ever changes, this needs revisiting rather than quietly under-reporting.
+      for (let node = this.parentElement; node; node = node.parentElement) {
+        if (node.hasAttribute('hidden')) return NO_LAYOUT;
+        if ((node as HTMLElement).style?.display === 'none') return NO_LAYOUT;
       }
 
       return HAS_LAYOUT;


### PR DESCRIPTION
Starts the port of `GanttCanvasV3` (4,078 lines) to the design-system canvas (499 lines). **Nothing changes for anyone** — `/gantt-tool` renders exactly what it rendered before unless the URL asks for the replacement by name (`?canvas=next`, sticky per browser, unknown values resolve to legacy).

## What the PR now contains

| commit | slice |
| --- | --- |
| `9f3144d` | The seam (`canvas-flag.ts`), the pure adapter, and slice 1: **Move commit** |
| `e04dd1d` | CI fix: the `getClientRects` shim's ancestor walk was 65% of the focus-trap suite's runtime (21.4s→7.3s); under coverage that pushed three tests past their timeout. Narrowed + a 7-test guard suite |
| `c28395e` | Slice 2: **milestones** — legacy rule + marker + same modal, real named buttons, outside the `aria-hidden` axis |
| `3a30381` | Slice 3: **axis labels and weekend/holiday shading** — the axis was rendering unlabelled; ticks share the bars' `dayOffset`, same `getUnifiedHolidays`/"ABMY" source as legacy |
| `753e22f` | Slice 4: **AMS chevrons** — fixed a live mis-render (AMS bars overran the canvas by up to 3 years of pixels, since bounds exclude contract ends); legacy's 5-chevron 160px strip as one named button |
| `1bbbdbc` | Slice 5: **tree columns** — the tree pane becomes legacy's four-column grid (Duration / Work Days / Start-End, legacy widths and formats asserted literally), and working days join each bar's accessible name, making good the promise in `TimelineAxis`'s header |

## Corrections that reshaped the plan (checked, not assumed)

- **No drag-to-move / drag-to-resize on bars** anywhere in legacy; dates are edited via modals. Slice 1 (Move) therefore *adds* rather than replaces — legacy-path regression risk nil.
- **No dependency editing or rendering.** Zero references in the canvas; only the two deletion-impact modals read the field.
- **No task search.** The `Search` input filters the *resource list* inside the capacity panel — moved to that slice.
- The bars' drag handlers are for dropping **resources**; three of the four are inert (`logger.warn`, no write).
- `moveTask` / `movePhase` / `autoAlignTask` / `autoAlignPhase` have no callers.

## Parity contract

`next/adapter.ts` is the only store↔canvas translation, pure so parity is asserted rather than eyeballed. Origin from `getProjectDuration()` (passed in, not recomputed). Inclusive durations (the `+ 1` at every legacy position site). Milestones, ticks, and detail cells reuse the same `dayOffset` / holiday list, so nothing sharing a date or a day count can disagree.

**One deliberate behavioural difference:** legacy fits the plan to the viewport width; the new canvas uses fixed px-per-day and scrolls — what makes bars comparable and lets it window 1,200 rows.

## Verification

60 new tests across flag, adapter, milestone layer, axis model, AMS chevron, detail columns, and the shim guard. Full suite under coverage, as CI runs it: **2140 passed, 0 failed** — the legacy path untouched, and asserted so (no details prop → the exact pre-existing tree).

## Remaining slices

1. Resource capacity panel (largest remaining piece; includes the resource search)
2. Resource drag-assignment (and decide whether the three inert phase handlers are a bug to fix or dead code to delete)
3. Zoom parity oddments, column resizing
4. WBS third level
5. Flip the default