### PR TITLE
Gantt: a plan shorter than the pane stretches to fill it end to end

### DIFF
--- a/src/components/ds/gantt/GanttCanvas.tsx
+++ b/src/components/ds/gantt/GanttCanvas.tsx
@@ -49,7 +49,7 @@ import {
   type FlatRow,
   type GanttPhase,
 } from "./rows";
-import { PX_PER_DAY, ROW_HEIGHT, nudgeDays, showsDayShading, type ZoomGrain } from "./scale";
+import { ROW_HEIGHT, effectivePxPerDay, nudgeDays, showsDayShading, type ZoomGrain } from "./scale";
 import {
   sayCursorMove,
   sayExpand,
@@ -180,6 +180,24 @@ export function GanttCanvas({
   const bodyRef = useRef<HTMLDivElement | null>(null);
   // The axis is the spec's two 28px tiers.
   const viewportHeight = height - 56;
+
+  // The timeline pane's inner width. The grain's density is a MINIMUM — a
+  // plan shorter than the pane stretches to fill it, so the chart always runs
+  // end to end and zooming only changes tick density (see effectivePxPerDay).
+  // 0 until first measure (and under test, where ResizeObserver is absent),
+  // which falls back to the spec density.
+  const [paneWidth, setPaneWidth] = useState(0);
+  React.useLayoutEffect(() => {
+    const el = bodyRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const measure = () => setPaneWidth(el.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const px = effectivePxPerDay(grain, totalDays, paneWidth);
 
   const window_ = computeWindow(rows.length, rowHeight, scrollTop, viewportHeight);
   const visible = rows.slice(window_.startIndex, window_.endIndex);
@@ -337,7 +355,7 @@ export function GanttCanvas({
             // place in the plan.
             bodyRef.current.scrollLeft = Math.max(
               0,
-              todayDay * PX_PER_DAY[grain] - bodyRef.current.clientWidth / 2
+              todayDay * px - bodyRef.current.clientWidth / 2
             );
           }
           break;
@@ -362,10 +380,10 @@ export function GanttCanvas({
       onMove,
       onRowActivate,
       pendingChanges,
+      px,
     ]
   );
 
-  const px = PX_PER_DAY[grain];
   const hasMilestones = milestones.length > 0;
   const hasAms = Object.values(placements).some((p) => p.ams);
   const hasHolidays = nonWorkingDays.some((d) => d.name);
@@ -491,6 +509,7 @@ export function GanttCanvas({
               minorTicks={minorTicks}
               nonWorkingDays={nonWorkingDays}
               todayDay={todayDay}
+              pxPerDay={px}
             />
 
             <div style={{ height: window_.totalHeight, position: "relative", width: totalDays * px }}>
@@ -532,6 +551,7 @@ export function GanttCanvas({
                 grain={grain}
                 totalDays={totalDays}
                 onActivate={onMilestoneActivate}
+                pxPerDay={px}
               />
               <div style={{ transform: `translateY(${window_.offsetTop}px)` }}>
                 {visible.map((row) => {

--- a/src/components/ds/gantt/GanttMilestones.tsx
+++ b/src/components/ds/gantt/GanttMilestones.tsx
@@ -43,6 +43,11 @@ export interface GanttMilestonesProps {
   totalDays: number;
   /** Opens milestone editing. Absent renders the layer inert but visible. */
   onActivate?: (id: string) => void;
+  /**
+   * Rendered day width. The canvas passes its stretch-to-fit density so the
+   * markers and the bars can never disagree; absent, the grain's spec density.
+   */
+  pxPerDay?: number;
 }
 
 /** Matches the legacy default (#FF3B30) so the two canvases agree on a plan. */
@@ -53,8 +58,9 @@ export function GanttMilestones({
   grain,
   totalDays,
   onActivate,
+  pxPerDay,
 }: GanttMilestonesProps) {
-  const px = PX_PER_DAY[grain];
+  const px = pxPerDay ?? PX_PER_DAY[grain];
 
   const visible = milestones.filter((m) => m.day >= 0 && m.day <= totalDays);
   if (visible.length === 0) return null;

--- a/src/components/ds/gantt/TimelineAxis.tsx
+++ b/src/components/ds/gantt/TimelineAxis.tsx
@@ -47,6 +47,11 @@ export interface TimelineAxisProps {
   nonWorkingDays?: NonWorkingDay[];
   /** Day offset of today, or undefined when outside the window. */
   todayDay?: number;
+  /**
+   * Rendered day width. The canvas passes its stretch-to-fit density so the
+   * axis and the bars can never disagree; absent, the grain's spec density.
+   */
+  pxPerDay?: number;
 }
 
 export function TimelineAxis({
@@ -56,8 +61,9 @@ export function TimelineAxis({
   minorTicks,
   nonWorkingDays = [],
   todayDay,
+  pxPerDay,
 }: TimelineAxisProps) {
-  const px = PX_PER_DAY[grain];
+  const px = pxPerDay ?? PX_PER_DAY[grain];
   const width = totalDays * px;
   const shading = showsDayShading(grain);
 

--- a/src/components/ds/gantt/__tests__/gantt.test.tsx
+++ b/src/components/ds/gantt/__tests__/gantt.test.tsx
@@ -16,6 +16,7 @@ import { AllocationCell } from "../AllocationCell";
 import {
   PX_PER_DAY,
   daysToPx,
+  effectivePxPerDay,
   pxToDays,
   labelFitsInside,
   showsDayShading,
@@ -61,6 +62,27 @@ describe("scale", () => {
     const width = 100;
     expect(labelFitsInside("Build", width)).toBe(true);
     expect(labelFitsInside("Chart of accounts workshop", width)).toBe(false);
+  });
+
+  test("a plan shorter than the pane stretches to fill it end to end", () => {
+    // 28 days at Week density is 235px; in a 1200px pane the day widens so
+    // the chart spans the pane exactly, at every grain — zooming out must
+    // never leave dead canvas to the right of a short plan.
+    for (const grain of ["Day", "Week", "Month", "Quarter"] as const) {
+      expect(effectivePxPerDay(grain, 28, 1200) * 28).toBeGreaterThanOrEqual(1200);
+    }
+  });
+
+  test("a plan longer than the pane keeps the grain's density and scrolls", () => {
+    // 3 years at Day zoom must NOT compress to fit — that is what the grain
+    // switch is for. The spec density is a floor, not a target.
+    expect(effectivePxPerDay("Day", 1095, 1200)).toBe(PX_PER_DAY.Day);
+  });
+
+  test("stretch degrades to the spec density before first measure", () => {
+    // paneWidth is 0 until the ResizeObserver fires (and always under jsdom).
+    expect(effectivePxPerDay("Week", 28, 0)).toBe(PX_PER_DAY.Week);
+    expect(effectivePxPerDay("Week", 0, 1200)).toBe(PX_PER_DAY.Week);
   });
 });
 

--- a/src/components/ds/gantt/scale.ts
+++ b/src/components/ds/gantt/scale.ts
@@ -48,6 +48,22 @@ export const MIN_BAR_PX = 4;
 /** The invisible hit area given to a sub-minimum bar. */
 export const MIN_HIT_PX = 24;
 
+/**
+ * The day width actually rendered: the grain's density, raised so a plan
+ * shorter than the viewport still spans it end to end. The grain then only
+ * changes tick density, never leaves dead canvas to the right — a 4-week plan
+ * at Quarter zoom is a full-width chart, not a 32px sliver.
+ */
+export function effectivePxPerDay(
+  grain: ZoomGrain,
+  totalDays: number,
+  viewportPx: number
+): number {
+  const base = PX_PER_DAY[grain];
+  if (totalDays <= 0 || viewportPx <= 0) return base;
+  return Math.max(base, viewportPx / totalDays);
+}
+
 export function daysToPx(days: number, grain: ZoomGrain): number {
   return days * PX_PER_DAY[grain];
 }


### PR DESCRIPTION
## Why

On the Timeline view, a short plan renders as a narrow sliver of chart with the rest of the frame dead white — and switching to a coarser grain shrinks it further (a 4-week plan is ~235px at Week zoom, 32px at Quarter). Expected: the timeline always covers the frame end to end, and the zoom control only changes date density.

## Root cause

The chart width was `totalDays × PX_PER_DAY[grain]` — a fixed density with no relation to the viewport, applied independently in the canvas, the axis, and the milestone layer.

## Fix

- `effectivePxPerDay(grain, totalDays, viewportPx)` in `scale.ts`: the grain's density becomes a **floor**. A plan shorter than the pane widens its day so the chart spans the pane exactly; a longer plan keeps the spec density and scrolls (which is what the grain switch is for).
- `GanttCanvas` measures its timeline pane with a `ResizeObserver` and threads the effective density into `TimelineAxis` and `GanttMilestones`, so ticks, shading, bars, today rule and markers can never disagree. The "T" (scroll to today) shortcut uses the same value.
- Before first measure — and under jsdom, where `ResizeObserver` doesn't exist — behaviour is unchanged, keeping every existing width assertion valid.

## Verification

- Three new scale tests pin the stretch (all four grains fill a 1200px pane for a 28-day plan), the floor (3-year plan at Day zoom is not compressed), and the fallback.
- `tsc --noEmit` clean, `next lint --max-warnings=0` clean, production build succeeds, 1,779 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TArsz4CrMDAKmeALMozkR5)_